### PR TITLE
Enable user-defined gray optical thickness calculations

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,5 +1,10 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
 [[ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.1"
@@ -40,14 +45,14 @@ version = "0.7.1"
 
 [[Compat]]
 deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "00a2cccc7f098ff3b66806862d275ca3db9e6e5a"
+git-tree-sha1 = "61fdd77467a5c3ad071ef8277ac6bd6af7dd4c04"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.5.0"
+version = "4.6.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.5.2+0"
+version = "1.0.1+0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -61,15 +66,15 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.5"
+version = "0.9.3"
 
 [[Documenter]]
-deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "47f13b6305ab195edb73c86815962d84e31b0f48"
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "58fea7c536acd71f3eef6be3b21c0df5f3df88fd"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.3"
+version = "0.27.24"
 
 [[DocumenterCitations]]
 deps = ["Bibliography", "DataStructures", "Documenter", "Markdown", "Unicode"]
@@ -120,9 +125,9 @@ version = "1.4.1"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.3"
 
 [[JSONSchema]]
 deps = ["HTTP", "JSON", "URIs"]
@@ -131,9 +136,9 @@ uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 version = "1.0.1"
 
 [[LaTeXStrings]]
-git-tree-sha1 = "c7f1c695e06c01b95a67f0cd1d34994f3e7db104"
+git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.2.1"
+version = "1.3.0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -215,9 +220,9 @@ version = "1.3.3"
 
 [[OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f6e9dba33f9f2c44e08a020b0caf6903be540004"
+git-tree-sha1 = "9ff31d101d987eb9d66bd8b176ac7c277beccd09"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.19+0"
+version = "1.1.20+0"
 
 [[OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
@@ -225,10 +230,10 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
 [[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
+deps = ["Dates", "SnoopPrecompile"]
+git-tree-sha1 = "6f4fbcd1ad45905a5dee3f4256fabb49aa2110c6"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.1.0"
+version = "2.5.7"
 
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -271,6 +276,12 @@ git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
 uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 version = "1.1.0"
 
+[[SnoopPrecompile]]
+deps = ["Preferences"]
+git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
+uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+version = "1.0.3"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
@@ -301,9 +312,9 @@ uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.9.11"
 
 [[URIs]]
-git-tree-sha1 = "ac00576f90d8a259f2c9d823e91d1de3fd44d348"
+git-tree-sha1 = "074f993b0ca030848b897beff716d93aca60f06a"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.4.1"
+version = "1.4.2"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]

--- a/docs/src/Optics.md
+++ b/docs/src/Optics.md
@@ -7,8 +7,8 @@
 The gray atmosphere (more precisely, semi-gray atmosphere) approximates the radiative properties of the atmosphere by taking the optical properties to be independent of wavelength, separately in the longwave and shortwave bands. 
 
 ### Longwave
-
-The optical depth (``d``) for longwave radiation follows [schneider2004](@cite):
+Two options are currently supported for computing the optical depth for longwave radiation.
+The optical depth (``d``) for longwave radiation, with the "GrayOpticalThicknessSchneider2004" option, follows [schneider2004](@cite):
 
 ```math
 \begin{align}
@@ -31,6 +31,25 @@ The optical thickness of an atmosphere layer (the differential optical depth) of
 ```math
 \begin{align}
 \tau(\phi, p) = \alpha d_0(\phi) \left(\frac{p}{p_0}\right)^\alpha \frac{\Delta p}{p}.
+\end{align}
+```
+
+
+The optical depth (``d``) for longwave radiation, with the "GrayOpticalThicknessOGorman2008" option, follows [ogorman2008](@cite):
+
+```math
+\begin{align}
+d(\phi, p) = \alpha \left[f_l \sigma + (1 - f_l) \sigma^4 \right] \left[ \tau_e + (\tau_p - \tau_e) sin^2\phi \right]
+\end{align}
+```
+
+where $f_l = 0.2$, $\sigma = \frac{p}{p_0}$ is pressure p normalized by
+surface pressure $p_0$, $\phi$ is latitude, and the longwave optical thicknesses at the equator and at the pole are  $\tau_e = 7.2$ and $\tau_p = 1.8$, respectively. $\alpha$ is a scaling factor. 
+
+The optical thickness of an atmosphere layer (the differential optical depth) of pressure thickness $\Delta 𝑝$ is
+```math
+\begin{align}
+\tau(\phi, p) = (\alpha * \frac{\Delta p}{p}) \left[f_l \sigma + 4 (1 - f_l) \sigma^4 \right] \left[ \tau_e + (\tau_p - \tau_e) sin^2\phi \right]
 \end{align}
 ```
 

--- a/docs/src/optics/AtmosphericStates.md
+++ b/docs/src/optics/AtmosphericStates.md
@@ -7,4 +7,6 @@ CurrentModule = RRTMGP.AtmosphericStates
 ```@docs
 AtmosphericState
 GrayAtmosphericState
+GrayOpticalThicknessSchneider2004
+GrayOpticalThicknessOGorman2008
 ```

--- a/docs/src/optics/Optics.md
+++ b/docs/src/optics/Optics.md
@@ -35,6 +35,8 @@ pade_eval
 compute_optical_props_kernel!
 compute_optical_props_kernel_lw!
 compute_sources_gray_kernel!
+compute_gray_optical_thickness_lw
+compute_gray_optical_thickness_sw
 ```
 
 ```@docs

--- a/src/optics/AtmosphericStates.jl
+++ b/src/optics/AtmosphericStates.jl
@@ -14,7 +14,10 @@ export AbstractAtmosphericState,
     setup_gray_as_pr_grid,
     setup_gray_as_alt_grid,
     MaxRandomOverlap,
-    AbstractCloudMask
+    AbstractCloudMask,
+    GrayOpticalThicknessSchneider2004,
+    GrayOpticalThicknessOGorman2008,
+    AbstractGrayOpticalThickness
 
 abstract type AbstractAtmosphericState{FT, I, FTA1D} end
 

--- a/src/optics/GrayOpticsKernels.jl
+++ b/src/optics/GrayOpticsKernels.jl
@@ -1,8 +1,6 @@
 
-# This functions calculates the optical thickness based on pressure 
-# and lapse rate for a gray atmosphere. 
-# See Schneider 2004, J. Atmos. Sci. (2004) 61 (12): 1317–1340.
-# https://doi.org/10.1175/1520-0469(2004)061<1317:TTATTS>2.0.CO;2
+# Calculate optical properties for gray radiation solver.
+
 """
     compute_optical_props_kernel!(
         op::AbstractOpticalProps{FT},
@@ -23,6 +21,7 @@ function compute_optical_props_kernel!(
 
     compute_optical_props_kernel_lw!(op, as, glaycol)     # computing optical thickness
     compute_sources_gray_kernel!(source, as, glaycol) # computing Planck sources
+    return nothing
 end
 
 """
@@ -43,12 +42,13 @@ function compute_optical_props_kernel_lw!(
 ) where {FT <: AbstractFloat}
     # setting references
     glay, gcol = glaycol
-    (; p_lay, p_lev, d0, α) = as
+    (; p_lay, p_lev, otp, lat) = as
     @inbounds p0 = p_lev[1, gcol]
-
-    @inbounds op.τ[glaycol...] = abs(
-        (α * d0[gcol] * (p_lay[glaycol...] / p0)^α / p_lay[glaycol...]) * (p_lev[glay + 1, gcol] - p_lev[glaycol...]),
-    )
+    @inbounds Δp = p_lev[glay + 1, gcol] - p_lev[glaycol...]
+    @inbounds p = p_lay[glaycol...]
+    @inbounds lat = as.lat[gcol]
+    @inbounds op.τ[glaycol...] = compute_gray_optical_thickness_lw(otp, glaycol, p0, Δp, p, lat)
+    return nothing
 end
 """
     compute_sources_gray_kernel!(
@@ -76,6 +76,7 @@ function compute_sources_gray_kernel!(
     if glay == 1
         @inbounds sfc_source[gcol] = sbc * as.t_sfc[gcol]^FT(4) / FT(π)   # computing sfc_source
     end
+    return nothing
 end
 
 """
@@ -94,12 +95,108 @@ function compute_optical_props_kernel!(
 ) where {FT <: AbstractFloat}
     # setting references
     glay, gcol = glaycol
-    (; p_lay, p_lev, d0, τ₀) = as
+    (; p_lay, p_lev, otp) = as
     @inbounds p0 = p_lev[1, gcol]
-    @inbounds op.τ[glay, gcol] = 2 * τ₀ * (p_lay[glaycol...] / p0) / p0 * (p_lev[glaycol...] - p_lev[glay + 1, gcol])
+    @inbounds Δp = p_lev[glay + 1, gcol] - p_lev[glaycol...]
+    @inbounds p = p_lay[glaycol...]
+
+    @inbounds op.τ[glay, gcol] = compute_gray_optical_thickness_sw(otp, glaycol, p0, Δp, p)
 
     if op isa TwoStream
         op.ssa[glaycol...] = FT(0)
         op.g[glaycol...] = FT(0)
     end
+    return nothing
+end
+"""
+    compute_gray_optical_thickness_lw(
+        params::GrayOpticalThicknessSchneider2004{FT},
+        glaycol,
+        p0,
+        Δp,
+        p,
+        lat,
+    ) where {FT<:AbstractFloat}
+
+This functions calculates the optical thickness based on pressure 
+and lapse rate for a gray atmosphere. 
+See Schneider 2004, J. Atmos. Sci. (2004) 61 (12): 1317–1340.
+DOI: https://doi.org/10.1175/1520-0469(2004)061<1317:TTATTS>2.0.CO;2
+"""
+function compute_gray_optical_thickness_lw(
+    params::GrayOpticalThicknessSchneider2004{FT},
+    glaycol,
+    p0,
+    Δp,
+    p,
+    lat,
+) where {FT <: AbstractFloat}
+    (; α, te, tt, Δt) = params
+    glay, gcol = glaycol
+    ts = te + Δt * (FT(1) / FT(3) - sin(lat)^2) # surface temp at a given latitude (K)
+    d0 = FT((ts / tt)^FT(4) - FT(1)) # optical depth
+    @inbounds τ = (α * d0 * (p / p0)^α / p) * Δp
+    return abs(τ)
+end
+
+compute_gray_optical_thickness_sw(params::GrayOpticalThicknessSchneider2004{FT}, rest...) where {FT} = FT(0)
+
+"""
+    compute_gray_optical_thickness_lw(
+        params::GrayOpticalThicknessOGorman2008{FT},
+        glaycol,
+        p0,
+        Δp,
+        p,
+        lat,
+    ) where {FT}
+
+This functions calculates the optical thickness based on pressure 
+and lapse rate for a gray atmosphere. 
+See O'Gorman 2008, Journal of Climate Vol 21, Page(s): 3815–3832.
+DOI: https://doi.org/10.1175/2007JCLI2065.1
+"""
+function compute_gray_optical_thickness_lw(
+    params::GrayOpticalThicknessOGorman2008{FT},
+    glaycol,
+    p0,
+    Δp,
+    p,
+    lat,
+) where {FT}
+    (; α, fₗ, τₑ, τₚ) = params
+    glay, gcol = glaycol
+    σ = p / p0
+
+    @inbounds τ = (α * Δp / p) * (fₗ * σ + (1 - fₗ) * 4 * σ^4) * (τₑ + (τₚ - τₑ) * sin(lat)^2)
+
+    return abs(τ)
+end
+"""
+    compute_gray_optical_thickness_sw(
+        params::GrayOpticalThicknessOGorman2008{FT},
+        glaycol,
+        p0,
+        Δp,
+        p,
+        rest...,
+    ) where {FT}
+ 
+This functions calculates the optical thickness based on pressure 
+for a gray atmosphere. 
+See O'Gorman 2008, Journal of Climate Vol 21, Page(s): 3815–3832.
+DOI: https://doi.org/10.1175/2007JCLI2065.1
+"""
+function compute_gray_optical_thickness_sw(
+    params::GrayOpticalThicknessOGorman2008{FT},
+    glaycol,
+    p0,
+    Δp,
+    p,
+    rest...,
+) where {FT}
+    (; τ₀) = params
+    glay, gcol = glaycol
+    @inbounds τ = 2 * τ₀ * (p / p0) * (Δp / p0)
+    return abs(τ)
 end

--- a/test/gray_atm.jl
+++ b/test/gray_atm.jl
@@ -58,7 +58,8 @@ function gray_atmos_lw_equil(
         lat = DA{FT}(range(FT(-π / 2), FT(π / 2), length = ncol)) # latitude
     end
 
-    as = setup_gray_as_pr_grid(nlay, lat, p0, pe, param_set, DA)
+    otp = GrayOpticalThicknessSchneider2004(FT) # optical thickness parameters
+    as = setup_gray_as_pr_grid(nlay, lat, p0, pe, otp, param_set, DA)
     op = OPC(FT, ncol, nlay, DA)
     src_lw = source_func_longwave(param_set, FT, ncol, nlay, opc, DA)
     bcs_lw = LwBCs(DA{FT, 2}(sfc_emis), inc_flux)
@@ -152,6 +153,7 @@ function gray_atmos_sw_test(
     sfc_alb_direct = DA{FT, 2}(undef, nbnd, ncol) # surface albedo (direct)
     sfc_alb_diffuse = DA{FT, 2}(undef, nbnd, ncol) # surface albedo (diffuse)
     inc_flux_diffuse = nothing
+    otp = GrayOpticalThicknessOGorman2008(FT) # optical thickness parameters
 
     top_at_1 = false                          # Top-of-atmos at pt# 1 (true/false)
 
@@ -166,7 +168,7 @@ function gray_atmos_sw_test(
     sfc_alb_direct .= FT(0.1)
     sfc_alb_diffuse .= FT(0.1)
 
-    as = setup_gray_as_pr_grid(nlay, lat, p0, pe, param_set, DA) # init gray atmos state
+    as = setup_gray_as_pr_grid(nlay, lat, p0, pe, otp, param_set, DA) # init gray atmos state
     op = OPC(FT, ncol, nlay, DA)
     src_sw = source_func_shortwave(FT, ncol, nlay, opc, DA)
     bcs_sw = SwBCs(zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse)


### PR DESCRIPTION
Enable user-defined gray optical thickness calculations

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
