### PR TITLE
Remove unnecessary type parameters

### DIFF
--- a/src/optics/AngularDiscretizations.jl
+++ b/src/optics/AngularDiscretizations.jl
@@ -6,7 +6,7 @@ using Adapt
 export AngularDiscretization
 
 """
-    AngularDiscretization{FT,FTA1D,I}
+    AngularDiscretization{FT,FTA1D}
 
 Weights and angle secants for first order (k=1) Gaussian quadrature.
 Values from Table 2, Clough et al, 1992, doi:10.1029/92JD01419
@@ -15,9 +15,9 @@ after Abramowitz & Stegun 1972, page 921
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AngularDiscretization{FT <: AbstractFloat, FTA1D <: AbstractArray{FT, 1}, I <: Int}
+struct AngularDiscretization{FT <: AbstractFloat, FTA1D <: AbstractArray{FT, 1}}
     "number of quadrature angles"
-    n_gauss_angles::I
+    n_gauss_angles::Int
     "quadrature secants / secant of propagation angle"
     gauss_Ds::FTA1D
     "quadrature weights"
@@ -25,8 +25,8 @@ struct AngularDiscretization{FT <: AbstractFloat, FTA1D <: AbstractArray{FT, 1},
 end
 Adapt.@adapt_structure AngularDiscretization
 
-function AngularDiscretization(::Type{FT}, ::Type{DA}, n_gauss_angles::I) where {FT <: AbstractFloat, I <: Int, DA}
-    max_gauss_pts = I(4)
+function AngularDiscretization(::Type{FT}, ::Type{DA}, n_gauss_angles::Int) where {FT <: AbstractFloat, DA}
+    max_gauss_pts = 4
     @assert 1 ≤ n_gauss_angles ≤ max_gauss_pts
     if n_gauss_angles == 1
         gauss_Ds = DA{FT}([1.660000000000])
@@ -42,7 +42,7 @@ function AngularDiscretization(::Type{FT}, ::Type{DA}, n_gauss_angles::I) where 
         gauss_wts = DA{FT}([0.135506913400 0.203464568000 0.129847547600 0.031180971000])
     end
 
-    return AngularDiscretization{eltype(gauss_Ds), typeof(gauss_Ds), eltype(n_gauss_angles)}(
+    return AngularDiscretization{eltype(gauss_Ds), typeof(gauss_Ds)}(
         n_gauss_angles,
         gauss_Ds, # Diffusivity angle, not Gaussian angle
         gauss_wts,

--- a/src/optics/AtmosphericStates.jl
+++ b/src/optics/AtmosphericStates.jl
@@ -19,7 +19,7 @@ export AbstractAtmosphericState,
     GrayOpticalThicknessOGorman2008,
     AbstractGrayOpticalThickness
 
-abstract type AbstractAtmosphericState{FT, I, FTA1D} end
+abstract type AbstractAtmosphericState{FT, FTA1D} end
 
 include("GrayAtmosphericStates.jl")
 
@@ -29,8 +29,8 @@ struct MaxRandomOverlap <: AbstractCloudMask end
 Adapt.@adapt_structure MaxRandomOverlap
 
 """
-    AtmosphericState{FT,FTA1D,FTA1DN,FTA2D,CLDP,CLDM,VMR,I} <:
-        AbstractAtmosphericState{FT,I,FTA1D}
+    AtmosphericState{FT,FTA1D,FTA1DN,FTA2D,CLDP,CLDM,VMR} <:
+        AbstractAtmosphericState{FT,FTA1D}
 
 Atmospheric conditions, used to compute optical properties. 
 
@@ -47,8 +47,7 @@ struct AtmosphericState{
     RND <: Union{AbstractArray{FT, 3}, Nothing},
     CMASK <: Union{AbstractCloudMask, Nothing},
     VMR <: AbstractVmr{FT},
-    I <: Int,
-} <: AbstractAtmosphericState{FT, I, FTA1D}
+} <: AbstractAtmosphericState{FT, FTA1D}
     "longitude, in degrees (`ncol`), optional"
     lon::FTA1DN
     "latitude, in degrees (`ncol`), optional"
@@ -88,13 +87,13 @@ struct AtmosphericState{
     "cloud mask type"
     cld_mask_type::CMASK
     "ice roughness, 1 = none, 2 = medium, 3 = rough"
-    ice_rgh::I
+    ice_rgh::Int
     "Number of layers."
-    nlay::I
+    nlay::Int
     "Number of columns."
-    ncol::I
+    ncol::Int
     "Number of gases."
-    ngas::I
+    ngas::Int
 end
 Adapt.@adapt_structure AtmosphericState
 end

--- a/src/optics/GasOptics.jl
+++ b/src/optics/GasOptics.jl
@@ -39,26 +39,26 @@ function compute_col_gas_kernel!(
 end
 """
     compute_interp_fractions(
-        lkp::AbstractLookUp{I,FT},
+        lkp::AbstractLookUp{FT},
         vmr,
         p_lay,
         t_lay,
         tropo,
         ibnd,
         glaycol,
-    ) where {I<:Int,FT<:AbstractFloat}
+    ) where {FT<:AbstractFloat}
 
 compute interpolation fractions for binary species parameter, pressure and temperature.
 """
 @inline function compute_interp_fractions(
-    lkp::AbstractLookUp{I, FT},
+    lkp::AbstractLookUp{FT},
     vmr,
     p_lay,
     t_lay,
     tropo,
     ibnd,
     glaycol,
-) where {I <: Int, FT <: AbstractFloat}
+) where {FT <: AbstractFloat}
     jftemp = compute_interp_frac_temp(lkp, t_lay, glaycol...)
     jfpress = compute_interp_frac_press(lkp, p_lay, tropo, glaycol...)
     jfη, col_mix = compute_interp_frac_η(lkp, vmr, tropo, jftemp[1], ibnd, glaycol...)
@@ -67,20 +67,15 @@ end
 
 """
     compute_interp_frac_temp(
-        lkp::AbstractLookUp{I,FT},
+        lkp::AbstractLookUp{FT},
         t_lay,
         glay,
         gcol,
-    ) where {I<:Int,FT<:AbstractFloat}
+    ) where {FT<:AbstractFloat}
 
 compute interpolation fraction for temperature.
 """
-@inline function compute_interp_frac_temp(
-    lkp::AbstractLookUp{I, FT},
-    t_lay,
-    glay,
-    gcol,
-) where {I <: Int, FT <: AbstractFloat}
+@inline function compute_interp_frac_temp(lkp::AbstractLookUp{FT}, t_lay, glay, gcol) where {FT <: AbstractFloat}
     (; Δ_t_ref, n_t_ref, t_ref) = lkp
 
     @inbounds jtemp = loc_lower(t_lay, Δ_t_ref, n_t_ref, t_ref)
@@ -113,26 +108,26 @@ end
 
 """
     compute_interp_frac_η(
-        lkp::AbstractLookUp{I,FT},
+        lkp::AbstractLookUp{FT},
         vmr,
         tropo,
         jtemp,
         ibnd,
         glay,
         gcol,
-    ) where {FT<:AbstractFloat,I<:Int}
+    ) where {FT<:AbstractFloat}
 
 Compute interpolation fraction for binary species parameter.
 """
 @inline function compute_interp_frac_η(
-    lkp::AbstractLookUp{I, FT},
+    lkp::AbstractLookUp{FT},
     vmr,
     tropo,
     jtemp,
     ibnd,
     glay,
     gcol,
-) where {FT <: AbstractFloat, I <: Int}
+) where {FT <: AbstractFloat}
     (; n_η, key_species, vmr_ref) = lkp
     ig = view(key_species, :, tropo, ibnd)
 
@@ -144,7 +139,7 @@ Compute interpolation fraction for binary species parameter.
     col_mix1 = vmr1 + η_half * vmr2
     η = col_mix1 ≥ eps(FT) * 2 ? vmr1 / col_mix1 : FT(0.5)
     loc_η = FT(η * (n_η - 1))
-    jη1 = min(unsafe_trunc(I, loc_η) + 1, n_η - 1)
+    jη1 = min(unsafe_trunc(Int, loc_η) + 1, n_η - 1)
     #fη1 = loc_η % FT(1) # TODO: "%: operator seems unstable on GPU
     #fη1 = FT(loc_η % 1) # to be revisited
     fη1 = loc_η - fld(loc_η, FT(1))
@@ -154,7 +149,7 @@ Compute interpolation fraction for binary species parameter.
     col_mix2 = vmr1 + η_half * vmr2
     η = col_mix2 ≥ eps(FT) * 2 ? vmr1 / col_mix2 : FT(0.5)
     loc_η = FT(η * (n_η - 1))
-    jη2 = min(unsafe_trunc(I, loc_η) + 1, n_η - 1)
+    jη2 = min(unsafe_trunc(Int, loc_η) + 1, n_η - 1)
     #fη2 = loc_η % FT(1) # TODO: "%" operator seems unstable on GPU
     #fη2 = FT(loc_η % 1) # to be revisited
     fη2 = loc_η - fld(loc_η, FT(1))
@@ -164,7 +159,7 @@ end
 
 """
     compute_τ_ssa_lw_src!(
-        lkp::AbstractLookUp{I,FT},
+        lkp::AbstractLookUp{FT},
         vmr,
         col_dry,
         igpt,
@@ -173,13 +168,13 @@ end
         t_lay,
         glaycol,
         src_args...,
-    ) where {FT<:AbstractFloat,I<:Int}
+    ) where {FT<:AbstractFloat}
 
 Compute optical thickness, single scattering albedo, asymmetry parameter 
 and longwave sources whenever applicable.
 """
 @inline function compute_τ_ssa_lw_src!(
-    lkp::AbstractLookUp{I, FT},
+    lkp::AbstractLookUp{FT},
     vmr,
     col_dry,
     igpt,
@@ -188,7 +183,7 @@ and longwave sources whenever applicable.
     t_lay,
     glaycol,
     src_args...,
-) where {FT <: AbstractFloat, I <: Int}
+) where {FT <: AbstractFloat}
     # upper/lower troposphere
     tropo = p_lay > lkp.p_ref_tropo ? 1 : 2
     # volume mixing ratio of h2o
@@ -216,45 +211,45 @@ end
 """
     compute_τ_minor(
         lkp::AbstractLookUp,
-        tropo::I,
+        tropo::Int,
         vmr,
         vmr_h2o::FT,
         col_dry,
         p_lay::FT,
         t_lay::FT,
-        jtemp::I,
+        jtemp::Int,
         ftemp::FT,
-        jη1::I,
-        jη2::I,
+        jη1::Int,
+        jη2::Int,
         fη1::FT,
         fη2::FT,
         igpt,
         ibnd,
         glay,
         gcol,
-    ) where {FT<:AbstractFloat,I<:Int}
+    ) where {FT<:AbstractFloat}
 
 Compute optical thickness contributions from minor gases.
 """
 @inline function compute_τ_minor(
     lkp::AbstractLookUp,
-    tropo::I,
+    tropo::Int,
     vmr,
     vmr_h2o::FT,
     col_dry,
     p_lay::FT,
     t_lay::FT,
-    jtemp::I,
+    jtemp::Int,
     ftemp::FT,
-    jη1::I,
-    jη2::I,
+    jη1::Int,
+    jη2::Int,
     fη1::FT,
     fη2::FT,
     igpt,
     ibnd,
     glay,
     gcol,
-) where {FT <: AbstractFloat, I <: Int}
+) where {FT <: AbstractFloat}
 
     if tropo == 1 # in lower atmosphere
         minor_bnd_st = lkp.minor_lower_bnd_st
@@ -307,33 +302,33 @@ end
 """
     compute_τ_rayleigh(
         lkp::LookUpSW,
-        tropo::I,
+        tropo::Int,
         col_dry::FT,
         vmr_h2o::FT,
-        jtemp::I,
+        jtemp::Int,
         ftemp::FT,
-        jη1::I,
-        jη2::I,
+        jη1::Int,
+        jη2::Int,
         fη1::FT,
         fη2::FT,
-        igpt::I,
-    ) where {FT<:AbstractFloat,I<:Int}
+        igpt::Int,
+    ) where {FT<:AbstractFloat}
 
 Compute Rayleigh scattering optical depths for shortwave problem
 """
 @inline function compute_τ_rayleigh(
     lkp::LookUpSW,
-    tropo::I,
+    tropo::Int,
     col_dry::FT,
     vmr_h2o::FT,
-    jtemp::I,
+    jtemp::Int,
     ftemp::FT,
-    jη1::I,
-    jη2::I,
+    jη1::Int,
+    jη2::Int,
     fη1::FT,
     fη2::FT,
-    igpt::I,
-) where {FT <: AbstractFloat, I <: Int}
+    igpt::Int,
+) where {FT <: AbstractFloat}
     if tropo == 1
         τ_ray = interp2d(fη1, fη2, ftemp, lkp.rayl_lower, igpt, jη1, jη2, jtemp) * (vmr_h2o + FT(1)) * col_dry
     else
@@ -343,7 +338,7 @@ Compute Rayleigh scattering optical depths for shortwave problem
     return τ_ray
 end
 
-@inline function compute_τ_rayleigh(lkp::LookUpLW{I, FT}, args...) where {FT <: AbstractFloat, I <: Int}
+@inline function compute_τ_rayleigh(lkp::LookUpLW{FT}, args...) where {FT <: AbstractFloat}
     return FT(0)
 end
 

--- a/src/optics/GrayAtmosphericStates.jl
+++ b/src/optics/GrayAtmosphericStates.jl
@@ -53,8 +53,8 @@ GrayOpticalThicknessOGorman2008(::Type{FT}) where {FT <: AbstractFloat} =
 
 
 """
-    GrayAtmosphericState{FT,FTA1D,FTA2D,I} <: 
-        AbstractAtmosphericState{FT,I,FTA1D}
+    GrayAtmosphericState{FT,FTA1D,FTA2D} <: 
+        AbstractAtmosphericState{FT,FTA1D}
 
 Atmospheric conditions, used to compute optical properties with the gray atmosphere approximation
 
@@ -65,9 +65,8 @@ struct GrayAtmosphericState{
     FT <: AbstractFloat,
     FTA1D <: AbstractArray{FT, 1},
     FTA2D <: AbstractArray{FT, 2},
-    I <: Int,
     OTP <: AbstractGrayOpticalThickness,
-} <: AbstractAtmosphericState{FT, I, FTA1D}
+} <: AbstractAtmosphericState{FT, FTA1D}
     "latitude, in degrees, for each column; `(ncol,)`"
     lat::FTA1D
     "Layer pressures `[Pa, mb]`; `(nlay, ncol)`"
@@ -85,9 +84,9 @@ struct GrayAtmosphericState{
     "optical thickness parameters"
     otp::OTP
     "Number of layers."
-    nlay::I
+    nlay::Int
     "Number of columns."
-    ncol::I
+    ncol::Int
 end
 Adapt.@adapt_structure GrayAtmosphericState
 #---------------------------------------------------------------
@@ -137,7 +136,7 @@ function setup_gray_as_pr_grid(
         end
     end
     #------------------------------------------------
-    return GrayAtmosphericState{eltype(t_sfc), typeof(t_sfc), typeof(p_lev), Int, typeof(otp)}(
+    return GrayAtmosphericState{eltype(t_sfc), typeof(t_sfc), typeof(p_lev), typeof(otp)}(
         lat,
         p_lay,
         p_lev,
@@ -227,7 +226,7 @@ function setup_gray_as_alt_grid(
         #--------------------------------------------------------
         t_sfc[icol] = t_lev[1, icol]
     end
-    return GrayAtmosphericState{FT, DA{FT, 1}, DA{FT, 2}, Int}(
+    return GrayAtmosphericState{FT, DA{FT, 1}, DA{FT, 2}}(
         p_lay,
         p_lev,
         t_lay,

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -6,15 +6,15 @@ using Adapt
 export AbstractLookUp, LookUpLW, LookUpSW, LookUpCld
 
 """
-    AbstractLookUp{I,FT}
+    AbstractLookUp{FT}
 
 Abstract lookup table for longwave and shortwave problems.
 """
-abstract type AbstractLookUp{I, FT} end
+abstract type AbstractLookUp{FT} end
 
 """
-    LookUpLW{I,FT,UI8,UI8A1D,IA1D,IA2D,IA3D,FTA1D,FTA2D,FTA3D,FTA4D} <: 
-        AbstractLookUp{I,FT}
+    LookUpLW{FT,UI8A1D,IA1D,IA2D,IA3D,FTA1D,FTA2D,FTA3D,FTA4D} <: 
+        AbstractLookUp{FT}
 
 Longwave lookup tables, used to compute optical properties. 
 
@@ -22,49 +22,47 @@ Longwave lookup tables, used to compute optical properties.
 $(DocStringExtensions.FIELDS)
 """
 struct LookUpLW{
-    I <: Int,
     FT <: AbstractFloat,
-    UI8 <: UInt8,
-    UI8A1D <: AbstractArray{UI8, 1},
-    IA1D <: AbstractArray{I, 1},
-    IA2D <: AbstractArray{I, 2},
-    IA3D <: AbstractArray{I, 3},
+    UI8A1D <: AbstractArray{UInt8, 1},
+    IA1D <: AbstractArray{Int, 1},
+    IA2D <: AbstractArray{Int, 2},
+    IA3D <: AbstractArray{Int, 3},
     FTA1D <: AbstractArray{FT, 1},
     FTA2D <: AbstractArray{FT, 2},
     FTA3D <: AbstractArray{FT, 3},
     FTA4D <: AbstractArray{FT, 4},
-} <: AbstractLookUp{I, FT}
+} <: AbstractLookUp{FT}
     "number of gases used in the lookup table"
-    n_gases::I
+    n_gases::Int
     "number of longwave bands"
-    n_bnd::I
+    n_bnd::Int
     "number of `g-points`"
-    n_gpt::I
+    n_gpt::Int
     "number of atmospheric layers (=2, lower and upper atmospheres)"
-    n_atmos_layers::I
+    n_atmos_layers::Int
     "number of reference temperatures for absorption coefficient lookup table"
-    n_t_ref::I
+    n_t_ref::Int
     "number of reference pressures for absorption lookup table"
-    n_p_ref::I
+    n_p_ref::Int
     "number of reference binary mixing fractions, for absorption coefficient lookup table"
-    n_η::I
+    n_η::Int
     "number of reference temperatures, for Planck source calculations"
-    n_t_plnk::I
+    n_t_plnk::Int
     "number of major absorbing gases"
-    n_maj_absrb::I
+    n_maj_absrb::Int
     "number of minor absorbing gases"
-    n_min_absrb::I
+    n_min_absrb::Int
     "number of minor absorbers in lower atmosphere"
-    n_min_absrb_lower::I
+    n_min_absrb_lower::Int
     "number of minor absorbers in upper atmosphere"
-    n_min_absrb_upper::I
-    n_absrb_ext::I # not used
+    n_min_absrb_upper::Int
+    n_absrb_ext::Int # not used
     "number of minor contributors in the lower atmosphere"
-    n_contrib_lower::I
+    n_contrib_lower::Int
     "number of minor contributors in the upper atmosphere"
-    n_contrib_upper::I
+    n_contrib_upper::Int
     "vmr array index for h2o"
-    idx_h2o::I
+    idx_h2o::Int
     "Reference pressure separating upper and lower atmosphere"
     p_ref_tropo::FT
     "Reference temperature"
@@ -140,34 +138,34 @@ struct LookUpLW{
 end
 Adapt.@adapt_structure LookUpLW
 
-function LookUpLW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: AbstractFloat, DA}
+function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     UI8 = UInt8
     UI8A1D = DA{UInt8, 1}
     STA = Array{String, 1}
-    IA1D = DA{I, 1}
-    IA2D = DA{I, 2}
-    IA3D = DA{I, 3}
+    IA1D = DA{Int, 1}
+    IA2D = DA{Int, 2}
+    IA3D = DA{Int, 3}
     FTA1D = DA{FT, 1}
     FTA2D = DA{FT, 2}
     FTA3D = DA{FT, 3}
     FTA4D = DA{FT, 4}
-    DSTAI = Dict{String, I}
+    DSTAI = Dict{String, Int}
 
-    n_bnd = I(ds.dim["bnd"])
-    n_gpt = I(ds.dim["gpt"])
-    n_atmos_layers = I(ds.dim["atmos_layer"])
-    n_t_ref = I(ds.dim["temperature"])
-    n_p_ref = I(ds.dim["pressure"])
-    n_t_plnk = I(ds.dim["temperature_Planck"])
-    n_maj_absrb = I(ds.dim["absorber"])
-    n_min_absrb = I(ds.dim["minor_absorber"])
-    n_min_absrb_lower = I(ds.dim["minor_absorber_intervals_lower"])
-    n_min_absrb_upper = I(ds.dim["minor_absorber_intervals_upper"])
+    n_bnd = Int(ds.dim["bnd"])
+    n_gpt = Int(ds.dim["gpt"])
+    n_atmos_layers = Int(ds.dim["atmos_layer"])
+    n_t_ref = Int(ds.dim["temperature"])
+    n_p_ref = Int(ds.dim["pressure"])
+    n_t_plnk = Int(ds.dim["temperature_Planck"])
+    n_maj_absrb = Int(ds.dim["absorber"])
+    n_min_absrb = Int(ds.dim["minor_absorber"])
+    n_min_absrb_lower = Int(ds.dim["minor_absorber_intervals_lower"])
+    n_min_absrb_upper = Int(ds.dim["minor_absorber_intervals_upper"])
 
-    n_absrb_ext = I(ds.dim["absorber_ext"])
-    n_contrib_lower = I(ds.dim["contributors_lower"])
-    n_contrib_upper = I(ds.dim["contributors_upper"])
+    n_absrb_ext = Int(ds.dim["absorber_ext"])
+    n_contrib_lower = Int(ds.dim["contributors_lower"])
+    n_contrib_upper = Int(ds.dim["contributors_upper"])
 
     p_ref_tropo = FT(ds["press_ref_trop"][:][1])
     t_ref_absrb = FT(ds["absorption_coefficient_ref_T"][:][1])
@@ -182,15 +180,15 @@ function LookUpLW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     scaling_gas_upper = STA(undef, n_min_absrb_upper)
     idx_gases = DSTAI()
 
-    idx_gases_minor_lower = zeros(I, n_min_absrb_lower)
-    idx_gases_minor_upper = zeros(I, n_min_absrb_upper)
+    idx_gases_minor_lower = zeros(Int, n_min_absrb_lower)
+    idx_gases_minor_upper = zeros(Int, n_min_absrb_upper)
 
-    idx_scaling_gas_lower = zeros(I, n_min_absrb_lower)
-    idx_scaling_gas_upper = zeros(I, n_min_absrb_upper)
+    idx_scaling_gas_lower = zeros(Int, n_min_absrb_lower)
+    idx_scaling_gas_upper = zeros(Int, n_min_absrb_upper)
 
     for igas in 1:n_maj_absrb
         gases_major[igas] = strip(String(ds["gas_names"][:, igas]))
-        idx_gases[gases_major[igas]] = I(igas)
+        idx_gases[gases_major[igas]] = Int(igas)
     end
 
     idx_h2o = idx_gases["h2o"]
@@ -252,7 +250,7 @@ function LookUpLW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     t_planck = FTA1D(ds["temperature_Planck"][:])
 
     totplnk = FTA2D(ds["totplnk"][:])
-    bnd_lims_gpt = Array{I, 2}(ds["bnd_limits_gpt"][:])
+    bnd_lims_gpt = Array{Int, 2}(ds["bnd_limits_gpt"][:])
     bnd_lims_wn = FTA2D(ds["bnd_limits_wavenumber"][:])
     #-----------------------
     major_gpt2bnd = Array{UI8, 1}(undef, n_gpt)
@@ -261,8 +259,8 @@ function LookUpLW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     end
     #-----------------------
     bnd_lims_gpt = IA2D(bnd_lims_gpt)
-    minor_lower_gpt_lims = Array{I, 2}(ds["minor_limits_gpt_lower"][:])
-    minor_upper_gpt_lims = Array{I, 2}(ds["minor_limits_gpt_upper"][:])
+    minor_lower_gpt_lims = Array{Int, 2}(ds["minor_limits_gpt_lower"][:])
+    minor_upper_gpt_lims = Array{Int, 2}(ds["minor_limits_gpt_upper"][:])
     #-----------------------
     minor_lower_bnd = zeros(UI8, n_min_absrb_lower)
     minor_upper_bnd = zeros(UI8, n_min_absrb_upper)
@@ -342,7 +340,7 @@ function LookUpLW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     n_η = size(kmajor, 2)
 
     return (
-        LookUpLW{I, FT, UI8, UI8A1D, IA1D, IA2D, IA3D, FTA1D, FTA2D, FTA3D, FTA4D}(
+        LookUpLW{FT, UI8A1D, IA1D, IA2D, IA3D, FTA1D, FTA2D, FTA3D, FTA4D}(
             n_gases,
             n_bnd,
             n_gpt,
@@ -402,8 +400,8 @@ function LookUpLW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
 end
 
 """
-    LookUpSW{I,FT,UI8,UI8A1D,IA1D,IA2D,IA3D,FTA1D,FTA2D,FTA3D,FTA4D} <:
-        AbstractLookUp{I,FT}
+    LookUpSW{FT,UI8A1D,IA1D,IA2D,IA3D,FTA1D,FTA2D,FTA3D,FTA4D} <:
+        AbstractLookUp{FT}
 
 Shortwave lookup tables, used to compute optical properties. 
 
@@ -411,47 +409,45 @@ Shortwave lookup tables, used to compute optical properties.
 $(DocStringExtensions.FIELDS)
 """
 struct LookUpSW{
-    I <: Int,
     FT <: AbstractFloat,
-    UI8 <: UInt8,
-    UI8A1D <: AbstractArray{UI8, 1},
-    IA1D <: AbstractArray{I, 1},
-    IA2D <: AbstractArray{I, 2},
-    IA3D <: AbstractArray{I, 3},
+    UI8A1D <: AbstractArray{UInt8, 1},
+    IA1D <: AbstractArray{Int, 1},
+    IA2D <: AbstractArray{Int, 2},
+    IA3D <: AbstractArray{Int, 3},
     FTA1D <: AbstractArray{FT, 1},
     FTA2D <: AbstractArray{FT, 2},
     FTA3D <: AbstractArray{FT, 3},
     FTA4D <: AbstractArray{FT, 4},
-} <: AbstractLookUp{I, FT}
+} <: AbstractLookUp{FT}
     "number of gases used in the lookup table"
-    n_gases::I
+    n_gases::Int
     "number of shortwave bands"
-    n_bnd::I
+    n_bnd::Int
     "number of `g-points`"
-    n_gpt::I
+    n_gpt::Int
     "number of atmospheric layers (=2, lower and upper atmospheres)"
-    n_atmos_layers::I
+    n_atmos_layers::Int
     "number of reference temperatures for absorption coefficient lookup table"
-    n_t_ref::I
+    n_t_ref::Int
     "number of reference pressures for absorption lookup table"
-    n_p_ref::I
+    n_p_ref::Int
     "number of reference binary mixing fractions, for absorption coefficient lookup table"
-    n_η::I
+    n_η::Int
     "number of major absorbing gases"
-    n_maj_absrb::I
+    n_maj_absrb::Int
     "number of minor absorbing gases"
-    n_min_absrb::I
+    n_min_absrb::Int
     "number of minor absorbers in lower atmosphere"
-    n_min_absrb_lower::I
+    n_min_absrb_lower::Int
     "number of minor absorbers in upper atmosphere"
-    n_min_absrb_upper::I
-    n_absrb_ext::I # not used
+    n_min_absrb_upper::Int
+    n_absrb_ext::Int # not used
     "number of minor contributors in the lower atmosphere"
-    n_contrib_lower::I
+    n_contrib_lower::Int
     "number of minor contributors in the upper atmosphere"
-    n_contrib_upper::I
+    n_contrib_upper::Int
     "vmr array index for h2o"
-    idx_h2o::I
+    idx_h2o::Int
     "Reference pressure separating upper and lower atmosphere"
     p_ref_tropo::FT
     "Reference temperature"
@@ -530,35 +526,35 @@ end
 Adapt.@adapt_structure LookUpSW
 
 
-function LookUpSW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: AbstractFloat, DA}
+function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     UI8 = UInt8
     UI8A1D = DA{UInt8, 1}
     STA = Array{String, 1}
-    IA1D = DA{I, 1}
-    IA2D = DA{I, 2}
-    IA3D = DA{I, 3}
+    IA1D = DA{Int, 1}
+    IA2D = DA{Int, 2}
+    IA3D = DA{Int, 3}
     FTA1D = DA{FT, 1}
     FTA2D = DA{FT, 2}
     FTA3D = DA{FT, 3}
     FTA4D = DA{FT, 4}
-    DSTAI = Dict{String, I}
+    DSTAI = Dict{String, Int}
 
-    n_bnd = I(ds.dim["bnd"])
-    n_gpt = I(ds.dim["gpt"])
-    n_atmos_layers = I(ds.dim["atmos_layer"])
-    n_t_ref = I(ds.dim["temperature"])
-    n_p_ref = I(ds.dim["pressure"])
+    n_bnd = Int(ds.dim["bnd"])
+    n_gpt = Int(ds.dim["gpt"])
+    n_atmos_layers = Int(ds.dim["atmos_layer"])
+    n_t_ref = Int(ds.dim["temperature"])
+    n_p_ref = Int(ds.dim["pressure"])
 
-    n_maj_absrb = I(ds.dim["absorber"])
-    n_min_absrb = I(ds.dim["minor_absorber"])
+    n_maj_absrb = Int(ds.dim["absorber"])
+    n_min_absrb = Int(ds.dim["minor_absorber"])
 
-    n_min_absrb_lower = I(ds.dim["minor_absorber_intervals_lower"])
-    n_min_absrb_upper = I(ds.dim["minor_absorber_intervals_upper"])
-    n_absrb_ext = I(ds.dim["absorber_ext"])
+    n_min_absrb_lower = Int(ds.dim["minor_absorber_intervals_lower"])
+    n_min_absrb_upper = Int(ds.dim["minor_absorber_intervals_upper"])
+    n_absrb_ext = Int(ds.dim["absorber_ext"])
 
-    n_contrib_lower = I(ds.dim["contributors_lower"])
-    n_contrib_upper = I(ds.dim["contributors_upper"])
+    n_contrib_lower = Int(ds.dim["contributors_lower"])
+    n_contrib_upper = Int(ds.dim["contributors_upper"])
 
     p_ref_tropo = FT(ds["press_ref_trop"][:][1])
     t_ref_absrb = FT(ds["absorption_coefficient_ref_T"][:][1])
@@ -573,15 +569,15 @@ function LookUpSW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     scaling_gas_upper = STA(undef, n_min_absrb_upper)
     idx_gases = DSTAI()
 
-    idx_gases_minor_lower = zeros(I, n_min_absrb_lower)
-    idx_gases_minor_upper = zeros(I, n_min_absrb_upper)
+    idx_gases_minor_lower = zeros(Int, n_min_absrb_lower)
+    idx_gases_minor_upper = zeros(Int, n_min_absrb_upper)
 
-    idx_scaling_gas_lower = zeros(I, n_min_absrb_lower)
-    idx_scaling_gas_upper = zeros(I, n_min_absrb_upper)
+    idx_scaling_gas_lower = zeros(Int, n_min_absrb_lower)
+    idx_scaling_gas_upper = zeros(Int, n_min_absrb_upper)
 
     for igas in 1:n_maj_absrb
         gases_major[igas] = strip(String(ds["gas_names"][:, igas]))
-        idx_gases[gases_major[igas]] = I(igas)
+        idx_gases[gases_major[igas]] = Int(igas)
     end
 
     idx_h2o = idx_gases["h2o"]
@@ -634,7 +630,7 @@ function LookUpSW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     kminor_start_lower = IA1D(ds["kminor_start_lower"][:])
     kminor_start_upper = IA1D(ds["kminor_start_upper"][:])
 
-    bnd_lims_gpt = Array{I, 2}(ds["bnd_limits_gpt"][:])
+    bnd_lims_gpt = Array{Int, 2}(ds["bnd_limits_gpt"][:])
     bnd_lims_wn = FTA2D(ds["bnd_limits_wavenumber"][:])
     #-----------------------
     major_gpt2bnd = Array{UI8, 1}(undef, n_gpt)
@@ -643,8 +639,8 @@ function LookUpSW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     end
     #-----------------------
     bnd_lims_gpt = IA2D(bnd_lims_gpt)
-    minor_lower_gpt_lims = Array{I, 2}(ds["minor_limits_gpt_lower"][:])
-    minor_upper_gpt_lims = Array{I, 2}(ds["minor_limits_gpt_upper"][:])
+    minor_lower_gpt_lims = Array{Int, 2}(ds["minor_limits_gpt_lower"][:])
+    minor_upper_gpt_lims = Array{Int, 2}(ds["minor_limits_gpt_upper"][:])
     #-----------------------
     minor_lower_bnd = zeros(UI8, n_min_absrb_lower)
     minor_upper_bnd = zeros(UI8, n_min_absrb_upper)
@@ -729,7 +725,7 @@ function LookUpSW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
     solar_src_scaled = FTA1D(solar_src ./ solar_src_tot)
 
     return (
-        LookUpSW{I, FT, UI8, UI8A1D, IA1D, IA2D, IA3D, FTA1D, FTA2D, FTA3D, FTA4D}(
+        LookUpSW{FT, UI8A1D, IA1D, IA2D, IA3D, FTA1D, FTA2D, FTA3D, FTA4D}(
             n_gases,
             n_bnd,
             n_gpt,
@@ -789,7 +785,7 @@ function LookUpSW(ds, ::Type{I}, ::Type{FT}, ::Type{DA}) where {I <: Int, FT <: 
 end
 
 """
-    LookUpCld{I,FT,FTA1D,FTA2D,FTA3D,FTA4D}
+    LookUpCld{FT,FTA1D,FTA2D,FTA3D,FTA4D}
 
 Lookup table for cloud optics.
 
@@ -802,25 +798,25 @@ These are used to determine the optical properties of ice and water cloud togeth
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct LookUpCld{I, B, FT, FTA1D, FTA2D, FTA3D, FTA4D}
+struct LookUpCld{B, FT, FTA1D, FTA2D, FTA3D, FTA4D}
     "number of bands"
-    nband::I
+    nband::Int
     "number of ice roughness types"
-    nrghice::I
+    nrghice::Int
     "number of liquid particle sizes"
-    nsize_liq::I
+    nsize_liq::Int
     "number of ice particle sizes"
-    nsize_ice::I
+    nsize_ice::Int
     "number of size regimes"
-    nsizereg::I
+    nsizereg::Int
     "number of extinction coefficients for pade approximation"
-    ncoeff_ext::I
+    ncoeff_ext::Int
     "number of ssa/g coefficients for pade approximation"
-    ncoeff_ssa_g::I
+    ncoeff_ssa_g::Int
     "number of size regime boundaries for pade interpolation"
-    nbound::I
+    nbound::Int
     "pair = 2"
-    pair::I
+    pair::Int
     "liquid particle size lower bound for LUT interpolation"
     radliq_lwr::FT
     "liquid particle size upper bound for LUT interpolation"
@@ -876,28 +872,22 @@ struct LookUpCld{I, B, FT, FTA1D, FTA2D, FTA3D, FTA4D}
 end
 Adapt.@adapt_structure LookUpCld
 
-function LookUpCld(
-    ds,
-    ::Type{I},
-    ::Type{FT},
-    ::Type{DA},
-    use_lut::Bool = true,
-) where {I <: Int, FT <: AbstractFloat, DA}
+function LookUpCld(ds, ::Type{FT}, ::Type{DA}, use_lut::Bool = true) where {FT <: AbstractFloat, DA}
 
     FTA1D = DA{FT, 1}
     FTA2D = DA{FT, 2}
     FTA3D = DA{FT, 3}
     FTA4D = DA{FT, 4}
 
-    nband = I(ds.dim["nband"])
-    nrghice = I(ds.dim["nrghice"])
-    nsize_liq = I(ds.dim["nsize_liq"])
-    nsize_ice = I(ds.dim["nsize_ice"])
-    nsizereg = I(ds.dim["nsizereg"])
-    ncoeff_ext = I(ds.dim["ncoeff_ext"])
-    ncoeff_ssa_g = I(ds.dim["ncoeff_ssa_g"])
-    nbound = I(ds.dim["nbound"])
-    pair = I(ds.dim["pair"])
+    nband = Int(ds.dim["nband"])
+    nrghice = Int(ds.dim["nrghice"])
+    nsize_liq = Int(ds.dim["nsize_liq"])
+    nsize_ice = Int(ds.dim["nsize_ice"])
+    nsizereg = Int(ds.dim["nsizereg"])
+    ncoeff_ext = Int(ds.dim["ncoeff_ext"])
+    ncoeff_ssa_g = Int(ds.dim["ncoeff_ssa_g"])
+    nbound = Int(ds.dim["nbound"])
+    pair = Int(ds.dim["pair"])
 
     @assert nsizereg == 3 # RRTMGP pade approximation assumes exactly (3) size regimes
 
@@ -935,7 +925,7 @@ function LookUpCld(
 
     bnd_lims_wn = FTA2D(ds["bnd_limits_wavenumber"][:])
 
-    return (LookUpCld{I, Bool, FT, FTA1D, FTA2D, FTA3D, FTA4D}(
+    return (LookUpCld{Bool, FT, FTA1D, FTA2D, FTA3D, FTA4D}(
         nband,
         nrghice,
         nsize_liq,

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -24,7 +24,7 @@ Optical properties for one scalar and two stream calculations.
 abstract type AbstractOpticalProps{FT <: AbstractFloat, FTA2D <: AbstractArray{FT, 2}} end
 
 """
-    OneScalar{FT,FTA1D,FTA2D,I,AD} <: AbstractOpticalProps{FT,FTA2D}
+    OneScalar{FT,FTA1D,FTA2D,AD} <: AbstractOpticalProps{FT,FTA2D}
 
 Single scalar approximation for optical depth, used in
 calculations accounting for extinction and emission
@@ -42,9 +42,8 @@ end
 Adapt.@adapt_structure OneScalar
 
 function OneScalar(::Type{FT}, ncol::Int, nlay::Int, ::Type{DA}) where {FT <: AbstractFloat, DA}
-    I = Int
     τ = DA{FT, 2}(undef, nlay, ncol)
-    ad = AngularDiscretization(FT, DA, I(1))
+    ad = AngularDiscretization(FT, DA, 1)
 
     return OneScalar{eltype(τ), typeof(τ), typeof(ad)}(τ, ad)
 end
@@ -141,11 +140,11 @@ end
         op::AbstractOpticalProps{FT},
         as::AtmosphericState{FT},
         sf::AbstractSourceLW{FT},
-        gcol::I,
-        igpt::I,
-        lkp::LookUpLW{I,FT},
+        gcol::Int,
+        igpt::Int,
+        lkp::LookUpLW{FT},
         lkp_cld::Union{LookUpCld,Nothing} = nothing,
-    ) where {I<:Int,FT<:AbstractFloat}
+    ) where {FT<:AbstractFloat}
 
 Computes optical properties for the longwave problem.
 """
@@ -153,11 +152,11 @@ function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     sf::AbstractSourceLW{FT},
-    gcol::I,
-    igpt::I,
-    lkp::LookUpLW{I, FT},
+    gcol::Int,
+    igpt::Int,
+    lkp::LookUpLW{FT},
     lkp_cld::Union{LookUpCld, Nothing} = nothing,
-) where {I <: Int, FT <: AbstractFloat}
+) where {FT <: AbstractFloat}
     nlay = as.nlay
     lkp_args = (lkp_cld === nothing) ? (lkp,) : (lkp, lkp_cld)
     for ilay in 1:nlay
@@ -171,22 +170,22 @@ end
     compute_optical_props!(
         op::AbstractOpticalProps{FT},
         as::AtmosphericState{FT},
-        gcol::I,
-        igpt::I,
-        lkp::LookUpSW{I,FT},
+        gcol::Int,
+        igpt::Int,
+        lkp::LookUpSW{FT},
         lkp_cld::Union{LookUpCld,Nothing} = nothing,
-    ) where {I<:Int,FT<:AbstractFloat}
+    ) where {FT<:AbstractFloat}
 
 Computes optical properties for the shortwave problem.
 """
 function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
-    gcol::I,
-    igpt::I,
-    lkp::LookUpSW{I, FT},
+    gcol::Int,
+    igpt::Int,
+    lkp::LookUpSW{FT},
     lkp_cld::Union{LookUpCld, Nothing} = nothing,
-) where {I <: Int, FT <: AbstractFloat}
+) where {FT <: AbstractFloat}
     nlay = as.nlay
     lkp_args = (lkp_cld === nothing) ? (lkp,) : (lkp, lkp_cld)
     for ilay in 1:nlay
@@ -201,8 +200,8 @@ end
         op::AbstractOpticalProps{FT},
         as::GrayAtmosphericState{FT},
         sf::AbstractSourceLW{FT},
-        gcol::I,
-        igpt::I = 1,
+        gcol::Int,
+        igpt::Int = 1,
     ) where {FT<:AbstractFloat}
 
 Computes optical properties for the longwave gray radiation problem.
@@ -211,9 +210,9 @@ function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::GrayAtmosphericState{FT},
     sf::AbstractSourceLW{FT},
-    gcol::I,
-    igpt::I = 1,
-) where {FT <: AbstractFloat, I <: Int}
+    gcol::Int,
+    igpt::Int = 1,
+) where {FT <: AbstractFloat}
     nlay = as.nlay
     for ilay in 1:nlay
         glaycol = (ilay, gcol)
@@ -226,8 +225,8 @@ end
     compute_optical_props!(
         op::AbstractOpticalProps{FT},
         as::GrayAtmosphericState{FT},
-        gcol::I,
-        igpt::I = 1,
+        gcol::Int,
+        igpt::Int = 1,
     ) where {FT<:AbstractFloat}
 
 Computes optical properties for the shortwave gray radiation problem.
@@ -235,9 +234,9 @@ Computes optical properties for the shortwave gray radiation problem.
 function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::GrayAtmosphericState{FT},
-    gcol::I,
-    igpt::I = 1,
-) where {FT <: AbstractFloat, I <: Int}
+    gcol::Int,
+    igpt::Int = 1,
+) where {FT <: AbstractFloat}
     nlay = as.nlay
     for ilay in 1:nlay
         glaycol = (ilay, gcol)

--- a/src/optics/OpticsKernels.jl
+++ b/src/optics/OpticsKernels.jl
@@ -10,9 +10,9 @@ function compute_optical_props_kernel!(
     glaycol,
     sf::AbstractSourceLW{FT},
     igpt,
-    lkp::LookUpLW{I, FT},
+    lkp::LookUpLW{FT},
     lkp_cld::LookUpCld,
-) where {I <: Int, FT <: AbstractFloat}
+) where {FT <: AbstractFloat}
     ibnd = lkp.major_gpt2bnd[igpt]
 
     compute_optical_props_kernel!(op, as, glaycol, sf, igpt, lkp) # longwave gas optics
@@ -26,8 +26,8 @@ function compute_optical_props_kernel!(
     glaycol,
     sf::AbstractSourceLW{FT},
     igpt,
-    lkp::LookUpLW{I, FT},
-) where {I <: Int, FT <: AbstractFloat}
+    lkp::LookUpLW{FT},
+) where {FT <: AbstractFloat}
     t_sfc = as.t_sfc[glaycol[2]]
     t_lev = as.t_lev
     compute_optical_props_kernel!(op, as, glaycol, igpt, lkp, sf, t_lev, t_sfc)
@@ -39,9 +39,9 @@ function compute_optical_props_kernel!(
     as::AtmosphericState{FT},
     glaycol,
     igpt,
-    lkp::LookUpSW{I, FT},
+    lkp::LookUpSW{FT},
     lkp_cld::LookUpCld,
-) where {I <: Int, FT <: AbstractFloat}
+) where {FT <: AbstractFloat}
     ibnd = lkp.major_gpt2bnd[igpt]
 
     compute_optical_props_kernel!(op, as, glaycol, igpt, lkp) # shortwave gas optics
@@ -52,11 +52,11 @@ end
 function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
-    glaycol::Tuple{I, I},
-    igpt::I,
-    lkp::LookUpLW{I, FT},
+    glaycol::Tuple{Int, Int},
+    igpt::Int,
+    lkp::LookUpLW{FT},
     src_args...,
-) where {I <: Int, FT <: AbstractFloat}
+) where {FT <: AbstractFloat}
 
     vmr = as.vmr
     col_dry = as.col_dry[glaycol...]
@@ -77,10 +77,10 @@ end
 function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
-    glaycol::Tuple{I, I},
-    igpt::I,
-    lkp::LookUpSW{I, FT},
-) where {I <: Int, FT <: AbstractFloat}
+    glaycol::Tuple{Int, Int},
+    igpt::Int,
+    lkp::LookUpSW{FT},
+) where {FT <: AbstractFloat}
 
     vmr = as.vmr
     col_dry = as.col_dry[glaycol...]

--- a/src/optics/OpticsUtils.jl
+++ b/src/optics/OpticsUtils.jl
@@ -20,11 +20,11 @@ end
         fη2::FT,
         ftemp::FT,
         coeff::FTA3D,
-        igpt::I,
-        jη1::I,
-        jη2::I,
-        jtemp::I,
-    ) where {FT<:AbstractFloat,FTA3D<:AbstractArray{FT,3},I<:Int}
+        igpt::Int,
+        jη1::Int,
+        jη2::Int,
+        jtemp::Int,
+    ) where {FT<:AbstractFloat,FTA3D<:AbstractArray{FT,3}}
 
 Perform 2D linear interpolation.
 
@@ -41,11 +41,11 @@ Perform 2D linear interpolation.
     fη2::FT,
     ftemp::FT,
     coeff::FTA3D,
-    igpt::I,
-    jη1::I,
-    jη2::I,
-    jtemp::I,
-) where {FT <: AbstractFloat, FTA3D <: AbstractArray{FT, 3}, I <: Int}
+    igpt::Int,
+    jη1::Int,
+    jη2::Int,
+    jtemp::Int,
+) where {FT <: AbstractFloat, FTA3D <: AbstractArray{FT, 3}}
     return @inbounds (FT(1) - fη1) * (1 - ftemp) * coeff[igpt, jη1, jtemp] +
                      fη1 * (1 - ftemp) * coeff[igpt, jη1 + 1, jtemp] +
                      (FT(1) - fη2) * ftemp * coeff[igpt, jη2, jtemp + 1] +
@@ -54,19 +54,19 @@ end
 
 """
     interp3d(
-        jη1::I,
-        jη2::I,
+        jη1::Int,
+        jη2::Int,
         fη1::FT,
         fη2::FT,
-        jtemp::I,
+        jtemp::Int,
         ftemp::FT,
-        jpresst::I,
+        jpresst::Int,
         fpress::FT,
         coeff::FTA4D,
-        igpt::I,
+        igpt::Int,
         s1::FT = FT(1),
         s2::FT = FT(1),
-    ) where {FT<:AbstractFloat,FTA4D<:AbstractArray{FT,4},I<:Int}
+    ) where {FT<:AbstractFloat,FTA4D<:AbstractArray{FT,4}}
 
 Perform 3D linear interpolation.
 
@@ -90,19 +90,19 @@ where,
 
 """
 @inline function interp3d(
-    jη1::I,
-    jη2::I,
+    jη1::Int,
+    jη2::Int,
     fη1::FT,
     fη2::FT,
-    jtemp::I,
+    jtemp::Int,
     ftemp::FT,
-    jpresst::I,
+    jpresst::Int,
     fpress::FT,
     coeff::FTA4D,
-    igpt::I,
+    igpt::Int,
     s1::FT = FT(1),
     s2::FT = FT(1),
-) where {FT <: AbstractFloat, FTA4D <: AbstractArray{FT, 4}, I <: Int}
+) where {FT <: AbstractFloat, FTA4D <: AbstractArray{FT, 4}}
     omftemp = FT(1) - ftemp
     omfpress = FT(1) - fpress
     omfη1 = FT(1) - fη1

--- a/src/optics/RTE.jl
+++ b/src/optics/RTE.jl
@@ -62,7 +62,7 @@ struct Solver{AS, OP, SL, SS, BCL, BCS, FXBL, FXBS, FXL, FXS}
         FT = eltype(as.p_lev)
         FTA1D = typeof(as.t_sfc)
         FTA2D = typeof(as.p_lev)
-        @assert targs[1] <: AbstractAtmosphericState{FT, Int, FTA1D}
+        @assert targs[1] <: AbstractAtmosphericState{FT, FTA1D}
         @assert targs[2] <: AbstractOpticalProps{FT, FTA2D}
         @assert targs[3] <: Union{AbstractSourceLW{FT, FTA1D, FTA2D}, Nothing}
         @assert targs[4] <: Union{SourceSW2Str{FT, FTA1D, FTA2D}, Nothing}

--- a/src/optics/Sources.jl
+++ b/src/optics/Sources.jl
@@ -235,7 +235,7 @@ struct SourceSW2Str{FT <: AbstractFloat, FTA1D <: AbstractArray{FT, 1}, FTA2D <:
 end
 Adapt.@adapt_structure SourceSW2Str
 
-function SourceSW2Str(::Type{FT}, ::Type{DA}, nlay::I, ncol::I) where {FT <: AbstractFloat, I <: Int, DA}
+function SourceSW2Str(::Type{FT}, ::Type{DA}, nlay::Int, ncol::Int) where {FT <: AbstractFloat, DA}
     FTA1D = DA{FT, 1}
     FTA2D = DA{FT, 2}
 
@@ -267,21 +267,21 @@ end
 """
     source_func_shortwave(
         ::Type{FT},
-        ncol::I,
-        nlay::I,
+        ncol::Int,
+        nlay::Int,
         opc::Symbol,
         ::Type{DA},
-    ) where {FT<:AbstractFloat,I<:Int,DA}
+    ) where {FT<:AbstractFloat,DA}
 
 Initializes the shortwave source for one scalar and two stream simulations.
 """
 function source_func_shortwave(
     ::Type{FT},
-    ncol::I,
-    nlay::I,
+    ncol::Int,
+    nlay::Int,
     opc::Symbol,
     ::Type{DA},
-) where {FT <: AbstractFloat, I <: Int, DA}
+) where {FT <: AbstractFloat, DA}
     if opc == :OneScalar
         return nothing
     else

--- a/src/rte/RTESolverKernels.jl
+++ b/src/rte/RTESolverKernels.jl
@@ -299,11 +299,11 @@ function rte_sw_noscat_solve_kernel!(
     flux::FluxSW{FT},
     op::OneScalar{FT},
     bcs_sw::SwBCs{FT},
-    igpt::I,
+    igpt::Int,
     solar_src_scaled::AbstractArray{FT, 1},
-    gcol::I,
-    nlev::I,
-) where {FT <: AbstractFloat, I <: Int}
+    gcol::Int,
+    nlev::Int,
+) where {FT <: AbstractFloat}
     solar_frac = solar_src_scaled[igpt]
     (; toa_flux, zenith) = bcs_sw
     n_gpt = length(solar_src_scaled)
@@ -338,9 +338,9 @@ function sw_two_stream!(
     op::TwoStream{FT},
     src_sw::SourceSW2Str{FT},
     bcs_sw::SwBCs{FT},
-    gcol::I,
-    nlay::I,
-) where {FT <: AbstractFloat, I <: Int}
+    gcol::Int,
+    nlay::Int,
+) where {FT <: AbstractFloat}
     zenith = bcs_sw.zenith
     (; τ, ssa, g) = op
     (; Rdif, Tdif, Rdir, Tdir, Tnoscat) = src_sw
@@ -417,13 +417,13 @@ Direct-beam and source for diffuse radiation
 function sw_source_2str!(
     src_sw::SourceSW2Str{FT},
     bcs_sw::SwBCs{FT},
-    gcol::I,
+    gcol::Int,
     flux::FluxSW{FT},
-    igpt::I,
+    igpt::Int,
     solar_src_scaled::AbstractArray{FT, 1},
     major_gpt2bnd::AbstractArray{UInt8, 1},
-    nlay::I,
-) where {FT <: AbstractFloat, I <: Int}
+    nlay::Int,
+) where {FT <: AbstractFloat}
     ibnd = major_gpt2bnd[igpt]
     solar_frac = solar_src_scaled[igpt]
     (; toa_flux, zenith, sfc_alb_direct) = bcs_sw
@@ -460,12 +460,12 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
 function adding_sw!(
     src_sw::SourceSW2Str{FT},
     bcs_sw::SwBCs{FT},
-    gcol::I,
+    gcol::Int,
     flux::FluxSW{FT},
-    igpt::I,
+    igpt::Int,
     major_gpt2bnd::AbstractArray{UInt8, 1},
-    nlev::I,
-) where {FT <: AbstractFloat, I <: Int}
+    nlev::Int,
+) where {FT <: AbstractFloat}
     ibnd = major_gpt2bnd[igpt]
     nlay = nlev - 1
     n_gpt = length(major_gpt2bnd)

--- a/test/all_sky.jl
+++ b/test/all_sky.jl
@@ -29,15 +29,14 @@ DA = array_type()
 function all_sky(
     ::Type{OPC},
     ::Type{FT},
-    ::Type{I},
     ::Type{DA};
     use_lut::Bool = true,
     cldfrac = FT(1),
-) where {FT <: AbstractFloat, I <: Int, DA, OPC}
+) where {FT <: AbstractFloat, DA, OPC}
     opc = Symbol(OPC)
     FTA1D = DA{FT, 1}
     FTA2D = DA{FT, 2}
-    max_threads = Int(256)
+    max_threads = 256
     n_gauss_angles = 1
     ncol = 128 # repeats col#1 128 time per RRTMGP example
 
@@ -55,19 +54,19 @@ function all_sky(
 
     #reading longwave gas optics lookup data
     ds_lw = Dataset(lw_file, "r")
-    lookup_lw, idx_gases = LookUpLW(ds_lw, I, FT, DA)
+    lookup_lw, idx_gases = LookUpLW(ds_lw, FT, DA)
     close(ds_lw)
     # reading longwave cloud lookup data
     ds_lw_cld = Dataset(lw_cld_file, "r")
-    lookup_lw_cld = LookUpCld(ds_lw_cld, I, FT, DA, use_lut)
+    lookup_lw_cld = LookUpCld(ds_lw_cld, FT, DA, use_lut)
     close(ds_lw_cld)
     #reading shortwave gas optics lookup data
     ds_sw = Dataset(sw_file, "r")
-    lookup_sw, idx_gases = LookUpSW(ds_sw, I, FT, DA)
+    lookup_sw, idx_gases = LookUpSW(ds_sw, FT, DA)
     close(ds_sw)
     # reading longwave cloud lookup data
     ds_sw_cld = Dataset(sw_cld_file, "r")
-    lookup_sw_cld = LookUpCld(ds_sw_cld, I, FT, DA, use_lut)
+    lookup_sw_cld = LookUpCld(ds_sw_cld, FT, DA, use_lut)
     close(ds_sw_cld)
     # reading input file 
     ds_in = Dataset(input_file, "r")
@@ -165,8 +164,8 @@ function all_sky(
 end
 
 @testset "Cloudy (all-sky, Two-stream calculations using lookup table method" begin
-    @time all_sky(TwoStream, Float64, Int, DA, use_lut = true, cldfrac = Float64(1))
+    @time all_sky(TwoStream, Float64, DA, use_lut = true, cldfrac = Float64(1))
 end
 @testset "Cloudy (all-sky), Two-stream calculations using Pade method" begin
-    @time all_sky(TwoStream, Float64, Int, DA, use_lut = false, cldfrac = Float64(1))
+    @time all_sky(TwoStream, Float64, DA, use_lut = false, cldfrac = Float64(1))
 end

--- a/test/clear_sky.jl
+++ b/test/clear_sky.jl
@@ -30,9 +30,8 @@ function clear_sky(
     ::Type{SRC},
     ::Type{VMR},
     ::Type{FT},
-    ::Type{I},
     ::Type{DA},
-) where {FT <: AbstractFloat, I <: Int, DA, OPC, SRC, VMR}
+) where {FT <: AbstractFloat, DA, OPC, SRC, VMR}
     opc = Symbol(OPC)
     lw_file = get_ref_filename(:lookup_tables, :clearsky, λ = :lw) # lw lookup tables for gas optics
     sw_file = get_ref_filename(:lookup_tables, :clearsky, λ = :sw) # sw lookup tables for gas optics
@@ -45,18 +44,18 @@ function clear_sky(
 
     FTA1D = DA{FT, 1}
     FTA2D = DA{FT, 2}
-    max_threads = Int(256)
+    max_threads = 256
     exp_no = 1
     n_gauss_angles = 1
 
     # reading longwave lookup data
     ds_lw = Dataset(lw_file, "r")
-    lookup_lw, idx_gases = LookUpLW(ds_lw, I, FT, DA)
+    lookup_lw, idx_gases = LookUpLW(ds_lw, FT, DA)
     close(ds_lw)
 
     # reading shortwave lookup data
     ds_sw = Dataset(sw_file, "r")
-    lookup_sw, idx_gases = LookUpSW(ds_sw, I, FT, DA)
+    lookup_sw, idx_gases = LookUpSW(ds_sw, FT, DA)
     close(ds_sw)
 
     # reading rfmip data to atmospheric state
@@ -153,5 +152,5 @@ function clear_sky(
     @test max_err_flux_dn_sw ≤ toler_sw
 end
 @testset "testing clear sky 2-stream solver" begin
-    @time clear_sky(TwoStream, SourceLW2Str, VmrGM, Float64, Int, array_type())
+    @time clear_sky(TwoStream, SourceLW2Str, VmrGM, Float64, array_type())
 end

--- a/test/gray_atm.jl
+++ b/test/gray_atm.jl
@@ -26,13 +26,7 @@ DA = array_type()
 """
 Example program to demonstrate the calculation of longwave radiative fluxes in a model gray atmosphere.
 """
-function gray_atmos_lw_equil(
-    ::Type{OPC},
-    ::Type{FT},
-    ::Type{I},
-    ::Type{DA},
-    ncol::Int,
-) where {FT <: AbstractFloat, I <: Int, DA, OPC}
+function gray_atmos_lw_equil(::Type{OPC}, ::Type{FT}, ::Type{DA}, ncol::Int) where {FT <: AbstractFloat, DA, OPC}
     opc = Symbol(OPC)
     nlay = 60                               # number of layers
     p0 = FT(100000)                         # surface pressure (Pa)
@@ -46,11 +40,11 @@ function gray_atmos_lw_equil(
     nsteps = ndays * (24 / tstep)           # number of timesteps
     temp_toler = FT(0.1)                    # tolerance for temperature (Kelvin)
     flux_grad_toler = FT(1e-5)              # tolerance for flux gradient
-    n_gauss_angles = I(1)                   # for non-scattering calculation
+    n_gauss_angles = 1                   # for non-scattering calculation
     sfc_emis = Array{FT}(undef, nbnd, ncol) # surface emissivity
     sfc_emis .= FT(1.0)
     inc_flux = nothing                      # incoming flux
-    max_threads = Int(256)                  # maximum number of threads for KA kernels
+    max_threads = 256                  # maximum number of threads for KA kernels
 
     if ncol == 1
         lat = DA{FT}([0])                   # latitude
@@ -124,13 +118,7 @@ function gray_atmos_lw_equil(
 end
 #------------------------------------------------------------------------------
 
-function gray_atmos_sw_test(
-    ::Type{OPC},
-    ::Type{FT},
-    ::Type{I},
-    ::Type{DA},
-    ncol::Int,
-) where {FT <: AbstractFloat, I <: Int, DA, OPC}
+function gray_atmos_sw_test(::Type{OPC}, ::Type{FT}, ::Type{DA}, ncol::Int) where {FT <: AbstractFloat, DA, OPC}
     opc = Symbol(OPC)
     nlay = 60                         # number of layers
     p0 = FT(100000)                   # surface pressure (Pa)
@@ -142,10 +130,10 @@ function gray_atmos_sw_test(
     Δt = FT(60 * 60 * tstep)          # timestep in seconds
     ndays = 365 * 40                  # # of simulation days
     nsteps = ndays * (24 / tstep)     # number of timesteps
-    n_gauss_angles = I(1)             # for non-scattering calculation
+    n_gauss_angles = 1             # for non-scattering calculation
     sfc_emis = Array{FT}(undef, nbnd, ncol) # surface emissivity
     sfc_emis .= FT(1.0)
-    max_threads = Int(256)            # maximum number of threads for KA kernels
+    max_threads = 256            # maximum number of threads for KA kernels
     deg2rad = FT(π) / FT(180)
 
     zenith = DA{FT, 1}(undef, ncol)   # solar zenith angle in radians
@@ -196,12 +184,12 @@ function gray_atmos_sw_test(
 end
 
 if DA == CuArray
-    @time gray_atmos_lw_equil(OneScalar, Float64, Int, DA, Int(4096))
-    @time gray_atmos_lw_equil(TwoStream, Float64, Int, DA, Int(4096))
+    @time gray_atmos_lw_equil(OneScalar, Float64, DA, 4096)
+    @time gray_atmos_lw_equil(TwoStream, Float64, DA, 4096)
 else
-    @time gray_atmos_lw_equil(OneScalar, Float64, Int, DA, Int(9))
-    @time gray_atmos_lw_equil(TwoStream, Float64, Int, DA, Int(9))
+    @time gray_atmos_lw_equil(OneScalar, Float64, DA, 9)
+    @time gray_atmos_lw_equil(TwoStream, Float64, DA, 9)
 end
 
-@time gray_atmos_sw_test(OneScalar, Float64, Int, DA, Int(1))
-@time gray_atmos_sw_test(TwoStream, Float64, Int, DA, Int(1))
+@time gray_atmos_sw_test(OneScalar, Float64, DA, 1)
+@time gray_atmos_sw_test(TwoStream, Float64, DA, 1)

--- a/test/read_all_sky.jl
+++ b/test/read_all_sky.jl
@@ -148,7 +148,6 @@ function setup_allsky_as(
             typeof(random_lw),
             MaxRandomOverlap,
             typeof(vmr),
-            Int,
         }(
             lon,
             lat,

--- a/test/read_rfmip_clear_sky.jl
+++ b/test/read_rfmip_clear_sky.jl
@@ -132,7 +132,6 @@ function setup_rfmip_as(
             typeof(random_lw),
             Nothing,
             typeof(vmr),
-            Int,
         }(
             lon,
             lat,

--- a/test/rfmip_clear_sky_lw.jl
+++ b/test/rfmip_clear_sky_lw.jl
@@ -29,9 +29,8 @@ function lw_rfmip(
     ::Type{SRC},
     ::Type{VMR},
     ::Type{FT},
-    ::Type{I},
     ::Type{DA},
-) where {FT <: AbstractFloat, I <: Int, OPC, SRC, VMR, DA}
+) where {FT <: AbstractFloat, OPC, SRC, VMR, DA}
     opc = Symbol(OPC)
     lw_file = get_ref_filename(:lookup_tables, :clearsky, λ = :lw) # lw lookup tables
     lw_input_file = get_ref_filename(:atmos_state, :clearsky)      # clear-sky atmos state
@@ -47,7 +46,7 @@ function lw_rfmip(
 
     # reading longwave lookup data
     ds_lw = Dataset(lw_file, "r")
-    lookup_lw, idx_gases = LookUpLW(ds_lw, I, FT, DA)
+    lookup_lw, idx_gases = LookUpLW(ds_lw, FT, DA)
     close(ds_lw)
     # reading rfmip data to atmospheric state
     ds_lw_in = Dataset(lw_input_file, "r")

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -29,9 +29,8 @@ function sw_rfmip(
     ::Type{SRC},
     ::Type{VMR},
     ::Type{FT},
-    ::Type{I},
     ::Type{DA},
-) where {FT <: AbstractFloat, I <: Int, DA, OPC, SRC, VMR}
+) where {FT <: AbstractFloat, DA, OPC, SRC, VMR}
     opc = Symbol(OPC)
     sw_file = get_ref_filename(:lookup_tables, :clearsky, λ = :sw) # sw lookup tables
     sw_input_file = get_ref_filename(:atmos_state, :clearsky)      # clear-sky atmos state
@@ -46,7 +45,7 @@ function sw_rfmip(
 
     # reading shortwave lookup data
     ds_sw = Dataset(sw_file, "r")
-    lookup_sw, idx_gases = LookUpSW(ds_sw, I, FT, DA)
+    lookup_sw, idx_gases = LookUpSW(ds_sw, FT, DA)
     close(ds_sw)
     # reading rfmip data to atmospheric state
     ds_sw_in = Dataset(sw_input_file, "r")


### PR DESCRIPTION
There is no reason to have type parameters that we bound to concrete types:

```julia
julia> isconcretetype(UInt8)
true

julia> isconcretetype(Int)
true
```

This is similar to using `where {FT <: Float64}`, we might as well not have the type parameters, and not waste compiling a generic method with type assertions.


This PR removes these unnecessary type parameters. [xref](https://julialang.slack.com/archives/C03LD7K8HLN/p1683743629523789?thread_ts=1683740387.868789&cid=C03LD7K8HLN):

> FWIW, this bit also a bit odd: `where I<:Int64`, since this means I is either `Union{}` or `Int`, but seems like it would always just be an `Int`?



Unfortunately, this is a breaking change, but fixing upstream breakages with this should be easy.