### PR TITLE
Precompute expensive terms

### DIFF
--- a/src/optics/GasOptics.jl
+++ b/src/optics/GasOptics.jl
@@ -98,9 +98,10 @@ Compute interpolation fraction for pressure.
 @inline function compute_interp_frac_press(lkp::AbstractLookUp, p_lay, tropo, glay, gcol)
     (; Δ_ln_p_ref, p_ref, n_p_ref) = lkp
 
-    @inbounds jpress = Int(min(max(fld(log(p_ref[1]) - log(p_lay), Δ_ln_p_ref) + 1, 1), n_p_ref - 1) + 1)
+    log_p_lay = log(p_lay)
+    @inbounds jpress = Int(min(max(fld(log(p_ref[1]) - log_p_lay, Δ_ln_p_ref) + 1, 1), n_p_ref - 1) + 1)
 
-    @inbounds fpress = (log(p_ref[jpress - 1]) - log(p_lay)) / Δ_ln_p_ref
+    @inbounds fpress = (log(p_ref[jpress - 1]) - log_p_lay) / Δ_ln_p_ref
     jpress = jpress + tropo - 1
 
     return (jpress, fpress)

--- a/src/rte/RTESolverKernels.jl
+++ b/src/rte/RTESolverKernels.jl
@@ -169,10 +169,11 @@ function rte_lw_2stream_source!(
         γ2 = lw_diff_sec * FT(0.5) * ssa[glay, gcol] * (1 - g[glay, gcol])
         k = sqrt(max((γ1 + γ2) * (γ1 - γ2), FT(1e-12)))
 
+        coeff = exp(-2 * τ[glay, gcol] * k)
         # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
-        RT_term = 1 / (k * (1 + exp(-2 * τ[glay, gcol] * k)) + γ1 * (1 - exp(-2 * τ[glay, gcol] * k)))
+        RT_term = 1 / (k * (1 + coeff) + γ1 * (1 - coeff))
 
-        @inbounds Rdif[glay, gcol] = RT_term * γ2 * (1 - exp(-2 * τ[glay, gcol] * k)) # Equation 25
+        @inbounds Rdif[glay, gcol] = RT_term * γ2 * (1 - coeff) # Equation 25
         @inbounds Tdif[glay, gcol] = RT_term * 2 * k * exp(-τ[glay, gcol] * k) # Equation 26
 
         # Source function for diffuse radiation


### PR DESCRIPTION
Based on the flame graph, the `exp` and `log` functions are a bit expensive and, since they are repeated, this PR precomputes and reuses the precomputed values.