### PR TITLE
Eliminate GPU to CPU copy for some GPU arrays in RTE

### DIFF
--- a/src/optics/Fluxes.jl
+++ b/src/optics/Fluxes.jl
@@ -96,10 +96,18 @@ function set_flux_to_zero!(flux::FluxLW{FT}) where {FT<:AbstractFloat}
     return nothing
 end
 
-function set_flux_to_zero!(flux::FluxLW{FT}, gcol::Int) where {FT<:AbstractFloat}
+"""
+    set_flux_to_zero!(flux::FluxLW{FT}, gcol::Int) where {FT<:AbstractFloat}
+
+Set longwave flux for column `gcol` to zero
+"""
+function set_flux_to_zero!(
+    flux::FluxLW{FT},
+    gcol::Int,
+) where {FT<:AbstractFloat}
     (; flux_up, flux_dn, flux_net) = flux
     nlev = size(flux_up, 1)
-    @inbounds for ilev in 1:nlev
+    @inbounds for ilev = 1:nlev
         flux_up[ilev, gcol] = FT(0)
         flux_dn[ilev, gcol] = FT(0)
         flux_net[ilev, gcol] = FT(0)
@@ -120,11 +128,19 @@ function set_flux_to_zero!(flux::FluxSW{FT}) where {FT<:AbstractFloat}
     flux.flux_dn_dir .= FT(0)
     return nothing
 end
+"""
+    set_flux_to_zero!(flux::FluxSW{FT}, gcol::Int) where {FT<:AbstractFloat}
 
-function set_flux_to_zero!(flux::FluxSW{FT}, gcol::Int) where {FT<:AbstractFloat}
+Set shortwave flux for column `gcol` to zero
+
+"""
+function set_flux_to_zero!(
+    flux::FluxSW{FT},
+    gcol::Int,
+) where {FT<:AbstractFloat}
     (; flux_up, flux_dn, flux_net, flux_dn_dir) = flux
     nlev = size(flux_up, 1)
-    @inbounds for ilev in 1:nlev
+    @inbounds for ilev = 1:nlev
         flux_up[ilev, gcol] = FT(0)
         flux_dn[ilev, gcol] = FT(0)
         flux_net[ilev, gcol] = FT(0)
@@ -146,14 +162,18 @@ function add_to_flux!(flux1::FluxLW, flux2::FluxLW)
     flux1.flux_net .+= flux2.flux_net
     return nothing
 end
+"""
+    add_to_flux!(flux1::FluxLW, flux2::FluxLW, gcol::Int)
 
+add longwave flux2 to longwave flux1 for column `gcol`
+flux1 .+= flux2
+
+"""
 function add_to_flux!(flux1::FluxLW, flux2::FluxLW, gcol::Int)
-    flux_up1, flux_dn1, flux_net1 = 
-        flux1.flux_up, flux1.flux_dn, flux1.flux_net
-    flux_up2, flux_dn2, flux_net2 = 
-        flux2.flux_up, flux2.flux_dn, flux2.flux_net
+    flux_up1, flux_dn1, flux_net1 = flux1.flux_up, flux1.flux_dn, flux1.flux_net
+    flux_up2, flux_dn2, flux_net2 = flux2.flux_up, flux2.flux_dn, flux2.flux_net
     nlev = size(flux_up1, 1)
-    @inbounds for ilev in 1:nlev
+    @inbounds for ilev = 1:nlev
         flux_up1[ilev, gcol] += flux_up2[ilev, gcol]
         flux_dn1[ilev, gcol] += flux_dn2[ilev, gcol]
         flux_net1[ilev, gcol] += flux_net2[ilev, gcol]
@@ -175,14 +195,20 @@ function add_to_flux!(flux1::FluxSW, flux2::FluxSW)
     flux1.flux_dn_dir .+= flux2.flux_dn_dir
     return nothing
 end
+"""
+    add_to_flux!(flux1::FluxSW, flux2::FluxSW, gcol::Int)
 
+add shortwave flux2 to shortwave flux1 for column `gcol`
+flux1 .+= flux2
+
+"""
 function add_to_flux!(flux1::FluxSW, flux2::FluxSW, gcol)
-    flux_up1, flux_dn1, flux_net1, flux_dn_dir1 = 
+    flux_up1, flux_dn1, flux_net1, flux_dn_dir1 =
         flux1.flux_up, flux1.flux_dn, flux1.flux_net, flux1.flux_dn_dir
-    flux_up2, flux_dn2, flux_net2, flux_dn_dir2 = 
+    flux_up2, flux_dn2, flux_net2, flux_dn_dir2 =
         flux2.flux_up, flux2.flux_dn, flux2.flux_net, flux2.flux_dn_dir
     nlev = size(flux_up1, 1)
-    @inbounds for ilev in 1:nlev
+    @inbounds for ilev = 1:nlev
         flux_up1[ilev, gcol] += flux_up2[ilev, gcol]
         flux_dn1[ilev, gcol] += flux_dn2[ilev, gcol]
         flux_net1[ilev, gcol] += flux_net2[ilev, gcol]

--- a/src/optics/Fluxes.jl
+++ b/src/optics/Fluxes.jl
@@ -96,6 +96,17 @@ function set_flux_to_zero!(flux::FluxLW{FT}) where {FT<:AbstractFloat}
     return nothing
 end
 
+function set_flux_to_zero!(flux::FluxLW{FT}, gcol::Int) where {FT<:AbstractFloat}
+    (; flux_up, flux_dn, flux_net) = flux
+    nlev = size(flux_up, 1)
+    @inbounds for ilev in 1:nlev
+        flux_up[ilev, gcol] = FT(0)
+        flux_dn[ilev, gcol] = FT(0)
+        flux_net[ilev, gcol] = FT(0)
+    end
+    return nothing
+end
+
 """
     set_flux_to_zero!(flux::FluxSW{FT}) where {FT<:AbstractFloat}
 
@@ -107,6 +118,18 @@ function set_flux_to_zero!(flux::FluxSW{FT}) where {FT<:AbstractFloat}
     flux.flux_dn .= FT(0)
     flux.flux_net .= FT(0)
     flux.flux_dn_dir .= FT(0)
+    return nothing
+end
+
+function set_flux_to_zero!(flux::FluxSW{FT}, gcol::Int) where {FT<:AbstractFloat}
+    (; flux_up, flux_dn, flux_net, flux_dn_dir) = flux
+    nlev = size(flux_up, 1)
+    @inbounds for ilev in 1:nlev
+        flux_up[ilev, gcol] = FT(0)
+        flux_dn[ilev, gcol] = FT(0)
+        flux_net[ilev, gcol] = FT(0)
+        flux_dn_dir[ilev, gcol] = FT(0)
+    end
     return nothing
 end
 
@@ -124,6 +147,20 @@ function add_to_flux!(flux1::FluxLW, flux2::FluxLW)
     return nothing
 end
 
+function add_to_flux!(flux1::FluxLW, flux2::FluxLW, gcol::Int)
+    flux_up1, flux_dn1, flux_net1 = 
+        flux1.flux_up, flux1.flux_dn, flux1.flux_net
+    flux_up2, flux_dn2, flux_net2 = 
+        flux2.flux_up, flux2.flux_dn, flux2.flux_net
+    nlev = size(flux_up1, 1)
+    @inbounds for ilev in 1:nlev
+        flux_up1[ilev, gcol] += flux_up2[ilev, gcol]
+        flux_dn1[ilev, gcol] += flux_dn2[ilev, gcol]
+        flux_net1[ilev, gcol] += flux_net2[ilev, gcol]
+    end
+    return nothing
+end
+
 """
     add_to_flux!(flux1::FluxSW, flux2::FluxSW)
 
@@ -136,6 +173,21 @@ function add_to_flux!(flux1::FluxSW, flux2::FluxSW)
     flux1.flux_dn .+= flux2.flux_dn
     flux1.flux_net .+= flux2.flux_net
     flux1.flux_dn_dir .+= flux2.flux_dn_dir
+    return nothing
+end
+
+function add_to_flux!(flux1::FluxSW, flux2::FluxSW, gcol)
+    flux_up1, flux_dn1, flux_net1, flux_dn_dir1 = 
+        flux1.flux_up, flux1.flux_dn, flux1.flux_net, flux1.flux_dn_dir
+    flux_up2, flux_dn2, flux_net2, flux_dn_dir2 = 
+        flux2.flux_up, flux2.flux_dn, flux2.flux_net, flux2.flux_dn_dir
+    nlev = size(flux_up1, 1)
+    @inbounds for ilev in 1:nlev
+        flux_up1[ilev, gcol] += flux_up2[ilev, gcol]
+        flux_dn1[ilev, gcol] += flux_dn2[ilev, gcol]
+        flux_net1[ilev, gcol] += flux_net2[ilev, gcol]
+        flux_dn_dir1[ilev, gcol] += flux_dn_dir2[ilev, gcol]
+    end
     return nothing
 end
 

--- a/src/rte/RTESolver.jl
+++ b/src/rte/RTESolver.jl
@@ -35,7 +35,7 @@ function solve_lw!(
 ) where {I<:Int,FT<:AbstractFloat}
     (; as, op, bcs_lw, src_lw, flux_lw, fluxb_lw) = slv
     (; nlay, ncol) = as
-
+    DA = array_type()
     nargs = length(lkp_args)
     @assert nargs < 3
     if nargs > 0
@@ -43,65 +43,59 @@ function solve_lw!(
         if nargs == 2
             @assert lkp_args[2] isa LookUpCld
         end
-        n_gpt = lkp_args[1].n_gpt
-        major_gpt2bnd = Array{I,1}(lkp_args[1].major_gpt2bnd) #TODO temp fix to avoid scalar indexing
+        (; n_gpt, major_gpt2bnd) = lkp_args[1]
         flux = fluxb_lw
     else
         n_gpt = 1
+        major_gpt2bnd = DA(UInt8[1])
         flux = flux_lw
     end
-    ibnd = 1
-    set_flux_to_zero!(flux_lw)
 
     for igpt = 1:n_gpt
-        if nargs > 0 && lkp_args[1] isa LookUpLW
-            ibnd = major_gpt2bnd[igpt]
-        end
         # computing optical properties
         compute_optical_props!(op, as, src_lw, igpt, lkp_args...)
-
         if op isa OneScalar
             rte_lw_noscat_solve!(
                 flux,
+                flux_lw,
                 src_lw,
                 bcs_lw,
                 op,
                 nlay,
                 ncol,
                 igpt,
-                ibnd,
+                major_gpt2bnd,
                 max_threads,
             ) # no-scattering solver
         else
             rte_lw_2stream_solve!(
                 flux,
+                flux_lw,
                 src_lw,
                 bcs_lw,
                 op,
                 nlay,
                 ncol,
                 igpt,
-                ibnd,
+                major_gpt2bnd,
                 max_threads,
             ) # 2-stream solver
         end
-
-        nargs > 0 && add_to_flux!(flux_lw, flux)
     end
-    flux_lw.flux_net .= flux_lw.flux_up .- flux_lw.flux_dn
     return nothing
 end
 
 """
     rte_lw_noscat_solve!(
         flux::FluxLW{FT},
+        flux_lw::FluxLW{FT},
         src_lw::SourceLWNoScat{FT},
         bcs_lw::LwBCs{FT},
         op::OneScalar{FT},
         nlay,
         ncol,
         igpt,
-        ibnd,
+        major_gpt2bnd::AbstractArray{UInt8,1},
         max_threads,
     ) where {FT<:AbstractFloat}
 
@@ -112,24 +106,27 @@ using user-supplied weights. Currently, only n_gauss_angles = 1 supported.
 """
 function rte_lw_noscat_solve!(
     flux::FluxLW{FT},
+    flux_lw::FluxLW{FT},
     src_lw::SourceLWNoScat{FT},
     bcs_lw::LwBCs{FT},
     op::OneScalar{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
+    major_gpt2bnd::AbstractArray{UInt8,1},
     max_threads,
 ) where {FT<:AbstractFloat}
     nlev = nlay + 1
+    n_gpt = length(major_gpt2bnd)
     device = array_device(op.τ)
     if device === CUDADevice() # launch CUDA kernel
         tx = min(ncol, max_threads)
         bx = cld(ncol, tx)
-        args = (flux, src_lw, bcs_lw, op, nlay, ncol, igpt, ibnd)
+        args = (flux, flux_lw, src_lw, bcs_lw, op, nlay, ncol, igpt, major_gpt2bnd)
         @cuda threads = (tx) blocks = (bx) rte_lw_noscat_solve_CUDA!(args...)
     else # use Julia native multithreading
         @inbounds Threads.@threads for gcol = 1:ncol
+            igpt == 1 && set_flux_to_zero!(flux_lw, gcol)
             rte_lw_noscat_source!(src_lw, op, gcol, nlay)
             rte_lw_noscat_transport!(
                 src_lw,
@@ -138,10 +135,11 @@ function rte_lw_noscat_solve!(
                 gcol,
                 flux,
                 igpt,
-                ibnd,
+                major_gpt2bnd,
                 nlay,
                 nlev,
             )
+            n_gpt > 1 && add_to_flux!(flux_lw, flux, gcol)
         end
     end
     #------------------------------------------------
@@ -150,17 +148,20 @@ end
 # ---------------------------------------------------------------    
 function rte_lw_noscat_solve_CUDA!(
     flux::FluxLW{FT},
+    flux_lw::FluxLW{FT},
     src_lw::SourceLWNoScat{FT},
     bcs_lw::LwBCs{FT},
     op::OneScalar{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
+    major_gpt2bnd,
 ) where {FT<:AbstractFloat}
     gcol = threadIdx().x + (blockIdx().x - 1) * blockDim().x # global id
     nlev = nlay + 1
+    n_gpt = length(major_gpt2bnd)
     if gcol ≤ ncol
+        igpt == 1 && set_flux_to_zero!(flux_lw, gcol)
         rte_lw_noscat_source!(src_lw, op, gcol, nlay)
         rte_lw_noscat_transport!(
             src_lw,
@@ -169,10 +170,11 @@ function rte_lw_noscat_solve_CUDA!(
             gcol,
             flux,
             igpt,
-            ibnd,
+            major_gpt2bnd,
             nlay,
             nlev,
         )
+        n_gpt > 1 && add_to_flux!(flux_lw, flux, gcol)
     end
     return nothing
 end
@@ -180,13 +182,14 @@ end
 """
     rte_lw_2stream_solve!(
         flux::FluxLW{FT},
+        flux_lw::FluxLW{FT},
         src_lw::SourceLW2Str{FT},
         bcs_lw::LwBCs{FT},
         op::TwoStream{FT},
         nlay,
         ncol,
         igpt,
-        ibnd,
+        major_gpt2bnd::AbstractArray{UInt8,1},
         max_threads,
     ) where {FT<:AbstractFloat}
 
@@ -202,50 +205,58 @@ transport (adding_lw!)
 """
 function rte_lw_2stream_solve!(
     flux::FluxLW{FT},
+    flux_lw::FluxLW{FT},
     src_lw::SourceLW2Str{FT},
     bcs_lw::LwBCs{FT},
     op::TwoStream{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
+    major_gpt2bnd::AbstractArray{UInt8,1},
     max_threads,
 ) where {FT<:AbstractFloat}
     nlev = nlay + 1
+    n_gpt = length(major_gpt2bnd)
     device = array_device(op.τ)
     if device === CUDADevice() # launch CUDA kernel
         tx = min(ncol, max_threads)
         bx = cld(ncol, tx)
-        args = (flux, src_lw, bcs_lw, op, nlay, ncol, igpt, ibnd)
+        args = (flux, flux_lw, src_lw, bcs_lw, op, nlay, ncol, igpt, major_gpt2bnd)
         @cuda threads = (tx) blocks = (bx) rte_lw_2stream_solve_CUDA!(args...)
     else # use Julia native multithreading
         Threads.@threads for gcol = 1:ncol
+            igpt == 1 && set_flux_to_zero!(flux_lw, gcol)
             rte_lw_2stream_combine_sources!(src_lw, gcol, nlev, ncol)
             rte_lw_2stream_source!(op, src_lw, gcol, nlay, ncol)
-            adding_lw!(flux, src_lw, bcs_lw, gcol, igpt, ibnd, nlev, ncol)
+            adding_lw!(flux, src_lw, bcs_lw, gcol, igpt, major_gpt2bnd, nlev, ncol)
+            n_gpt > 1 && add_to_flux!(flux_lw, flux, gcol)
         end
     end
-    #------------------------------------------------
     return nothing
 end
 # -------------------------------------------------------------------------------------------------
 function rte_lw_2stream_solve_CUDA!(
     flux::FluxLW{FT},
+    flux_lw::FluxLW{FT},
     src_lw::SourceLW2Str{FT},
     bcs_lw::LwBCs{FT},
     op::TwoStream{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
+    major_gpt2bnd::AbstractArray{UInt8,1},
 ) where {FT<:AbstractFloat}
     gcol = threadIdx().x + (blockIdx().x - 1) * blockDim().x # global id
     nlev = nlay + 1
+    n_gpt = length(major_gpt2bnd)
     if gcol ≤ ncol
+        igpt == 1 && set_flux_to_zero!(flux_lw, gcol)
         rte_lw_2stream_combine_sources!(src_lw, gcol, nlev, ncol)
         rte_lw_2stream_source!(op, src_lw, gcol, nlay, ncol)
-        adding_lw!(flux, src_lw, bcs_lw, gcol, igpt, ibnd, nlev, ncol)
+        adding_lw!(flux, src_lw, bcs_lw, gcol, igpt, major_gpt2bnd, nlev, ncol)
+        n_gpt > 1 && add_to_flux!(flux_lw, flux, gcol)
     end
+    return nothing
 end
 
 """
@@ -264,7 +275,7 @@ function solve_sw!(
 ) where {I<:Int,FT<:AbstractFloat}
     (; as, op, bcs_sw, src_sw, flux_sw, fluxb_sw) = slv
     (; nlay, ncol) = as
-
+    DA = array_type()
     nargs = length(lkp_args)
     @assert nargs < 3
     if nargs > 0
@@ -272,72 +283,59 @@ function solve_sw!(
         if nargs == 2
             @assert lkp_args[2] isa LookUpCld
         end
-        n_gpt = lkp_args[1].n_gpt
-        major_gpt2bnd = Array{I,1}(lkp_args[1].major_gpt2bnd)#TODO temp fix to avoid scalar indexing
-        solar_src_scaled = Array{FT,1}(lkp_args[1].solar_src_scaled)
+        (; n_gpt, major_gpt2bnd, solar_src_scaled) = lkp_args[1]
         flux = fluxb_sw
     else
         n_gpt = 1
+        major_gpt2bnd = DA(UInt8[1])
+        solar_src_scaled = DA(FT[1])
         flux = flux_sw
     end
-    ibnd = 1
-    solar_frac = FT(1)
-    set_flux_to_zero!(slv.flux_sw)
     for igpt = 1:n_gpt
-        if nargs > 0 && lkp_args[1] isa LookUpSW
-            ibnd = major_gpt2bnd[igpt]
-            solar_frac = solar_src_scaled[igpt]
-        end
         # computing optical properties
         compute_optical_props!(op, as, igpt, lkp_args...)
-
         # solving radiative transfer equation
         if slv.op isa OneScalar
             rte_sw_noscat_solve!(
                 flux,
+                flux_sw,
                 op,
                 bcs_sw,
                 nlay,
                 ncol,
                 igpt,
-                ibnd,
-                solar_frac,
+                solar_src_scaled,
                 max_threads,
             ) # no-scattering solver
         else
             rte_sw_2stream_solve!(
                 flux,
+                flux_sw,
                 op,
                 bcs_sw,
                 src_sw,
                 nlay,
                 ncol,
                 igpt,
-                ibnd,
-                solar_frac,
+                major_gpt2bnd,
+                solar_src_scaled,
                 max_threads,
             ) # 2-stream solver
-            flux.flux_dn .+= flux.flux_dn_dir
         end
-        nargs > 0 && add_to_flux!(flux_sw, flux)
     end
-    if slv.op isa TwoStream
-        flux_sw.flux_net .= flux_sw.flux_up .- flux_sw.flux_dn
-    end
-
     return nothing
 end
 
 """
     rte_sw_noscat_solve!(
         flux::FluxSW{FT},
+        flux_sw::FluxSW{FT},
         op::OneScalar{FT},
         bcs_sw::SwBCs{FT},
         nlay,
         ncol,
         igpt,
-        ibnd,
-        solar_frac::FT,
+        solar_src_scaled::AbstractArray{FT,1},
         max_threads,
     ) where {FT<:AbstractFloat}
 
@@ -346,32 +344,37 @@ No-scattering solver for the shortwave problem.
 """
 function rte_sw_noscat_solve!(
     flux::FluxSW{FT},
+    flux_sw::FluxSW{FT},
     op::OneScalar{FT},
     bcs_sw::SwBCs{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
-    solar_frac::FT,
+    solar_src_scaled::AbstractArray{FT,1},
     max_threads,
 ) where {FT<:AbstractFloat}
     nlev = nlay + 1
+    n_gpt = length(solar_src_scaled)
     device = array_device(op.τ)
+    # setting references for flux_sw
     if device === CUDADevice() # launching CUDA kernel
         tx = min(ncol, max_threads)
         bx = cld(ncol, tx)
-        args = (flux, op, bcs_sw, nlay, ncol, igpt, ibnd, solar_frac)
+        args = (flux, flux_sw, op, bcs_sw, nlay, ncol, igpt, solar_src_scaled)
         @cuda threads = (tx) blocks = (bx) rte_sw_noscat_solve_CUDA!(args...)
     else # launch juila native multithreading
         @inbounds Threads.@threads for gcol = 1:ncol
+            igpt == 1 && set_flux_to_zero!(flux_sw, gcol)
             rte_sw_noscat_solve_kernel!(
                 flux,
                 op,
                 bcs_sw,
-                solar_frac,
+                igpt,
+                solar_src_scaled,
                 gcol,
                 nlev,
             )
+            n_gpt > 1 && add_to_flux!(flux_sw, flux, gcol)
         end
     end
     #-----------------------------------------------------------------------------------
@@ -380,18 +383,22 @@ end
 #--------------------------------------------------------------------------------------------------
 function rte_sw_noscat_solve_CUDA!(
     flux::FluxSW{FT},
+    flux_sw::FluxSW{FT},
     op::OneScalar{FT},
     bcs_sw::SwBCs{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
-    solar_frac::FT,
+    solar_src_scaled::AbstractArray{FT,1},
 ) where {FT<:AbstractFloat}
     gcol = threadIdx().x + (blockIdx().x - 1) * blockDim().x # global id
     nlev = nlay + 1
+    n_gpt = length(solar_src_scaled)
+    # setting references for flux_sw
     if gcol ≤ ncol
-        rte_sw_noscat_solve_kernel!(flux, op, bcs_sw, solar_frac, gcol, nlev)
+        igpt == 1 && set_flux_to_zero!(flux_sw, gcol)
+        rte_sw_noscat_solve_kernel!(flux, op, bcs_sw, igpt, solar_src_scaled, gcol, nlev)
+        n_gpt > 1 && add_to_flux!(flux_sw, flux, gcol)
     end
     return nothing
 end
@@ -399,14 +406,15 @@ end
 """
     rte_sw_2stream_solve!(
         flux::FluxSW{FT},
+        flux_sw::FluxSW{FT},
         op::TwoStream{FT},
         bcs_sw::SwBCs{FT},
         src_sw::SourceSW2Str{FT},
         nlay,
         ncol,
         igpt,
-        ibnd,
-        solar_frac::FT,
+        major_gpt2bnd::AbstractArray{UInt8,1},
+        solar_src_scaled::AbstractArray{FT,1},
         max_threads,
     ) where {FT<:AbstractFloat}
 
@@ -414,52 +422,61 @@ Two stream solver for the shortwave problem.
 """
 function rte_sw_2stream_solve!(
     flux::FluxSW{FT},
+    flux_sw::FluxSW{FT},
     op::TwoStream{FT},
     bcs_sw::SwBCs{FT},
     src_sw::SourceSW2Str{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
-    solar_frac::FT,
+    major_gpt2bnd::AbstractArray{UInt8,1},
+    solar_src_scaled::AbstractArray{FT,1},
     max_threads,
 ) where {FT<:AbstractFloat}
     nlev = nlay + 1
+    n_gpt = length(major_gpt2bnd)
     device = array_device(op.τ)
     if device === CUDADevice()
         tx = min(ncol, max_threads)
         bx = cld(ncol, tx)
-        args = (flux, op, bcs_sw, src_sw, nlay, ncol, igpt, ibnd, solar_frac)
+        args = (flux, flux_sw, op, bcs_sw, src_sw, nlay, ncol, igpt, major_gpt2bnd, solar_src_scaled)
         @cuda threads = (tx) blocks = (bx) rte_sw_2stream_solve_CUDA!(args...)
     else # launch julia native multithreading
+        # setting references for flux_sw
         @inbounds Threads.@threads for gcol = 1:ncol
+            igpt == 1 && set_flux_to_zero!(flux_sw, gcol)
             sw_two_stream!(op, src_sw, bcs_sw, gcol, nlay) # Cell properties: transmittance and reflectance for direct and diffuse radiation
-            sw_source_2str!(src_sw, bcs_sw, gcol, flux, solar_frac, ibnd, nlay) # Direct-beam and source for diffuse radiation
-            adding_sw!(src_sw, bcs_sw, gcol, flux, igpt, ibnd, nlev) # Transport
+            sw_source_2str!(src_sw, bcs_sw, gcol, flux, igpt, solar_src_scaled, major_gpt2bnd, nlay) # Direct-beam and source for diffuse radiation
+            adding_sw!(src_sw, bcs_sw, gcol, flux, igpt, major_gpt2bnd, nlev) # Transport
+            n_gpt > 1 && add_to_flux!(flux_sw, flux, gcol)
         end
     end
-    #--------------------------------------
     return nothing
 end
 #--------------------------------------------------------------------------------------------------
 function rte_sw_2stream_solve_CUDA!(
     flux::FluxSW{FT},
+    flux_sw::FluxSW{FT},
     op::TwoStream{FT},
     bcs_sw::SwBCs{FT},
     src_sw::SourceSW2Str{FT},
     nlay,
     ncol,
     igpt,
-    ibnd,
-    solar_frac::FT,
+    major_gpt2bnd::AbstractArray{UInt8,1},
+    solar_src_scaled::AbstractArray{FT,1},
 ) where {FT<:AbstractFloat}
     gcol = threadIdx().x + (blockIdx().x - 1) * blockDim().x # global id
     nlev = nlay + 1
+    n_gpt = length(major_gpt2bnd)
     if gcol ≤ ncol
+        igpt == 1 && set_flux_to_zero!(flux_sw, gcol)
         sw_two_stream!(op, src_sw, bcs_sw, gcol, nlay) # Cell properties: transmittance and reflectance for direct and diffuse radiation
-        sw_source_2str!(src_sw, bcs_sw, gcol, flux, solar_frac, ibnd, nlay) # Direct-beam and source for diffuse radiation
-        adding_sw!(src_sw, bcs_sw, gcol, flux, igpt, ibnd, nlev) # Transport
+        sw_source_2str!(src_sw, bcs_sw, gcol, flux, igpt, solar_src_scaled, major_gpt2bnd, nlay) # Direct-beam and source for diffuse radiation
+        adding_sw!(src_sw, bcs_sw, gcol, flux, igpt, major_gpt2bnd, nlev) # Transport
+        n_gpt > 1 && add_to_flux!(flux_sw, flux, gcol)
     end
+    return nothing
 end
 #--------------------------------------------------------------------------------------------------
 end

--- a/src/rte/RTESolverKernels.jl
+++ b/src/rte/RTESolverKernels.jl
@@ -334,14 +334,15 @@ function rte_sw_noscat_solve_kernel!(
     solar_src_scaled::AbstractArray{FT,1},
     gcol::I,
     nlev::I,
-) where {FT<:AbstractFloat, I<:Int}
+) where {FT<:AbstractFloat,I<:Int}
     solar_frac = solar_src_scaled[igpt]
     (; toa_flux, zenith) = bcs_sw
     n_gpt = length(solar_src_scaled)
     τ = op.τ
     (; flux_dn_dir, flux_net) = flux
     # downward propagation
-    @inbounds flux_dn_dir[nlev, gcol] = toa_flux[gcol] * solar_frac * cos(zenith[gcol])
+    @inbounds flux_dn_dir[nlev, gcol] =
+        toa_flux[gcol] * solar_frac * cos(zenith[gcol])
     @inbounds for ilev = nlev-1:-1:1
         flux_dn_dir[ilev, gcol] =
             flux_dn_dir[ilev+1, gcol] * exp(-τ[ilev, gcol] / cos(zenith[gcol]))
@@ -471,14 +472,16 @@ function sw_source_2str!(
 
     # layer index = level index
     # previous level is up (+1)
-    @inbounds flux_dn_dir[nlay+1, gcol] = toa_flux[gcol] * solar_frac * cos(zenith[gcol])
+    @inbounds flux_dn_dir[nlay+1, gcol] =
+        toa_flux[gcol] * solar_frac * cos(zenith[gcol])
     @inbounds for ilev = nlay:-1:1
         src_up[ilev, gcol] = Rdir[ilev, gcol] * flux_dn_dir[ilev+1, gcol]
         src_dn[ilev, gcol] = Tdir[ilev, gcol] * flux_dn_dir[ilev+1, gcol]
         flux_dn_dir[ilev, gcol] =
             Tnoscat[ilev, gcol] * flux_dn_dir[ilev+1, gcol]
     end
-    @inbounds sfc_source[gcol] = flux_dn_dir[1, gcol] * sfc_alb_direct[ibnd, gcol]
+    @inbounds sfc_source[gcol] =
+        flux_dn_dir[1, gcol] * sfc_alb_direct[ibnd, gcol]
 end
 
 """

--- a/src/rte/RTESolverKernels.jl
+++ b/src/rte/RTESolverKernels.jl
@@ -68,10 +68,11 @@ function rte_lw_noscat_transport!(
     gcol,
     flux::FluxLW{FT},
     igpt,
-    ibnd,
+    major_gpt2bnd::AbstractArray{UInt8,1},
     nlay,
     nlev,
 ) where {FT<:AbstractFloat}
+    ibnd = major_gpt2bnd[igpt]
     # setting references
     (; src_up, src_dn, sfc_source) = src_lw
     (; sfc_emis, inc_flux) = bcs_lw
@@ -245,11 +246,12 @@ function adding_lw!(
     bcs_lw::BCL,
     gcol,
     igpt,
-    ibnd,
+    major_gpt2bnd::AbstractArray{UInt8,1},
     nlev,
     ncol,
 ) where {FT<:AbstractFloat,SL<:SourceLW2Str{FT},BCL<:LwBCs{FT}}
     nlay = nlev - 1
+    ibnd = major_gpt2bnd[igpt]
     # setting references
     (; flux_up, flux_dn, flux_net) = flux
 
@@ -328,18 +330,22 @@ function rte_sw_noscat_solve_kernel!(
     flux::FluxSW{FT},
     op::OneScalar{FT},
     bcs_sw::SwBCs{FT},
-    solar_frac::FT,
-    gcol,
-    nlev,
-) where {FT<:AbstractFloat}
+    igpt::I,
+    solar_src_scaled::AbstractArray{FT,1},
+    gcol::I,
+    nlev::I,
+) where {FT<:AbstractFloat, I<:Int}
+    solar_frac = solar_src_scaled[igpt]
     (; toa_flux, zenith) = bcs_sw
+    n_gpt = length(solar_src_scaled)
     τ = op.τ
-    flux_dn_dir = flux.flux_dn_dir
+    (; flux_dn_dir, flux_net) = flux
     # downward propagation
-    flux_dn_dir[nlev, gcol] = toa_flux[gcol] * solar_frac * cos(zenith[gcol])
-    for ilev = nlev-1:-1:1
+    @inbounds flux_dn_dir[nlev, gcol] = toa_flux[gcol] * solar_frac * cos(zenith[gcol])
+    @inbounds for ilev = nlev-1:-1:1
         flux_dn_dir[ilev, gcol] =
             flux_dn_dir[ilev+1, gcol] * exp(-τ[ilev, gcol] / cos(zenith[gcol]))
+        flux_net[ilev, gcol] = -flux_dn_dir[ilev, gcol]
     end
 end
 
@@ -364,9 +370,9 @@ function sw_two_stream!(
     op::TwoStream{FT},
     src_sw::SourceSW2Str{FT},
     bcs_sw::SwBCs{FT},
-    gcol,
-    nlay,
-) where {FT<:AbstractFloat}
+    gcol::I,
+    nlay::I,
+) where {FT<:AbstractFloat,I<:Int}
     zenith = bcs_sw.zenith
     (; τ, ssa, g) = op
     (; Rdif, Tdif, Rdir, Tdir, Tnoscat) = src_sw
@@ -392,11 +398,11 @@ function sw_two_stream!(
             FT(1) /
             (k * (FT(1) + exp_minus2ktau) + γ1 * (FT(1) - exp_minus2ktau))
 
-        Rdif[glay, gcol] = RT_term * γ2 * (FT(1) - exp_minus2ktau) # Eqn. 25
-        Tdif[glay, gcol] = RT_term * FT(2) * k * exp_minusktau     # Eqn. 26
+        @inbounds Rdif[glay, gcol] = RT_term * γ2 * (FT(1) - exp_minus2ktau) # Eqn. 25
+        @inbounds Tdif[glay, gcol] = RT_term * FT(2) * k * exp_minusktau     # Eqn. 26
 
         # Transmittance of direct, unscattered beam. Also used below
-        Tnoscat[glay, gcol] = exp(-τ[glay, gcol] / cos(zenith[gcol]))
+        @inbounds Tnoscat[glay, gcol] = exp(-τ[glay, gcol] / cos(zenith[gcol]))
 
         # Direct reflect and transmission
         k_μ = k * cos(zenith[gcol])
@@ -411,7 +417,7 @@ function sw_two_stream!(
             RT_term = ssa[glay, gcol] * RT_term / eps(FT)
         end
 
-        Rdir[glay, gcol] =
+        @inbounds Rdir[glay, gcol] =
             RT_term * (
                 (FT(1) - k_μ) * (α2 + k_γ3) -
                 (FT(1) + k_μ) * (α2 - k_γ3) * exp_minus2ktau -
@@ -423,7 +429,7 @@ function sw_two_stream!(
         #   prefer underflow to overflow
         # Omitting direct transmittance
         #
-        Tdir[glay, gcol] =
+        @inbounds Tdir[glay, gcol] =
             -RT_term * (
                 (FT(1) + k_μ) * (α1 + k_γ4) * Tnoscat[glay, gcol] -
                 (FT(1) - k_μ) *
@@ -450,26 +456,29 @@ Direct-beam and source for diffuse radiation
 function sw_source_2str!(
     src_sw::SourceSW2Str{FT},
     bcs_sw::SwBCs{FT},
-    gcol,
+    gcol::I,
     flux::FluxSW{FT},
-    solar_frac::FT,
-    ibnd,
-    nlay,
-) where {FT<:AbstractFloat}
+    igpt::I,
+    solar_src_scaled::AbstractArray{FT,1},
+    major_gpt2bnd::AbstractArray{UInt8,1},
+    nlay::I,
+) where {FT<:AbstractFloat,I<:Int}
+    ibnd = major_gpt2bnd[igpt]
+    solar_frac = solar_src_scaled[igpt]
     (; toa_flux, zenith, sfc_alb_direct) = bcs_sw
     (; Rdir, Tdir, Tnoscat, src_up, src_dn, sfc_source) = src_sw
     flux_dn_dir = flux.flux_dn_dir
 
     # layer index = level index
     # previous level is up (+1)
-    flux_dn_dir[nlay+1, gcol] = toa_flux[gcol] * solar_frac * cos(zenith[gcol])
-    for ilev = nlay:-1:1
+    @inbounds flux_dn_dir[nlay+1, gcol] = toa_flux[gcol] * solar_frac * cos(zenith[gcol])
+    @inbounds for ilev = nlay:-1:1
         src_up[ilev, gcol] = Rdir[ilev, gcol] * flux_dn_dir[ilev+1, gcol]
         src_dn[ilev, gcol] = Tdir[ilev, gcol] * flux_dn_dir[ilev+1, gcol]
         flux_dn_dir[ilev, gcol] =
             Tnoscat[ilev, gcol] * flux_dn_dir[ilev+1, gcol]
     end
-    sfc_source[gcol] = flux_dn_dir[1, gcol] * sfc_alb_direct[ibnd, gcol]
+    @inbounds sfc_source[gcol] = flux_dn_dir[1, gcol] * sfc_alb_direct[ibnd, gcol]
 end
 
 """
@@ -491,17 +500,17 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
 function adding_sw!(
     src_sw::SourceSW2Str{FT},
     bcs_sw::SwBCs{FT},
-    gcol,
+    gcol::I,
     flux::FluxSW{FT},
-    igpt,
-    ibnd,
-    nlev,
-) where {FT<:AbstractFloat}
+    igpt::I,
+    major_gpt2bnd::AbstractArray{UInt8,1},
+    nlev::I,
+) where {FT<:AbstractFloat,I<:Int}
+    ibnd = major_gpt2bnd[igpt]
     nlay = nlev - 1
-    # setting references
-    (; flux_up, flux_dn, flux_net) = flux
-
-
+    n_gpt = length(major_gpt2bnd)
+    # destructuring
+    (; flux_up, flux_dn, flux_dn_dir, flux_net) = flux
     (; albedo, sfc_source, Rdif, Tdif, src_up, src_dn, src) = src_sw
 
     @inbounds for ilev = 1:nlev
@@ -532,7 +541,7 @@ function adding_sw!(
     end
 
     # Eq 12, at the top of the domain upwelling diffuse is due to ...
-    flux_up[nlev, gcol] =
+    @inbounds flux_up[nlev, gcol] =
         flux_dn[nlev, gcol] * albedo[nlev, gcol] + # ... reflection of incident diffuse and
         src[nlev, gcol]                          # scattering by the direct beam below
 
@@ -551,6 +560,7 @@ function adding_sw!(
     end
 
     @inbounds for ilev = 1:nlev
+        flux_dn[ilev, gcol] += flux_dn_dir[ilev, gcol]
         flux_net[ilev, gcol] = flux_up[ilev, gcol] - flux_dn[ilev, gcol]
     end
 end

--- a/test/all_sky.jl
+++ b/test/all_sky.jl
@@ -136,15 +136,9 @@ function all_sky(
         flux_lw,
         flux_sw,
     )
-    #------solvers
+    #------calling solvers
     solve_lw!(slv, max_threads, lookup_lw, lookup_lw_cld)
     solve_sw!(slv, max_threads, lookup_sw, lookup_sw_cld)
-
-    #for i = 1:10
-    #    @time solve_lw!(slv, max_threads, lookup_lw, lookup_lw_cld)
-    #    @time solve_sw!(slv, max_threads, lookup_sw, lookup_sw_cld)
-    #    println("------------------------------------------------")
-    #end
     #-------------
     # comparison
     method = use_lut ? "Lookup Table Interpolation method" : "PADE method"
@@ -193,6 +187,6 @@ function all_sky(
     @test max_err_flux_dn_sw < toler
 end
 println("running cloudy lookup table version")
-all_sky(TwoStream, Float64, Int, DA, use_lut = true)
+@time all_sky(TwoStream, Float64, Int, DA, use_lut = true)
 println("running cloudy pade version")
-all_sky(TwoStream, Float64, Int, DA, use_lut = false)
+@time all_sky(TwoStream, Float64, Int, DA, use_lut = false)

--- a/test/clear_sky.jl
+++ b/test/clear_sky.jl
@@ -139,15 +139,8 @@ function clear_sky(
         flux_lw,
         flux_sw,
     )
-
     solve_lw!(slv, max_threads, lookup_lw)
     solve_sw!(slv, max_threads, lookup_sw)
-
-    #for i = 1:10
-    #    @time solve_lw!(slv, max_threads, lookup_lw)
-    #    @time solve_sw!(slv, max_threads, lookup_sw)
-    #end
-
     # comparing longwave fluxes with data from RRTMGP FORTRAN code
     flip_ind = nlev:-1:1
 
@@ -208,4 +201,4 @@ function clear_sky(
     @test max_err_flux_dn_sw ≤ toler_sw
 end
 
-clear_sky(TwoStream, SourceLW2Str, VmrGM, Float64, Int, array_type())
+@time clear_sky(TwoStream, SourceLW2Str, VmrGM, Float64, Int, array_type())

--- a/test/gray_atm.jl
+++ b/test/gray_atm.jl
@@ -228,12 +228,12 @@ function gray_atmos_sw_test(
 end
 
 if DA == CuArray
-    gray_atmos_lw_equil(OneScalar, Float64, Int, DA, Int(4096))
-    gray_atmos_lw_equil(TwoStream, Float64, Int, DA, Int(4096))
+    @time gray_atmos_lw_equil(OneScalar, Float64, Int, DA, Int(4096))
+    @time gray_atmos_lw_equil(TwoStream, Float64, Int, DA, Int(4096))
 else
-    gray_atmos_lw_equil(OneScalar, Float64, Int, DA, Int(9))
-    gray_atmos_lw_equil(TwoStream, Float64, Int, DA, Int(9))
+    @time gray_atmos_lw_equil(OneScalar, Float64, Int, DA, Int(9))
+    @time gray_atmos_lw_equil(TwoStream, Float64, Int, DA, Int(9))
 end
 
-gray_atmos_sw_test(OneScalar, Float64, Int, DA, Int(1))
-gray_atmos_sw_test(TwoStream, Float64, Int, DA, Int(1))
+@time gray_atmos_sw_test(OneScalar, Float64, Int, DA, Int(1))
+@time gray_atmos_sw_test(TwoStream, Float64, Int, DA, Int(1))


### PR DESCRIPTION
 Eliminate GPU to CPU copying for some arrays in RTE solver.
 Merge multiple RTE GPU kernels into a single GPU kernel.