### PR TITLE
Disable codecov annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # this allows a 10% drop from the previous base commit coverage
+        threshold: 10%
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
This PR disables codecov review annotations (not posted to the PRs, but the line-by-line annotations).