### PR TITLE
Update MPI config

### DIFF
--- a/.buildkite/JuliaProject.toml
+++ b/.buildkite/JuliaProject.toml
@@ -1,0 +1,18 @@
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
+MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+
+[preferences.CUDA_Runtime_jll]
+version = "local"
+
+[preferences.HDF5_jll]
+libhdf5_path = "libhdf5"
+libhdf5_hl_path = "libhdf5_hl"
+
+[preferences.MPIPreferences]
+_format = "1.0"
+abi = "OpenMPI"
+binary = "system"
+libmpi = "libmpi"
+mpiexec = "mpiexec"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,8 @@
+agents:
+  queue: central
+  slurm_mem: 8G
+  modules: julia/1.8.5 cuda/11.8 ucx/1.14.1_cuda-11.8 openmpi/4.1.5_cuda-11.8
+
 env:
   JULIA_VERSION: "1.8.5"
   CUDA_VERSION: "11.2"
@@ -6,6 +11,9 @@ steps:
   - label: "init cpu environments :computer:"
     key: "init_cpu_env"
     command:
+
+      - echo "--- Configure MPI"
+      - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
 
       - echo "--- Instantiate examples environment"
       - "julia --project=examples -e 'using Pkg; Pkg.develop(path=\".\")'"


### PR DESCRIPTION
Based on the warning:

```
┌ Warning: The JULIA_MPI_BINARY environment variable is no longer used to configure the MPI binary.
│ Please use the MPIPreferences.jl package instead:
│ 
│     MPIPreferences.use_system_binary()  # use the system binary
│     MPIPreferences.use_jll_binary()     # use JLL binary
│ 
│ See https://juliaparallel.org/MPI.jl/stable/configuration/ for more details
│ 
│   ENV["JULIA_MPI_BINARY"] = "system"
│   MPIPreferences.binary = "MPICH_jll"
└ @ MPI /central/.../rrtmgp-ci/276/depot/cpu/packages/MPI/yvXmK/src/MPI.jl:103
*************************************************
```
This PR updates the MPI config