### PR TITLE
Port over ClimaAtmos-needed changes

### DIFF
--- a/src/optics/GrayAtmosphericStates.jl
+++ b/src/optics/GrayAtmosphericStates.jl
@@ -26,8 +26,10 @@ struct GrayAtmosphericState{
     z_lev::FTA2D
     "Surface temperatures `[K]`; `(ncol)`"
     t_sfc::FTA1D
-    "lapse rate"
-    α::FT
+    "weight of linear term in longwave optical depth"
+    f::FT
+    "shortwave optical depth"
+    τ₀::FT
     "optical thickness parameter"
     d0::FTA1D
     "Number of layers."
@@ -66,7 +68,9 @@ function setup_gray_as_pr_grid(
     te = FT(300)                   # global mean surface temperature (K)
     tt = FT(200)                   # skin temp at top of atmosphere (K)
     Δt = FT(60)
-    α = FT(3.5)                   # lapse rate of radiative equillibrium
+    α = FT(3.5)
+    f = FT(0.2)
+    τ₀ = FT(0.22)
     r_d = RP.R_d(param_set)
     grav_ = RP.grav(param_set)
     args = (p_lev, p_lay, t_lev, t_lay, z_lev, t_sfc, lat, d0, efac, p0, pe, Δp, te, tt, Δt, α, r_d, grav_, nlay)
@@ -90,6 +94,8 @@ function setup_gray_as_pr_grid(
         z_lev,
         t_sfc,
         α,
+        f,
+        τ₀,
         d0,
         nlay,
         ncol,

--- a/src/optics/GrayOpticsKernels.jl
+++ b/src/optics/GrayOpticsKernels.jl
@@ -21,7 +21,7 @@ function compute_optical_props_kernel!(
     source::AbstractSourceLW{FT},
 ) where {FT <: AbstractFloat}
 
-    compute_optical_props_kernel_lw!(op, as, glaycol)     # computing optical thickness
+    compute_optical_props_kernel_lw!(op, as, glaycol) # computing optical thickness for LW
     compute_sources_gray_kernel!(source, as, glaycol) # computing Planck sources
 end
 
@@ -30,7 +30,7 @@ end
 
 Optical depth for longwave GrayRadiation.
 Reference:
- - TODO: add reference
+O'Gorman and Schneider 2008: https://journals.ametsoc.org/view/journals/clim/21/15/2007jcli2065.1.xml
 """
 function τ_lw_gray(p, pꜜ, pꜛ, p₀, τ₀, f)
     FT = eltype(p)
@@ -43,8 +43,7 @@ function compute_optical_props_kernel_lw!(
     glaycol,
 ) where {FT <: AbstractFloat}
     glay, gcol = glaycol
-    (; p_lay, p_lev, d0) = as
-    (; f) = TODO_some_struct
+    (; p_lay, p_lev, d0, f) = as
     @inbounds op.τ[glay, gcol] = τ_lw_gray(
         p_lay[glay, gcol],
         p_lev[glay, gcol],
@@ -53,10 +52,6 @@ function compute_optical_props_kernel_lw!(
         d0[gcol],
         f, # = FT(0.2)
     )
-    if op isa TwoStream
-        op.ssa[glaycol...] = FT(0)
-        op.g[glaycol...] = FT(0)
-    end
 end
 
 """
@@ -64,7 +59,7 @@ end
 
 Optical depth for shortwave GrayRadiation.
 Reference:
- - TODO: add reference
+O'Gorman and Schneider 2008: https://journals.ametsoc.org/view/journals/clim/21/15/2007jcli2065.1.xml
 """
 τ_sw_gray(p, pꜜ, pꜛ, p₀, τ₀) = 2 * τ₀ * (p / p₀) / p₀ * (pꜜ - pꜛ)
 
@@ -86,9 +81,8 @@ function compute_optical_props_kernel!(
 ) where {FT <: AbstractFloat}
     # setting references
     glay, gcol = glaycol
-    (; p_lay, p_lev, d0, α) = as
+    (; p_lay, p_lev, d0, τ₀) = as
     @inbounds p0 = p_lev[1, gcol]
-    (; f, τ₀) = TODO_some_struct # TODO: where should this be unpacked from ? `Y` vs `Yₜ`
     @inbounds op.τ[glay, gcol] = τ_sw_gray(
         p_lay[glay, gcol],
         p_lev[glay, gcol],


### PR DESCRIPTION
Currently, ClimaAtmos is overwriting some methods in RRTMGP to function properly. This PR ports over these modifications. This PR requires additional work:
 - [ ] replace hard-coded constants with somehow passed-in parameters
 - [ ] Add documentation for the newly added parameters
 - [ ] Add paper/equation references to the newly added equations.

@dennisYatunin, this is perhaps not high priority, but can I assign you to follow this through?