### PR TITLE
Add cloud fraction to AtmosphericState

### DIFF
--- a/src/optics/AtmosphericStates.jl
+++ b/src/optics/AtmosphericStates.jl
@@ -59,6 +59,8 @@ struct AtmosphericState{
     cld_path_liq::CLDP
     "cloud ice path"
     cld_path_ice::CLDP
+    "cloud fraction"
+    cld_frac::CLDP
     "cloud mask (longwave), = true if clouds are present"
     cld_mask_lw::CLDM
     "cloud mask (shortwave), = true if clouds are present"

--- a/test/read_all_sky.jl
+++ b/test/read_all_sky.jl
@@ -68,6 +68,7 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
     col_dry = DA{FT, 2}(undef, nlay, ncol)
     vmr_h2o = view(vmr.vmr, :, :, idx_gases["h2o"])
 
+    cld_frac = zeros(FT, nlay, ncol)
     cld_mask_lw = zeros(Bool, nlay, ncol, ngpt_lw)
     cld_mask_sw = zeros(Bool, nlay, ncol, ngpt_sw)
     cld_r_eff_liq = zeros(FT, nlay, ncol)
@@ -92,6 +93,7 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
         if p_lay[ilay, icol] > FT(10000) && p_lay[ilay, icol] < FT(90000) && icol % 3 ≠ 0
             cld_mask_lw[ilay, icol, :] .= true
             cld_mask_sw[ilay, icol, :] .= true
+            cld_frac[ilay, icol] = FT(1)
             if t_lay[ilay, icol] > FT(263)
                 cld_path_liq[ilay, icol] = FT(10)
                 cld_r_eff_liq[ilay, icol] = r_eff_liq
@@ -113,6 +115,7 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
 
     t_sfc = DA(t_sfc)
 
+    cld_frac = DA(cld_frac)
     cld_mask_lw = DA(cld_mask_lw)
     cld_mask_sw = DA(cld_mask_sw)
     cld_r_eff_liq = DA(cld_r_eff_liq)
@@ -145,6 +148,7 @@ function setup_allsky_as(ds_in, idx_gases, lkp_lw, lkp_sw, lkp_lw_cld, lkp_sw_cl
             cld_r_eff_ice,
             cld_path_liq,
             cld_path_ice,
+            cld_frac,
             cld_mask_lw,
             cld_mask_sw,
             ice_rgh,

--- a/test/read_rfmip_clear_sky.jl
+++ b/test/read_rfmip_clear_sky.jl
@@ -114,6 +114,7 @@ function setup_rfmip_as(
     cld_r_eff_ice = nothing
     cld_path_liq = nothing
     cld_path_ice = nothing
+    cld_frac = nothing
     cld_mask_lw = nothing
     cld_mask_sw = nothing
     ice_rgh = 1
@@ -142,6 +143,7 @@ function setup_rfmip_as(
             cld_r_eff_ice,
             cld_path_liq,
             cld_path_ice,
+            cld_frac,
             cld_mask_lw,
             cld_mask_sw,
             ice_rgh,


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Add cloud fraction input array to Atmospheric state

## Benefits and Risks
Allows user to prescribe cloud fraction for all-sky (cloudy) simulations.

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #299 
- Closes #299 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
