### PR TITLE
Fix Latency on julia 1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/optics/RTE.jl
+++ b/src/optics/RTE.jl
@@ -14,85 +14,70 @@ import ..Parameters as RP
 export Solver
 
 """
-    struct Solver{
-        FT,
-        I,
-        FTA1D,
-        FTA2D,
-        AS,
-        OP,
-        SL,
-        SS,
-        BCL,
-        BCS,
-        FXBL,
-        FXBS,
-        FXL,
-        FXS,
-    }
+    Solver(
+        as,
+        op,
+        src_lw,
+        src_sw,
+        bcs_lw,
+        bcs_sw,
+        fluxb_lw,
+        fluxb_sw,
+        flux_lw,
+        flux_sw
+    )
 
-The high-level RRTMGP data structure storing the atmospheric state, 
-optical properties, sources, boundary conditions and fluxes configurations
-for a given simulation.
+The high-level RRTMGP data structure storing
+the atmospheric state, optical properties,
+sources, boundary conditions and fluxes
+configurations for a given simulation.
 
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Solver{
-    FT <: AbstractFloat,
-    I <: Int,
-    FTA1D <: AbstractArray{FT, 1},
-    FTA2D <: AbstractArray{FT, 2},
-    AS <: AbstractAtmosphericState{FT, I, FTA1D},
-    OP <: AbstractOpticalProps{FT, FTA2D},
-    SL <: Union{AbstractSourceLW{FT, FTA1D, FTA2D}, Nothing},
-    SS <: Union{SourceSW2Str{FT, FTA1D, FTA2D}, Nothing},
-    BCL <: Union{LwBCs{FT}, Nothing},
-    BCS <: Union{SwBCs{FT}, Nothing},
-    FXBL <: Union{FluxLW{FT, FTA2D}, Nothing},
-    FXBS <: Union{FluxSW{FT, FTA2D}, Nothing},
-    FXL <: Union{FluxLW{FT, FTA2D}, Nothing},
-    FXS <: Union{FluxSW{FT, FTA2D}, Nothing},
-}
-    as::AS         # atmospheric state
-    op::OP         # optical properties
-    src_lw::SL     # source functions
-    src_sw::SS     # source functions
-    bcs_lw::BCL    # boundary conditions
-    bcs_sw::BCS    # boundary conditions
-    fluxb_lw::FXBL # temporary storage for bandwise calculations
-    fluxb_sw::FXBS # temporary storage for bandwise calculations
-    flux_lw::FXL   # fluxes for longwave problem
-    flux_sw::FXS   # fluxes for shortwave problem
+struct Solver{AS, OP, SL, SS, BCL, BCS, FXBL, FXBS, FXL, FXS}
+    "atmospheric state"
+    as::AS
+    "optical properties"
+    op::OP
+    "source functions"
+    src_lw::SL
+    "source functions"
+    src_sw::SS
+    "boundary conditions"
+    bcs_lw::BCL
+    "boundary conditions"
+    bcs_sw::BCS
+    "temporary storage for bandwise calculations"
+    fluxb_lw::FXBL
+    "temporary storage for bandwise calculations"
+    fluxb_sw::FXBS
+    "fluxes for longwave problem"
+    flux_lw::FXL
+    "fluxes for shortwave problem"
+    flux_sw::FXS
+    function Solver(as, op, src_lw, src_sw, bcs_lw, bcs_sw, fluxb_lw, fluxb_sw, flux_lw, flux_sw)
+        args = (as, op, src_lw, src_sw, bcs_lw, bcs_sw, fluxb_lw, fluxb_sw, flux_lw, flux_sw)
+        targs = typeof.(args)
+        FT = eltype(as.p_lev)
+        FTA1D = typeof(as.t_sfc)
+        FTA2D = typeof(as.p_lev)
+        @assert targs[1] <: AbstractAtmosphericState{FT, Int, FTA1D}
+        @assert targs[2] <: AbstractOpticalProps{FT, FTA2D}
+        @assert targs[3] <: Union{AbstractSourceLW{FT, FTA1D, FTA2D}, Nothing}
+        @assert targs[4] <: Union{SourceSW2Str{FT, FTA1D, FTA2D}, Nothing}
+        @assert targs[5] <: Union{LwBCs{FT}, Nothing}
+        @assert targs[6] <: Union{SwBCs{FT}, Nothing}
+        @assert targs[7] <: Union{FluxLW{FT, FTA2D}, Nothing}
+        @assert targs[8] <: Union{FluxSW{FT, FTA2D}, Nothing}
+        @assert targs[9] <: Union{FluxLW{FT, FTA2D}, Nothing}
+        @assert targs[10] <: Union{FluxSW{FT, FTA2D}, Nothing}
+        return new{targs...}(args...)
+    end
 end
 
-Solver(as, op, src_lw, src_sw, bcs_lw, bcs_sw, fluxb_lw, fluxb_sw, flux_lw, flux_sw) = Solver{
-    eltype(as.p_lev),
-    typeof(as.ncol),
-    typeof(as.t_sfc),
-    typeof(as.p_lev),
-    typeof(as),
-    typeof(op),
-    typeof(src_lw),
-    typeof(src_sw),
-    typeof(bcs_lw),
-    typeof(bcs_sw),
-    typeof(fluxb_lw),
-    typeof(fluxb_sw),
-    typeof(flux_lw),
-    typeof(flux_sw),
-}(
-    as,
-    op,
-    src_lw,
-    src_sw,
-    bcs_lw,
-    bcs_sw,
-    fluxb_lw,
-    fluxb_sw,
-    flux_lw,
-    flux_sw,
-)
+float_type(s::Solver) = eltype(s.as.p_lev)
+
 
 Adapt.@adapt_structure Solver
 end

--- a/src/rte/RTESolver.jl
+++ b/src/rte/RTESolver.jl
@@ -21,14 +21,14 @@ include("RTESolverKernels.jl")
 
 """
     solve_lw!(
-        slv::Solver{FT,I},
-        max_threads::I,
-        lkp_args...,
-    ) where {I<:Int,FT<:AbstractFloat}
+        slv::Solver,
+        max_threads::Int,
+        lkp_args...
+    )
 
 Solver for the longwave radiation problem
 """
-function solve_lw!(slv::Solver{FT, I}, max_threads::I, lkp_args...) where {I <: Int, FT <: AbstractFloat}
+function solve_lw!(slv::Solver, max_threads::Int, lkp_args...)
     (; as, op, bcs_lw, src_lw, flux_lw, fluxb_lw) = slv
     (; nlay, ncol) = as
     DA = array_type()
@@ -249,16 +249,17 @@ end
 
 """
     solve_sw!(
-        slv::Solver{FT,I},
-        max_threads::I,
+        slv::Solver,
+        max_threads::Int,
         lkp_args...,
-    ) where {I<:Int,FT<:AbstractFloat}
+    )
 
 Solver for the shortwave radiation problem
 """
-function solve_sw!(slv::Solver{FT, I}, max_threads::I, lkp_args...) where {I <: Int, FT <: AbstractFloat}
+function solve_sw!(slv::Solver, max_threads::Int, lkp_args...)
     (; as, op, bcs_sw, src_sw, flux_sw, fluxb_sw) = slv
     (; nlay, ncol) = as
+    FT = RTE.float_type(slv)
     DA = array_type()
     nargs = length(lkp_args)
     @assert nargs < 3


### PR DESCRIPTION
This PR fixes a major latency issue on Julia 1.9 (per @vtjnash on slack)

> it is a constructor for a type with too many Union parameters

The fix is to remove several `Union` parameter types. I also took the opportunity to reduce the type space for `Solver`-- there is no need to have `I <: Int` and `FT` in the type space since `Int` will always resolve the same and `FT` can be grabbed from `eltype`s of member arrays.

Main:
```julia
julia> @time using RRTMGP
[ Info: Precompiling RRTMGP [a01a1ee8-cea4-48fc-987c-fc7878d79da1]
532.620944 seconds (517.19 M allocations: 140.311 GiB, 2.15% gc time, 0.16% compilation time: 86% of which was recompilation)
```

This PR:
```julia
julia> @time using RRTMGP
[ Info: Precompiling RRTMGP [a01a1ee8-cea4-48fc-987c-fc7878d79da1]
  5.199173 seconds (5.78 M allocations: 453.897 MiB, 1.94% gc time, 15.94% compilation time: 88% of which was recompilation)
```

It's still not fantastic (there are other structs with several `Union`s), but it's at least not catastrophic.