### PR TITLE
Update Artifacts to add reference data for cloud fraction tests

### DIFF
--- a/gpuenv/Artifacts.toml
+++ b/gpuenv/Artifacts.toml
@@ -1,9 +1,9 @@
 # Artifacts file for RRTMGP.jl
 
 [RRTMGPReferenceData]
-git-tree-sha1 = "f9cf4d95c9a5d45144166ca237ca7195edc0d5fe"
+git-tree-sha1 = "c1a57ba6e9720b22e8c7bf328b7ebd478cd55191"
 lazy = true
 
     [[RRTMGPReferenceData.download]]
-    url = "https://caltech.box.com/shared/static/vaz7fwnotqpj2lkka0fbix14r4i6aps1.gz"
-    sha256 = "7b4f5dd649f8c34c727dcd17251789cf0d559d1cdf93d7869dd9e1bd71dee8df"
+    url = "https://caltech.box.com/shared/static/jxuj8c0632yqrhjialqa5zs1rrf4kxu9.gz"
+    sha256 = "c9320f9fc89fb0c3e5e92164072842b4043184464136be259e527ee01ff833e6"

--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -1,9 +1,9 @@
 # Artifacts file for RRTMGP.jl
 
 [RRTMGPReferenceData]
-git-tree-sha1 = "f9cf4d95c9a5d45144166ca237ca7195edc0d5fe"
+git-tree-sha1 = "c1a57ba6e9720b22e8c7bf328b7ebd478cd55191"
 lazy = true
 
     [[RRTMGPReferenceData.download]]
-    url = "https://caltech.box.com/shared/static/vaz7fwnotqpj2lkka0fbix14r4i6aps1.gz"
-    sha256 = "7b4f5dd649f8c34c727dcd17251789cf0d559d1cdf93d7869dd9e1bd71dee8df"
+    url = "https://caltech.box.com/shared/static/jxuj8c0632yqrhjialqa5zs1rrf4kxu9.gz"
+    sha256 = "c9320f9fc89fb0c3e5e92164072842b4043184464136be259e527ee01ff833e6"


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

Update Artifacts to add reference data for cloud fraction tests

## Benefits and Risks
Full spectrum flux data for cloudy simulations is added to Artifacts. This reference data is intended for use with cloud fraction tests.

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #305 
- Closes #305 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
