### PR TITLE
Avoid slowpath in pow

### DIFF
--- a/src/RRTMGP.jl
+++ b/src/RRTMGP.jl
@@ -1,5 +1,9 @@
 module RRTMGP
 
+# we may be hitting a slow path:
+# https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1
+pow_fast(x, y) = exp(y * log(x))
+
 import ClimaComms
 include("Parameters.jl")
 import .Parameters as RP

--- a/src/optics/GrayOpticsKernels.jl
+++ b/src/optics/GrayOpticsKernels.jl
@@ -136,7 +136,7 @@ function compute_gray_optical_thickness_lw(
     (; α, te, tt, Δt) = params
     ts = te + Δt * (FT(1) / FT(3) - sin(lat / FT(180) * FT(π))^2) # surface temp at a given latitude (K)
     d0 = FT((ts / tt)^FT(4) - FT(1)) # optical depth
-    @inbounds τ = (α * d0 * (p / p0)^α / p) * Δp
+    @inbounds τ = (α * d0 * pow_fast(p / p0, α) / p) * Δp
     return abs(τ)
 end
 

--- a/src/optics/GrayUtils.jl
+++ b/src/optics/GrayUtils.jl
@@ -5,6 +5,7 @@ import ClimaComms
 using ..AtmosphericStates
 using ..Fluxes
 
+import ..pow_fast
 import ..Parameters as RP
 
 export update_profile_lw!, compute_gray_heating_rate!
@@ -103,7 +104,8 @@ function update_profile_lw_kernel!(
     #-----------------------------------------------------------------------
     sbc = FT(RP.Stefan(param_set))
     for glev in 1:nlev
-        @inbounds T_ex_lev[glev, gcol] = ((flux_dn[glev, gcol] + (flux_net[glev, gcol] / FT(2))) / sbc)^FT(0.25)
+        @inbounds T_ex_lev[glev, gcol] =
+            pow_fast((flux_dn[glev, gcol] + (flux_net[glev, gcol] / FT(2))) / sbc, FT(0.25))
     end
 
     for glev in 2:nlev

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -7,6 +7,7 @@ using Random
 import ClimaComms
 #---------------------------------------
 using ..Vmrs
+import ..pow_fast
 using ..LookUpTables
 using ..AtmosphericStates
 using ..Sources


### PR DESCRIPTION
Based on the flame graphs, we seem to be hitting this slow path (https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1), same as what we hit in thermodynamics.

This PR adds `pow_fast(x, y) = exp(y * log(x))` to avoid the slow path.