### PR TITLE
Bump patch version for new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
In order to add CUDA 4.2.0 to ClimaAtmos (regardless of whether it uses RRTMGP), we need RRTMGP to be compatible. So, this PR bumps the patch version for a new release.