### PR TITLE
Remove splatting

### DIFF
--- a/docs/src/rte/RTESolver.md
+++ b/docs/src/rte/RTESolver.md
@@ -6,8 +6,7 @@ CurrentModule = RRTMGP.RTESolver
 
 ```@docs
 solve_lw!
-rte_lw_noscat_solve!
-rte_lw_2stream_solve!
+rte_lw_solve!
 solve_sw!
 rte_sw_noscat_solve!
 rte_sw_2stream_solve!

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -1,6 +1,8 @@
 #=
 julia --project=examples
 julia --project=examples perf/flame.jl gray_atm.jl
+julia --project=examples perf/flame.jl clear_sky.jl
+julia --project=examples perf/flame.jl all_sky.jl
 ```
 include(joinpath("perf", "flame.jl"))
 ```

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -798,7 +798,7 @@ These are used to determine the optical properties of ice and water cloud togeth
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct LookUpCld{B, FT, FTA1D, FTA2D, FTA3D, FTA4D}
+struct LookUpCld{B, FT, FTA1D, FTA2D, FTA3D, FTA4D} <: AbstractLookUp{FT}
     "number of bands"
     nband::Int
     "number of ice roughness types"

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -162,13 +162,16 @@ function compute_optical_props!(
     sf::AbstractSourceLW{FT},
     gcol::Int,
     igpt::Int,
-    lkp::LookUpLW{FT},
-    lkp_cld::Union{LookUpCld, Nothing} = nothing,
+    lkp::Union{AbstractLookUp, Nothing} = nothing,
+    lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
-    lkp_args = (lkp_cld === nothing) ? (lkp,) : (lkp, lkp_cld)
     for ilay in 1:nlay
-        compute_optical_props_kernel!(op, as, ilay, gcol, sf, igpt, lkp_args...)
+        if lkp_cld isa Nothing
+            compute_optical_props_kernel!(op, as, ilay, gcol, sf, igpt, lkp)
+        else
+            compute_optical_props_kernel!(op, as, ilay, gcol, sf, igpt, lkp, lkp_cld)
+        end
     end
     return nothing
 end
@@ -190,13 +193,16 @@ function compute_optical_props!(
     as::AtmosphericState{FT},
     gcol::Int,
     igpt::Int,
-    lkp::LookUpSW{FT},
-    lkp_cld::Union{LookUpCld, Nothing} = nothing,
+    lkp::Union{AbstractLookUp, Nothing} = nothing,
+    lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
-    lkp_args = (lkp_cld === nothing) ? (lkp,) : (lkp, lkp_cld)
     for ilay in 1:nlay
-        compute_optical_props_kernel!(op, as, ilay, gcol, igpt, lkp_args...)
+        if lkp_cld isa Nothing
+            compute_optical_props_kernel!(op, as, ilay, gcol, igpt, lkp)
+        else
+            compute_optical_props_kernel!(op, as, ilay, gcol, igpt, lkp, lkp_cld)
+        end
     end
     return nothing
 end
@@ -218,6 +224,8 @@ function compute_optical_props!(
     sf::AbstractSourceLW{FT},
     gcol::Int,
     igpt::Int = 1,
+    lkp::Union{AbstractLookUp, Nothing} = nothing,
+    lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
     for ilay in 1:nlay
@@ -241,6 +249,8 @@ function compute_optical_props!(
     as::GrayAtmosphericState{FT},
     gcol::Int,
     igpt::Int = 1,
+    lkp::Union{AbstractLookUp, Nothing} = nothing,
+    lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
     for ilay in 1:nlay

--- a/src/rte/RTESolverKernels.jl
+++ b/src/rte/RTESolverKernels.jl
@@ -221,11 +221,11 @@ function adding_lw!(
     flux::FluxLW{FT},
     src_lw::SL,
     bcs_lw::BCL,
-    gcol,
-    igpt,
+    gcol::Int,
+    igpt::Int,
     major_gpt2bnd::AbstractArray{UInt8, 1},
-    nlev,
-    ncol,
+    nlev::Int,
+    ncol::Int,
 ) where {FT <: AbstractFloat, SL <: SourceLW2Str{FT}, BCL <: LwBCs{FT}}
     nlay = nlev - 1
     ibnd = major_gpt2bnd[igpt]


### PR DESCRIPTION
This PR removes some splatting / slurping of arguments, which the compiler cannot seem to infer well. Closes #365.

This is a clear improvement based on the benchmarks.