### PR TITLE
Use new way of handling climaparameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.3.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 GaussQuadrature = "d54b0c1a-921d-58e0-8e36-89d8069c0969"
@@ -13,7 +12,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Adapt = "3.3"
-CLIMAParameters = "0.1, 0.2, 0.3, 0.4, 0.5, 0.6"
 CUDA = "3.8"
 DocStringExtensions = "0.8"
 GaussQuadrature = "0.5"

--- a/parameters/create_parameters.jl
+++ b/parameters/create_parameters.jl
@@ -1,0 +1,15 @@
+import CLIMAParameters as CP
+import RRTMGP.Parameters as RP
+
+#=
+include(joinpath(pkgdir(RRTMGP), "parameters", "create_parameters.jl"))
+param_set = create_insolation_parameters(FT)
+=#
+function create_insolation_parameters(FT, overrides::NamedTuple = NamedTuple())
+    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+    aliases = string.(fieldnames(RP.RRTMGPParameters))
+    pairs = CP.get_parameter_values!(toml_dict, aliases, "RRTMGP")
+    params = merge((; pairs...), overrides) # overrides
+    param_set = RP.RRTMGPParameters{FT}(; params...)
+    return param_set
+end

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -1,0 +1,25 @@
+module Parameters
+
+abstract type AbstractRRTMGPParameters end
+const ARP = AbstractRRTMGPParameters
+
+Base.@kwdef struct RRTMGPParameters{FT} <: ARP
+    grav::FT
+    molmass_dryair::FT
+    molmass_water::FT
+    gas_constant::FT
+    kappa_d::FT
+    Stefan::FT
+    avogad::FT
+end
+
+# Method wrappers
+for var in fieldnames(RRTMGPParameters)
+    @eval $var(ps::ARP) = ps.$var
+end
+
+# Derived parameters
+R_d(ps::ARP) = gas_constant(ps) / molmass_dryair(ps)
+cp_d(ps::ARP) = R_d(ps) / kappa_d(ps)
+
+end # module

--- a/src/RRTMGP.jl
+++ b/src/RRTMGP.jl
@@ -2,6 +2,9 @@ module RRTMGP
 
 include("Device.jl")
 
+include("Parameters.jl")
+import .Parameters as RP
+
 include(joinpath("optics", "Vmrs.jl"))
 include(joinpath("optics", "LookUpTables.jl"))
 include(joinpath("optics", "AngularDiscretizations.jl"))

--- a/src/optics/AtmosphericStates.jl
+++ b/src/optics/AtmosphericStates.jl
@@ -4,8 +4,7 @@ using ..Device: array_type, array_device, CUDADevice, CPU
 using DocStringExtensions
 using Adapt
 using GaussQuadrature
-using CLIMAParameters
-using CLIMAParameters.Planet: grav, R_d
+import ..Parameters as RP
 
 using ..Vmrs
 

--- a/src/optics/GrayAtmosphericStates.jl
+++ b/src/optics/GrayAtmosphericStates.jl
@@ -48,7 +48,7 @@ function setup_gray_as_pr_grid(
     lat::FTA1D,
     p0::FT,
     pe::FT,
-    param_set::AbstractEarthParameterSet,
+    param_set::RP.ARP,
     ::Type{DA},
     step = "linear",
 ) where {FT <: AbstractFloat, FTA1D <: AbstractArray{FT, 1}, DA}
@@ -67,8 +67,8 @@ function setup_gray_as_pr_grid(
     tt = FT(200)                   # skin temp at top of atmosphere (K)
     Δt = FT(60)
     α = FT(3.5)                   # lapse rate of radiative equillibrium
-    r_d = FT(R_d(param_set))
-    grav_ = FT((grav(param_set)))
+    r_d = RP.R_d(param_set)
+    grav_ = RP.grav(param_set)
     args = (p_lev, p_lay, t_lev, t_lay, z_lev, t_sfc, lat, d0, efac, p0, pe, Δp, te, tt, Δt, α, r_d, grav_, nlay)
     device = array_device(p_lev)
     if device === CUDADevice()
@@ -115,7 +115,7 @@ function setup_gray_as_alt_grid(
     zend::FT,
     ncls::Int,
     poly_order::Int,
-    param_set::AbstractEarthParameterSet,
+    param_set::RP.ARP,
     ::Type{DA},
 ) where {FT <: AbstractFloat, FTA1D <: AbstractArray{FT, 1}, DA}
     ncol = length(lat)
@@ -160,7 +160,7 @@ function setup_gray_as_alt_grid(
         t_lev[1, icol] = tt * (1 + d0[icol] * (p_lev[icol, 1] / p0)^α)^FT(0.25)
 
         for ilay in 1:nlay
-            H = FT(R_d(param_set)) * t_lev[ilay, icol] / FT(grav(param_set))
+            H = RP.R_d(param_set) * t_lev[ilay, icol] / RP.grav(param_set)
             Δz_lay = abs(z_lev[ilay + 1, icol] - z_lev[ilay, icol])
             p_lev[ilay + 1, icol] = p_lev[ilay, icol] * exp(-Δz_lay / H)
             t_lev[ilay + 1, icol] = tt * (1 + d0[icol] * (p_lev[ilay + 1, icol] / p0)^α)^FT(0.25)

--- a/src/optics/GrayOpticsKernels.jl
+++ b/src/optics/GrayOpticsKernels.jl
@@ -75,7 +75,7 @@ function compute_sources_gray_kernel!(
     (; t_lay, t_lev) = as
     (; lay_source, lev_source_inc, lev_source_dec, sfc_source) = source
 
-    sbc = FT(Stefan())
+    sbc = FT(RP.Stefan(source.param_set))
     @inbounds lay_source[glaycol...] = sbc * t_lay[glaycol...]^FT(4) / FT(π)   # computing lay_source
     @inbounds lev_source_inc[glaycol...] = sbc * t_lev[glay + 1, gcol]^FT(4) / FT(π)
     @inbounds lev_source_dec[glaycol...] = sbc * t_lev[glaycol...]^FT(4) / FT(π)

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -10,9 +10,7 @@ using ..LookUpTables
 using ..AtmosphericStates
 using ..Sources
 using ..AngularDiscretizations
-#---------------------------------------
-using CLIMAParameters
-using CLIMAParameters.Planet: molmass_dryair, molmass_water, grav
+import ..Parameters as RP
 #---------------------------------------
 
 export AbstractOpticalProps, OneScalar, TwoStream, compute_col_dry!, compute_optical_props!
@@ -92,16 +90,16 @@ This function computes the column amounts of dry or moist air.
 function compute_col_dry!(
     p_lev::FTA2D,
     col_dry::FTA2D,
-    param_set::AbstractEarthParameterSet,
+    param_set::RP.ARP,
     vmr_h2o::Union{AbstractArray{FT, 2}, Nothing} = nothing,
     lat::Union{AbstractArray{FT, 1}, Nothing} = nothing,
     max_threads::Int = Int(256),
 ) where {FT <: AbstractFloat, FTA2D <: AbstractArray{FT, 2}}
     nlay, ncol = size(col_dry)
-    mol_m_dry = FT(molmass_dryair(param_set))
-    mol_m_h2o = FT(molmass_water(param_set))
-    avogadro = FT(avogad())
-    helmert1 = FT(grav(param_set))
+    mol_m_dry = FT(RP.molmass_dryair(param_set))
+    mol_m_h2o = FT(RP.molmass_water(param_set))
+    avogadro = FT(RP.avogad(param_set))
+    helmert1 = FT(RP.grav(param_set))
     args = (p_lev, mol_m_dry, mol_m_h2o, avogadro, helmert1, vmr_h2o, lat)
     device = array_device(p_lev)
     if device === CUDADevice() # launching CUDA kernel

--- a/src/optics/RTE.jl
+++ b/src/optics/RTE.jl
@@ -9,8 +9,7 @@ using ..Fluxes
 using ..Optics
 using ..BCs
 
-using CLIMAParameters
-using CLIMAParameters.Planet: grav, R_d, cp_d
+import ..Parameters as RP
 
 export Solver
 

--- a/test/all_sky.jl
+++ b/test/all_sky.jl
@@ -15,13 +15,11 @@ using RRTMGP.AngularDiscretizations
 using RRTMGP.RTE
 using RRTMGP.RTESolver
 
-using CLIMAParameters
-struct EarthParameterSet <: AbstractEarthParameterSet end
-const param_set = EarthParameterSet()
+import CLIMAParameters as CP
+include(joinpath(pkgdir(RRTMGP), "parameters", "create_parameters.jl"))
 # overriding some parameters to match with RRTMGP FORTRAN code
-CLIMAParameters.Planet.grav(::EarthParameterSet) = 9.80665
-CLIMAParameters.Planet.molmass_dryair(::EarthParameterSet) = 0.028964
-CLIMAParameters.Planet.molmass_water(::EarthParameterSet) = 0.018016
+overrides = (; grav = 9.80665, molmass_dryair = 0.028964, molmass_water = 0.018016)
+param_set = create_insolation_parameters(Float64, overrides)
 
 include("reference_files.jl")
 include("read_all_sky.jl")
@@ -99,7 +97,7 @@ function all_sky(
     # Setting up longwave problem---------------------------------------
     ngpt_lw = lookup_lw.n_gpt
     op = OPC(FT, ncol, nlay, DA) # allocating optical properties object
-    src_lw = source_func_longwave(FT, ncol, nlay, opc, DA)   # allocating longwave source function object
+    src_lw = source_func_longwave(param_set, FT, ncol, nlay, opc, DA)   # allocating longwave source function object
     bcs_lw = LwBCs{FT, typeof(sfc_emis), Nothing}(sfc_emis, nothing)    # setting up boundary conditions
     fluxb_lw = FluxLW(ncol, nlay, FT, DA)                             # flux storage for bandwise calculations
     flux_lw = FluxLW(ncol, nlay, FT, DA)                              # longwave fluxes

--- a/test/rfmip_clear_sky_lw.jl
+++ b/test/rfmip_clear_sky_lw.jl
@@ -15,13 +15,11 @@ using RRTMGP.AngularDiscretizations
 using RRTMGP.RTE
 using RRTMGP.RTESolver
 
-using CLIMAParameters
-struct EarthParameterSet <: AbstractEarthParameterSet end
-const param_set = EarthParameterSet()
+import CLIMAParameters as CP
+include(joinpath(pkgdir(RRTMGP), "parameters", "create_parameters.jl"))
 # overriding some parameters to match with RRTMGP FORTRAN code
-CLIMAParameters.Planet.grav(::EarthParameterSet) = 9.80665
-CLIMAParameters.Planet.molmass_dryair(::EarthParameterSet) = 0.028964
-CLIMAParameters.Planet.molmass_water(::EarthParameterSet) = 0.018016
+overrides = (; grav = 9.80665, molmass_dryair = 0.028964, molmass_water = 0.018016)
+param_set = create_insolation_parameters(FT, overrides)
 
 include("reference_files.jl")
 include("read_rfmip_clear_sky.jl")

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -14,13 +14,12 @@ using RRTMGP.BCs
 using RRTMGP.RTE
 using RRTMGP.RTESolver
 
-using CLIMAParameters
-struct EarthParameterSet <: AbstractEarthParameterSet end
-const param_set = EarthParameterSet()
+import CLIMAParameters as CP
+
+include(joinpath(pkgdir(RRTMGP), "parameters", "create_parameters.jl"))
 # overriding some parameters to match with RRTMGP FORTRAN code
-CLIMAParameters.Planet.grav(::EarthParameterSet) = 9.80665
-CLIMAParameters.Planet.molmass_dryair(::EarthParameterSet) = 0.028964
-CLIMAParameters.Planet.molmass_water(::EarthParameterSet) = 0.018016
+overrides = (; grav = 9.80665, molmass_dryair = 0.028964, molmass_water = 0.018016)
+param_set = create_insolation_parameters(FT, overrides)
 
 include("reference_files.jl")
 include("read_rfmip_clear_sky.jl")


### PR DESCRIPTION
This PR updates RRTMGP.jl to use the new way of handling clima parameters, by defining `RRTMGPParameters` inside a new submodule, `Parameters`. This should be the last piece needed before upgrading ClimaAtmos.

It seemed like the simplest thing to do here was to add `param_set` to `SourceLWNoScat` and `SourceLW2Str`, so that `param_set` could propagate down to the compute kernel.