### PR TITLE
Refine/enlarge cloud_mask to be g-point and long/shortwave specific

### DIFF
--- a/src/optics/AtmosphericStates.jl
+++ b/src/optics/AtmosphericStates.jl
@@ -8,8 +8,7 @@ import ..Parameters as RP
 
 using ..Vmrs
 
-export AbstractAtmosphericState,
-    AtmosphericState, ClearAtmosphericState, GrayAtmosphericState, setup_gray_as_pr_grid, setup_gray_as_alt_grid
+export AbstractAtmosphericState, AtmosphericState, GrayAtmosphericState, setup_gray_as_pr_grid, setup_gray_as_alt_grid
 
 abstract type AbstractAtmosphericState{FT, I, FTA1D} end
 
@@ -30,7 +29,7 @@ struct AtmosphericState{
     FTA1DN <: Union{AbstractArray{FT, 1}, Nothing},
     FTA2D <: AbstractArray{FT, 2},
     CLDP <: Union{AbstractArray{FT, 2}, Nothing},
-    CLDM <: Union{AbstractArray{Bool, 2}, Nothing},
+    CLDM <: Union{AbstractArray{Bool, 3}, Nothing},
     VMR <: AbstractVmr{FT},
     I <: Int,
 } <: AbstractAtmosphericState{FT, I, FTA1D}
@@ -60,8 +59,10 @@ struct AtmosphericState{
     cld_path_liq::CLDP
     "cloud ice path"
     cld_path_ice::CLDP
-    "cloud mask"
-    cld_mask::CLDM
+    "cloud mask (longwave), = true if clouds are present"
+    cld_mask_lw::CLDM
+    "cloud mask (shortwave), = true if clouds are present"
+    cld_mask_sw::CLDM
     "ice roughness, 1 = none, 2 = medium, 3 = rough"
     ice_rgh::I
     "Number of layers."

--- a/test/all_sky.jl
+++ b/test/all_sky.jl
@@ -70,7 +70,6 @@ function all_sky(
     close(ds_sw_cld)
     # reading input file 
     ds_in = Dataset(input_file, "r")
-
     as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, zenith, toa_flux, bot_at_1 = setup_allsky_as(
         ds_in,
         idx_gases,
@@ -164,9 +163,9 @@ function all_sky(
     @test max_err_flux_up_sw < toler
     @test max_err_flux_dn_sw < toler
 end
-println("running cloudy lookup table version")
-@time all_sky(TwoStream, Float64, Int, DA, use_lut = true)
-println("-----------------------------------------------")
-println("running cloudy pade version")
-@time all_sky(TwoStream, Float64, Int, DA, use_lut = false)
-println("-----------------------------------------------")
+@testset "Cloudy (all-sky, Two-stream calculations using lookup table method" begin
+    @time all_sky(TwoStream, Float64, Int, DA, use_lut = true)
+end
+@testset "Cloudy (all-sky), Two-stream calculations using Pade method" begin
+    @time all_sky(TwoStream, Float64, Int, DA, use_lut = false)
+end

--- a/test/clear_sky.jl
+++ b/test/clear_sky.jl
@@ -152,6 +152,6 @@ function clear_sky(
     @test max_err_flux_up_sw ≤ toler_sw
     @test max_err_flux_dn_sw ≤ toler_sw
 end
-println("running clear sky 2 stream solver")
-@time clear_sky(TwoStream, SourceLW2Str, VmrGM, Float64, Int, array_type())
-println("*********************************************")
+@testset "testing clear sky 2-stream solver" begin
+    @time clear_sky(TwoStream, SourceLW2Str, VmrGM, Float64, Int, array_type())
+end

--- a/test/read_all_sky.jl
+++ b/test/read_all_sky.jl
@@ -8,7 +8,8 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
     ngas = lkp_lw.n_gases
     nbnd_lw = lkp_lw.n_bnd
     nbnd_sw = lkp_sw.n_bnd
-
+    ngpt_lw = lkp_lw.n_gpt
+    ngpt_sw = lkp_sw.n_gpt
     #---no lat / long information for this
     lon = nothing
     lat = nothing
@@ -67,7 +68,8 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
     col_dry = DA{FT, 2}(undef, nlay, ncol)
     vmr_h2o = view(vmr.vmr, :, :, idx_gases["h2o"])
 
-    cld_mask = zeros(Bool, nlay, ncol)
+    cld_mask_lw = zeros(Bool, nlay, ncol, ngpt_lw)
+    cld_mask_sw = zeros(Bool, nlay, ncol, ngpt_sw)
     cld_r_eff_liq = zeros(FT, nlay, ncol)
     cld_r_eff_ice = zeros(FT, nlay, ncol)
     cld_path_liq = zeros(FT, nlay, ncol)
@@ -88,7 +90,8 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
     # total cloudiness of earth
     for icol in 1:ncol, ilay in 1:nlay
         if p_lay[ilay, icol] > FT(10000) && p_lay[ilay, icol] < FT(90000) && icol % 3 ≠ 0
-            cld_mask[ilay, icol] = true
+            cld_mask_lw[ilay, icol, :] .= true
+            cld_mask_sw[ilay, icol, :] .= true
             if t_lay[ilay, icol] > FT(263)
                 cld_path_liq[ilay, icol] = FT(10)
                 cld_r_eff_liq[ilay, icol] = r_eff_liq
@@ -110,7 +113,8 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
 
     t_sfc = DA(t_sfc)
 
-    cld_mask = DA(cld_mask)
+    cld_mask_lw = DA(cld_mask_lw)
+    cld_mask_sw = DA(cld_mask_sw)
     cld_r_eff_liq = DA(cld_r_eff_liq)
     cld_r_eff_ice = DA(cld_r_eff_ice)
     cld_path_liq = DA(cld_path_liq)
@@ -124,7 +128,7 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
             typeof(lat),
             typeof(p_lev),
             typeof(cld_r_eff_liq),
-            typeof(cld_mask),
+            typeof(cld_mask_lw),
             typeof(vmr),
             Int,
         }(
@@ -141,7 +145,8 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
             cld_r_eff_ice,
             cld_path_liq,
             cld_path_ice,
-            cld_mask,
+            cld_mask_lw,
+            cld_mask_sw,
             ice_rgh,
             nlay,
             ncol,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,11 +5,14 @@ using Test
     include("gray_atm.jl")
 
 end
+println("================================================================\n\n\n")
 
 @testset "RRTMGP clear-sky tests" begin
     include("clear_sky.jl")
 end
+println("================================================================\n\n\n")
 
-@testset "RRTMGP clear-sky tests" begin
+@testset "RRTMGP all-sky (cloudy) tests" begin
     include("all_sky.jl")
 end
+println("================================================================\n\n\n")

--- a/test/runtests_gpu.jl
+++ b/test/runtests_gpu.jl
@@ -1,15 +1,16 @@
 using Test
 
 @testset "RRTMGP gray radiation tests" begin
-
     include("gray_atm.jl")
-
 end
+println("================================================================\n\n\n")
 
 @testset "RRTMGP clear-sky tests" begin
     include("clear_sky.jl")
 end
+println("================================================================\n\n\n")
 
-@testset "RRTMGP clear-sky tests" begin
+@testset "RRTMGP all-sky (cloudy) tests" begin
     include("all_sky.jl")
 end
+println("================================================================\n\n\n")


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Refine/enlarge cloud_mask to be g-point and long/shortwave specific, in preparation for implementing cloud fraction support.

## Benefits and Risks
Enables support for cloud fraction.

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #297 
- Closes #297 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
