### PR TITLE
Enable parallel initialization of CPU and GPU environments in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,8 +21,6 @@ steps:
     # env:
     #   JULIA_NUM_PRECOMPILE_TASKS: 8
 
-  - wait
-
   - label: "init gpu environments :computer:"
     key: "init_gpu_env"
     command:


### PR DESCRIPTION
Enable parallel initialization of CPU and GPU environments in Buildkite pipeline.
# PULL REQUEST

## Purpose and Content
(Clearly and concisely state the purpose of this PR)

## Benefits and Risks
This PR enables initialization of CPU and GPU environments to run simultaneously, saving build times.

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #
- Closes #

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
