### PR TITLE
Do less splatting

### DIFF
--- a/src/optics/CloudOptics.jl
+++ b/src/optics/CloudOptics.jl
@@ -5,7 +5,7 @@
         as::AtmosphericState,
         lkp::LookUpLW,
         lkp_cld,
-        glaycol,
+        glay, gcol,
         ibnd,
         igpt,
     )
@@ -13,12 +13,12 @@
 This function computes the longwave TwoStream clouds optics properties and adds them
 to the TwoStream longwave gas optics properties.
 """
-function add_cloud_optics_2stream(op::TwoStream, as::AtmosphericState, lkp::LookUpLW, lkp_cld, glaycol, ibnd, igpt)
+function add_cloud_optics_2stream(op::TwoStream, as::AtmosphericState, lkp::LookUpLW, lkp_cld, glay, gcol, ibnd, igpt)
     if as.cld_mask_lw isa AbstractArray
-        cld_mask = as.cld_mask_lw[igpt, glaycol...]
+        cld_mask = as.cld_mask_lw[igpt, glay, gcol]
         if cld_mask
-            τ_cl, τ_cl_ssa, τ_cl_ssag = compute_cld_props(lkp_cld, as, cld_mask, glaycol..., ibnd, igpt)
-            increment!(op, τ_cl, τ_cl_ssa, τ_cl_ssag, glaycol..., igpt)
+            τ_cl, τ_cl_ssa, τ_cl_ssag = compute_cld_props(lkp_cld, as, cld_mask, glay, gcol, ibnd, igpt)
+            increment!(op, τ_cl, τ_cl_ssa, τ_cl_ssag, glay, gcol, igpt)
         end
     end
     return nothing
@@ -30,7 +30,7 @@ end
         as::AtmosphericState,
         lkp::LookUpSW,
         lkp_cld,
-        glaycol,
+        glay, gcol,
         ibnd,
         igpt,
     )
@@ -38,13 +38,13 @@ end
 This function computes the shortwave TwoStream clouds optics properties and adds them
 to the TwoStream shortwave gase optics properties.
 """
-function add_cloud_optics_2stream(op::TwoStream, as::AtmosphericState, lkp::LookUpSW, lkp_cld, glaycol, ibnd, igpt)
+function add_cloud_optics_2stream(op::TwoStream, as::AtmosphericState, lkp::LookUpSW, lkp_cld, glay, gcol, ibnd, igpt)
     if as.cld_mask_sw isa AbstractArray
-        cld_mask = as.cld_mask_sw[igpt, glaycol...]
+        cld_mask = as.cld_mask_sw[igpt, glay, gcol]
         if cld_mask
-            τ_cl, τ_cl_ssa, τ_cl_ssag = compute_cld_props(lkp_cld, as, cld_mask, glaycol..., ibnd, igpt)
+            τ_cl, τ_cl_ssa, τ_cl_ssag = compute_cld_props(lkp_cld, as, cld_mask, glay, gcol, ibnd, igpt)
             τ_cl, τ_cl_ssa, τ_cl_ssag = delta_scale(τ_cl, τ_cl_ssa, τ_cl_ssag)
-            increment!(op, τ_cl, τ_cl_ssa, τ_cl_ssag, glaycol..., igpt)
+            increment!(op, τ_cl, τ_cl_ssa, τ_cl_ssag, glay, gcol, igpt)
         end
     end
     return nothing

--- a/src/optics/GrayOpticsKernels.jl
+++ b/src/optics/GrayOpticsKernels.jl
@@ -5,7 +5,7 @@
     compute_optical_props_kernel!(
         op::AbstractOpticalProps{FT},
         as::GrayAtmosphericState{FT},
-        glaycol,
+        glay, gcol,
         source::AbstractSourceLW{FT},
     ) where {FT<:AbstractFloat}
 
@@ -15,12 +15,13 @@ for the longwave solver.
 function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::GrayAtmosphericState{FT},
-    glaycol,
+    glay,
+    gcol,
     source::AbstractSourceLW{FT},
 ) where {FT <: AbstractFloat}
 
-    compute_optical_props_kernel_lw!(op, as, glaycol)     # computing optical thickness
-    compute_sources_gray_kernel!(source, as, glaycol) # computing Planck sources
+    compute_optical_props_kernel_lw!(op, as, glay, gcol)     # computing optical thickness
+    compute_sources_gray_kernel!(source, as, glay, gcol) # computing Planck sources
     return nothing
 end
 
@@ -28,7 +29,7 @@ end
     compute_optical_props_kernel!(
         op::AbstractOpticalProps{FT},
         as::GrayAtmosphericState{FT},
-        glaycol,
+        glay, gcol,
     ) where {FT<:AbstractFloat}
 
 
@@ -38,23 +39,23 @@ for the longwave solver.
 function compute_optical_props_kernel_lw!(
     op::AbstractOpticalProps{FT},
     as::GrayAtmosphericState{FT},
-    glaycol,
+    glay,
+    gcol,
 ) where {FT <: AbstractFloat}
     # setting references
-    glay, gcol = glaycol
     (; p_lay, p_lev, otp, lat) = as
     @inbounds p0 = p_lev[1, gcol]
-    @inbounds Δp = p_lev[glay + 1, gcol] - p_lev[glaycol...]
-    @inbounds p = p_lay[glaycol...]
+    @inbounds Δp = p_lev[glay + 1, gcol] - p_lev[glay, gcol]
+    @inbounds p = p_lay[glay, gcol]
     @inbounds lat = as.lat[gcol]
-    @inbounds op.τ[glaycol...] = compute_gray_optical_thickness_lw(otp, glaycol, p0, Δp, p, lat)
+    @inbounds op.τ[glay, gcol] = compute_gray_optical_thickness_lw(otp, glay, gcol, p0, Δp, p, lat)
     return nothing
 end
 """
     compute_sources_gray_kernel!(
         source::AbstractSourceLW{FT},
         as::GrayAtmosphericState{FT},
-        glaycol,
+        glay, gcol,
     ) where {FT<:AbstractFloat}
 
 This function computes the Planck sources for the gray longwave solver.
@@ -62,17 +63,17 @@ This function computes the Planck sources for the gray longwave solver.
 function compute_sources_gray_kernel!(
     source::AbstractSourceLW{FT},
     as::GrayAtmosphericState{FT},
-    glaycol,
+    glay,
+    gcol,
 ) where {FT <: AbstractFloat}
     # computing Planck sources
-    glay, gcol = glaycol
     (; t_lay, t_lev) = as
     (; lay_source, lev_source_inc, lev_source_dec, sfc_source) = source
 
     sbc = FT(RP.Stefan(source.param_set))
-    @inbounds lay_source[glaycol...] = sbc * t_lay[glaycol...]^FT(4) / FT(π)   # computing lay_source
-    @inbounds lev_source_inc[glaycol...] = sbc * t_lev[glay + 1, gcol]^FT(4) / FT(π)
-    @inbounds lev_source_dec[glaycol...] = sbc * t_lev[glaycol...]^FT(4) / FT(π)
+    @inbounds lay_source[glay, gcol] = sbc * t_lay[glay, gcol]^FT(4) / FT(π)   # computing lay_source
+    @inbounds lev_source_inc[glay, gcol] = sbc * t_lev[glay + 1, gcol]^FT(4) / FT(π)
+    @inbounds lev_source_dec[glay, gcol] = sbc * t_lev[glay, gcol]^FT(4) / FT(π)
     if glay == 1
         @inbounds sfc_source[gcol] = sbc * as.t_sfc[gcol]^FT(4) / FT(π)   # computing sfc_source
     end
@@ -83,7 +84,7 @@ end
     compute_optical_props_kernel!(
         op::AbstractOpticalProps{FT},
         as::GrayAtmosphericState{FT},
-        glaycol,
+        glay, gcol,
     ) where {FT<:AbstractFloat}
 This function computes the optical properties using the gray atmosphere assumption
 for the shortwave solver.
@@ -91,27 +92,27 @@ for the shortwave solver.
 function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::GrayAtmosphericState{FT},
-    glaycol,
+    glay,
+    gcol,
 ) where {FT <: AbstractFloat}
     # setting references
-    glay, gcol = glaycol
     (; p_lay, p_lev, otp) = as
     @inbounds p0 = p_lev[1, gcol]
-    @inbounds Δp = p_lev[glay + 1, gcol] - p_lev[glaycol...]
-    @inbounds p = p_lay[glaycol...]
+    @inbounds Δp = p_lev[glay + 1, gcol] - p_lev[glay, gcol]
+    @inbounds p = p_lay[glay, gcol]
 
-    @inbounds op.τ[glay, gcol] = compute_gray_optical_thickness_sw(otp, glaycol, p0, Δp, p)
+    @inbounds op.τ[glay, gcol] = compute_gray_optical_thickness_sw(otp, glay, gcol, p0, Δp, p)
 
     if op isa TwoStream
-        op.ssa[glaycol...] = FT(0)
-        op.g[glaycol...] = FT(0)
+        op.ssa[glay, gcol] = FT(0)
+        op.g[glay, gcol] = FT(0)
     end
     return nothing
 end
 """
     compute_gray_optical_thickness_lw(
         params::GrayOpticalThicknessSchneider2004{FT},
-        glaycol,
+        glay, gcol,
         p0,
         Δp,
         p,
@@ -125,14 +126,14 @@ DOI: https://doi.org/10.1175/1520-0469(2004)061<1317:TTATTS>2.0.CO;2
 """
 function compute_gray_optical_thickness_lw(
     params::GrayOpticalThicknessSchneider2004{FT},
-    glaycol,
+    glay,
+    gcol,
     p0,
     Δp,
     p,
     lat,
 ) where {FT <: AbstractFloat}
     (; α, te, tt, Δt) = params
-    glay, gcol = glaycol
     ts = te + Δt * (FT(1) / FT(3) - sin(lat / FT(180) * FT(π))^2) # surface temp at a given latitude (K)
     d0 = FT((ts / tt)^FT(4) - FT(1)) # optical depth
     @inbounds τ = (α * d0 * (p / p0)^α / p) * Δp
@@ -144,7 +145,7 @@ compute_gray_optical_thickness_sw(params::GrayOpticalThicknessSchneider2004{FT},
 """
     compute_gray_optical_thickness_lw(
         params::GrayOpticalThicknessOGorman2008{FT},
-        glaycol,
+        glay, gcol,
         p0,
         Δp,
         p,
@@ -158,14 +159,14 @@ DOI: https://doi.org/10.1175/2007JCLI2065.1
 """
 function compute_gray_optical_thickness_lw(
     params::GrayOpticalThicknessOGorman2008{FT},
-    glaycol,
+    glay,
+    gcol,
     p0,
     Δp,
     p,
     lat,
 ) where {FT}
     (; α, fₗ, τₑ, τₚ) = params
-    glay, gcol = glaycol
     σ = p / p0
 
     @inbounds τ = (α * Δp / p) * (fₗ * σ + (1 - fₗ) * 4 * σ^4) * (τₑ + (τₚ - τₑ) * sin(lat / FT(180) * FT(π))^2)
@@ -175,7 +176,7 @@ end
 """
     compute_gray_optical_thickness_sw(
         params::GrayOpticalThicknessOGorman2008{FT},
-        glaycol,
+        glay, gcol,
         p0,
         Δp,
         p,
@@ -189,14 +190,14 @@ DOI: https://doi.org/10.1175/2007JCLI2065.1
 """
 function compute_gray_optical_thickness_sw(
     params::GrayOpticalThicknessOGorman2008{FT},
-    glaycol,
+    glay,
+    gcol,
     p0,
     Δp,
     p,
     rest...,
 ) where {FT}
     (; τ₀) = params
-    glay, gcol = glaycol
     @inbounds τ = 2 * τ₀ * (p / p0) * (Δp / p0)
     return abs(τ)
 end


### PR DESCRIPTION
Based on the flame graphs, some functions seem to be suffering from the tuple splatting. This PR removes them for `glaycol` and just passes the two indices.