### PR TITLE
Propagate inbounds

### DIFF
--- a/src/optics/GasOptics.jl
+++ b/src/optics/GasOptics.jl
@@ -50,7 +50,7 @@ end
 
 compute interpolation fractions for binary species parameter, pressure and temperature.
 """
-@inline function compute_interp_fractions(
+Base.@propagate_inbounds function compute_interp_fractions(
     lkp::AbstractLookUp{FT},
     vmr,
     p_lay,
@@ -76,7 +76,12 @@ end
 
 compute interpolation fraction for temperature.
 """
-@inline function compute_interp_frac_temp(lkp::AbstractLookUp{FT}, t_lay, glay, gcol) where {FT <: AbstractFloat}
+Base.@propagate_inbounds function compute_interp_frac_temp(
+    lkp::AbstractLookUp{FT},
+    t_lay,
+    glay,
+    gcol,
+) where {FT <: AbstractFloat}
     (; Δ_t_ref, n_t_ref, t_ref) = lkp
 
     @inbounds jtemp = loc_lower(t_lay, Δ_t_ref, n_t_ref, t_ref)
@@ -96,7 +101,7 @@ end
 
 Compute interpolation fraction for pressure.
 """
-@inline function compute_interp_frac_press(lkp::AbstractLookUp, p_lay, tropo, glay, gcol)
+Base.@propagate_inbounds function compute_interp_frac_press(lkp::AbstractLookUp, p_lay, tropo, glay, gcol)
     (; Δ_ln_p_ref, p_ref, n_p_ref) = lkp
 
     log_p_lay = log(p_lay)
@@ -121,7 +126,7 @@ end
 
 Compute interpolation fraction for binary species parameter.
 """
-@inline function compute_interp_frac_η(
+Base.@propagate_inbounds function compute_interp_frac_η(
     lkp::AbstractLookUp{FT},
     vmr,
     tropo,
@@ -175,7 +180,7 @@ end
 Compute optical thickness, single scattering albedo, asymmetry parameter 
 and longwave sources whenever applicable.
 """
-@inline function compute_τ_ssa_lw_src!(
+Base.@propagate_inbounds function compute_τ_ssa_lw_src!(
     lkp::AbstractLookUp{FT},
     vmr,
     col_dry,
@@ -234,7 +239,7 @@ end
 
 Compute optical thickness contributions from minor gases.
 """
-@inline function compute_τ_minor(
+Base.@propagate_inbounds function compute_τ_minor(
     lkp::AbstractLookUp,
     tropo::Int,
     vmr,
@@ -319,7 +324,7 @@ end
 
 Compute Rayleigh scattering optical depths for shortwave problem
 """
-@inline function compute_τ_rayleigh(
+Base.@propagate_inbounds function compute_τ_rayleigh(
     lkp::LookUpSW,
     tropo::Int,
     col_dry::FT,
@@ -369,7 +374,7 @@ end
 Computes Planck sources for the longwave problem.
 
 """
-@inline function compute_lw_planck_src!(
+Base.@propagate_inbounds function compute_lw_planck_src!(
     lkp::LookUpLW,
     jη1,
     jη2,

--- a/src/optics/GrayAtmosphericStates.jl
+++ b/src/optics/GrayAtmosphericStates.jl
@@ -198,7 +198,7 @@ function setup_gray_as_alt_grid(
     pts = (pts .+ FT(1)) ./ FT(2)
     Δz_cell = zend / ncls
 
-    for icol in 1:ncol
+    @inbounds for icol in 1:ncol
         #---------bot_at_1---------------------------------------
         z_lev[1, icol] = zst
         z_lev[nlev, icol] = zend
@@ -277,7 +277,7 @@ function setup_gray_as_pr_grid_kernel!(
     t_lev[1, gcol] = tt * (FT(1) + d0[gcol] * (p_lev[1, gcol] / p0)^α)^FT(0.25)
     z_lev[1, gcol] = FT(0)
 
-    for ilay in 1:nlay
+    @inbounds for ilay in 1:nlay
         #                if step == "linear"
         p_lev[ilay + 1, gcol] = p_lev[ilay, gcol] - Δp
         #                else

--- a/src/optics/GrayUtils.jl
+++ b/src/optics/GrayUtils.jl
@@ -86,12 +86,12 @@ function update_profile_lw_kernel!(
     gcol,
 ) where {FT <: AbstractFloat}
     # updating t_lay based on heating rate
-    for glay in 1:nlay
-        @inbounds t_lay[glay, gcol] += Δt * hr_lay[glay, gcol]
+    @inbounds for glay in 1:nlay
+        t_lay[glay, gcol] += Δt * hr_lay[glay, gcol]
     end
     #--------compute t_lev from t_lay--------------------------------------
-    for glev in 2:(nlay - 1)
-        @inbounds t_lev[glev, gcol] =
+    @inbounds for glev in 2:(nlay - 1)
+        t_lev[glev, gcol] =
             FT(1 / 3) * t_lay[glev - 1, gcol] + FT(5 / 6) * t_lay[glev, gcol] - FT(1 / 6) * t_lay[glev + 1, gcol]
     end
 
@@ -103,13 +103,12 @@ function update_profile_lw_kernel!(
     @inbounds t_lev[nlay + 1, gcol] = FT(2) * t_lay[nlay, gcol] - t_lev[nlay, gcol]
     #-----------------------------------------------------------------------
     sbc = FT(RP.Stefan(param_set))
-    for glev in 1:nlev
-        @inbounds T_ex_lev[glev, gcol] =
-            pow_fast((flux_dn[glev, gcol] + (flux_net[glev, gcol] / FT(2))) / sbc, FT(0.25))
+    @inbounds for glev in 1:nlev
+        T_ex_lev[glev, gcol] = pow_fast((flux_dn[glev, gcol] + (flux_net[glev, gcol] / FT(2))) / sbc, FT(0.25))
     end
 
-    for glev in 2:nlev
-        @inbounds flux_grad[glev - 1, gcol] = abs(flux_net[glev, gcol] - flux_net[glev - 1, gcol])
+    @inbounds for glev in 2:nlev
+        flux_grad[glev - 1, gcol] = abs(flux_net[glev, gcol] - flux_net[glev - 1, gcol])
     end
     #-----------------------------------------------------------------------
 end
@@ -157,8 +156,8 @@ function compute_gray_heating_rate_CUDA!(ncol, args...)
 end
 
 function compute_gray_heating_rate_kernel!(hr_lay, flux_net, p_lev, grav_, cp_d_, nlay, gcol)
-    for ilay in 1:nlay
-        @inbounds hr_lay[ilay, gcol] =
+    @inbounds for ilay in 1:nlay
+        hr_lay[ilay, gcol] =
             grav_ * (flux_net[ilay + 1, gcol] - flux_net[ilay, gcol]) / (p_lev[ilay + 1, gcol] - p_lev[ilay, gcol]) /
             cp_d_
     end

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -186,7 +186,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     idx_scaling_gas_lower = zeros(Int, n_min_absrb_lower)
     idx_scaling_gas_upper = zeros(Int, n_min_absrb_upper)
 
-    for igas in 1:n_maj_absrb
+    @inbounds for igas in 1:n_maj_absrb
         gases_major[igas] = strip(String(ds["gas_names"][:, igas]))
         idx_gases[gases_major[igas]] = Int(igas)
     end
@@ -198,12 +198,12 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     n_gases = n_maj_absrb
 
-    for igas in 1:n_min_absrb
+    @inbounds for igas in 1:n_min_absrb
         gases_minor[igas] = strip(String(ds["gas_minor"][:, igas]))
         id_minor[igas] = strip(String(ds["identifier_minor"][:, igas]))
     end
 
-    for igas in 1:n_min_absrb_lower
+    @inbounds for igas in 1:n_min_absrb_lower
         gases_minor_lower[igas] = strip(String(ds["minor_gases_lower"][:, igas]))
         scaling_gas_lower[igas] = strip(String(ds["scaling_gas_lower"][:, igas]))
         if ~isempty(gases_minor_lower[igas])
@@ -216,7 +216,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     idx_gases_minor_lower = DA(idx_gases_minor_lower)
     idx_scaling_gas_lower = DA(idx_scaling_gas_lower)
 
-    for igas in 1:n_min_absrb_upper
+    @inbounds for igas in 1:n_min_absrb_upper
         gases_minor_upper[igas] = strip(String(ds["minor_gases_upper"][:, igas]))
         scaling_gas_upper[igas] = strip(String(ds["scaling_gas_upper"][:, igas]))
         if ~isempty(gases_minor_upper[igas])
@@ -230,7 +230,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     idx_scaling_gas_upper = DA(idx_scaling_gas_upper)
 
     key_species = ds["key_species"][:]
-    for j in 1:size(key_species, 3)
+    @inbounds for j in 1:size(key_species, 3)
         for i in 1:size(key_species, 2)
             if key_species[1, i, j] == 0 && key_species[2, i, j] == 0
                 key_species[1:2, i, j] .= 2
@@ -254,7 +254,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     bnd_lims_wn = FTA2D(ds["bnd_limits_wavenumber"][:])
     #-----------------------
     major_gpt2bnd = Array{UI8, 1}(undef, n_gpt)
-    for i in 1:n_bnd
+    @inbounds for i in 1:n_bnd
         major_gpt2bnd[bnd_lims_gpt[1, i]:bnd_lims_gpt[2, i]] .= UI8(i)
     end
     #-----------------------
@@ -272,7 +272,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     minor_upper_gpt_sh = Array{Int, 1}(undef, n_min_absrb_upper)
 
     minor_lower_gpt_sh[1] = 0
-    for i in 1:n_min_absrb_lower
+    @inbounds for i in 1:n_min_absrb_lower
         minor_lower_bnd[i] = major_gpt2bnd[minor_lower_gpt_lims[1, i]]
         if i > 1
             minor_lower_gpt_sh[i] =
@@ -281,7 +281,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     end
 
     minor_upper_gpt_sh[1] = 0
-    for i in 1:n_min_absrb_upper
+    @inbounds for i in 1:n_min_absrb_upper
         minor_upper_bnd[i] = major_gpt2bnd[minor_upper_gpt_lims[1, i]]
         if i > 1
             minor_upper_gpt_sh[i] =
@@ -292,7 +292,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     minor_lower_bnd_st[1] = 1
     minor_upper_bnd_st[1] = 1
 
-    for ibnd in 2:(n_bnd + 1)
+    @inbounds for ibnd in 2:(n_bnd + 1)
         loc_low = findlast(isequal(UI8(ibnd - 1)), minor_lower_bnd)
         loc_upp = findlast(isequal(UI8(ibnd - 1)), minor_upper_bnd)
         if isnothing(loc_low)
@@ -575,7 +575,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     idx_scaling_gas_lower = zeros(Int, n_min_absrb_lower)
     idx_scaling_gas_upper = zeros(Int, n_min_absrb_upper)
 
-    for igas in 1:n_maj_absrb
+    @inbounds for igas in 1:n_maj_absrb
         gases_major[igas] = strip(String(ds["gas_names"][:, igas]))
         idx_gases[gases_major[igas]] = Int(igas)
     end
@@ -586,12 +586,12 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     n_gases = n_maj_absrb
 
-    for igas in 1:n_min_absrb
+    @inbounds for igas in 1:n_min_absrb
         gases_minor[igas] = strip(String(ds["gas_minor"][:, igas]))
         id_minor[igas] = strip(String(ds["identifier_minor"][:, igas]))
     end
 
-    for igas in 1:n_min_absrb_lower
+    @inbounds for igas in 1:n_min_absrb_lower
         gases_minor_lower[igas] = strip(String(ds["minor_gases_lower"][:, igas]))
         scaling_gas_lower[igas] = strip(String(ds["scaling_gas_lower"][:, igas]))
         if ~isempty(gases_minor_lower[igas])
@@ -602,7 +602,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
         end
     end
 
-    for igas in 1:n_min_absrb_upper
+    @inbounds for igas in 1:n_min_absrb_upper
         gases_minor_upper[igas] = strip(String(ds["minor_gases_upper"][:, igas]))
         scaling_gas_upper[igas] = strip(String(ds["scaling_gas_upper"][:, igas]))
         if ~isempty(gases_minor_upper[igas])
@@ -614,7 +614,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     end
 
     key_species = ds["key_species"][:]
-    for j in 1:size(key_species, 3)
+    @inbounds for j in 1:size(key_species, 3)
         for i in 1:size(key_species, 2)
             if key_species[1, i, j] == 0 && key_species[2, i, j] == 0
                 key_species[1:2, i, j] .= 2
@@ -634,7 +634,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     bnd_lims_wn = FTA2D(ds["bnd_limits_wavenumber"][:])
     #-----------------------
     major_gpt2bnd = Array{UI8, 1}(undef, n_gpt)
-    for i in 1:n_bnd
+    @inbounds for i in 1:n_bnd
         major_gpt2bnd[bnd_lims_gpt[1, i]:bnd_lims_gpt[2, i]] .= UI8(i)
     end
     #-----------------------
@@ -652,7 +652,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     minor_upper_gpt_sh = Array{Int, 1}(undef, n_min_absrb_upper)
 
     minor_lower_gpt_sh[1] = 0
-    for i in 1:n_min_absrb_lower
+    @inbounds for i in 1:n_min_absrb_lower
         minor_lower_bnd[i] = major_gpt2bnd[minor_lower_gpt_lims[1, i]]
         if i > 1
             minor_lower_gpt_sh[i] =
@@ -661,7 +661,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     end
 
     minor_upper_gpt_sh[1] = 0
-    for i in 1:n_min_absrb_upper
+    @inbounds for i in 1:n_min_absrb_upper
         minor_upper_bnd[i] = major_gpt2bnd[minor_upper_gpt_lims[1, i]]
         if i > 1
             minor_upper_gpt_sh[i] =
@@ -672,7 +672,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     minor_lower_bnd_st[1] = 1
     minor_upper_bnd_st[1] = 1
 
-    for ibnd in 2:(n_bnd + 1)
+    @inbounds for ibnd in 2:(n_bnd + 1)
         loc_low = findlast(isequal(UI8(ibnd - 1)), minor_lower_bnd)
         loc_upp = findlast(isequal(UI8(ibnd - 1)), minor_upper_bnd)
         if isnothing(loc_low)

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -132,7 +132,7 @@ function compute_col_gas_CUDA!(col_dry, args...)
     return nothing
 end
 #-----------------------------------------------------------------------------
-function compute_optical_props_CUDA!(op, as, args...)
+Base.@propagate_inbounds function compute_optical_props_CUDA!(op, as, args...)
     glx = threadIdx().x + (blockIdx().x - 1) * blockDim().x # global id
     nlay, ncol = size(op.τ)
     if glx ≤ nlay * ncol
@@ -156,7 +156,7 @@ end
 
 Computes optical properties for the longwave problem.
 """
-function compute_optical_props!(
+Base.@propagate_inbounds function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     sf::AbstractSourceLW{FT},
@@ -166,7 +166,7 @@ function compute_optical_props!(
     lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
-    for ilay in 1:nlay
+    @inbounds for ilay in 1:nlay
         if lkp_cld isa Nothing
             compute_optical_props_kernel!(op, as, ilay, gcol, sf, igpt, lkp)
         else
@@ -188,7 +188,7 @@ end
 
 Computes optical properties for the shortwave problem.
 """
-function compute_optical_props!(
+Base.@propagate_inbounds function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     gcol::Int,
@@ -197,7 +197,7 @@ function compute_optical_props!(
     lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
-    for ilay in 1:nlay
+    @inbounds for ilay in 1:nlay
         if lkp_cld isa Nothing
             compute_optical_props_kernel!(op, as, ilay, gcol, igpt, lkp)
         else
@@ -218,7 +218,7 @@ end
 
 Computes optical properties for the longwave gray radiation problem.
 """
-function compute_optical_props!(
+Base.@propagate_inbounds function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::GrayAtmosphericState{FT},
     sf::AbstractSourceLW{FT},
@@ -228,7 +228,7 @@ function compute_optical_props!(
     lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
-    for ilay in 1:nlay
+    @inbounds for ilay in 1:nlay
         compute_optical_props_kernel!(op, as, ilay, gcol, sf)
     end
     return nothing
@@ -244,7 +244,7 @@ end
 
 Computes optical properties for the shortwave gray radiation problem.
 """
-function compute_optical_props!(
+Base.@propagate_inbounds function compute_optical_props!(
     op::AbstractOpticalProps{FT},
     as::GrayAtmosphericState{FT},
     gcol::Int,
@@ -253,7 +253,7 @@ function compute_optical_props!(
     lkp_cld::Union{AbstractLookUp, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     nlay = as.nlay
-    for ilay in 1:nlay
+    @inbounds for ilay in 1:nlay
         compute_optical_props_kernel!(op, as, ilay, gcol)
     end
     return nothing

--- a/src/optics/OpticsKernels.jl
+++ b/src/optics/OpticsKernels.jl
@@ -4,7 +4,7 @@ include("GasOptics.jl")
 include("CloudOptics.jl")
 include("GrayOpticsKernels.jl")
 
-function compute_optical_props_kernel!(
+Base.@propagate_inbounds function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     glay,
@@ -21,7 +21,7 @@ function compute_optical_props_kernel!(
     return nothing
 end
 
-function compute_optical_props_kernel!(
+Base.@propagate_inbounds function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     glay,
@@ -36,7 +36,7 @@ function compute_optical_props_kernel!(
     return nothing
 end
 
-function compute_optical_props_kernel!(
+Base.@propagate_inbounds function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     glay,
@@ -52,7 +52,7 @@ function compute_optical_props_kernel!(
     return nothing
 end
 
-function compute_optical_props_kernel!(
+Base.@propagate_inbounds function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     glay,
@@ -78,7 +78,7 @@ function compute_optical_props_kernel!(
     return nothing
 end
 
-function compute_optical_props_kernel!(
+Base.@propagate_inbounds function compute_optical_props_kernel!(
     op::AbstractOpticalProps{FT},
     as::AtmosphericState{FT},
     glay,

--- a/src/optics/OpticsUtils.jl
+++ b/src/optics/OpticsUtils.jl
@@ -1,12 +1,12 @@
 
-@inline loc_lower(xi, Δx, n, x) = @inbounds max(min(unsafe_trunc(Int, (xi - x[1]) / Δx) + 1, n - 1), 1)
+Base.@propagate_inbounds loc_lower(xi, Δx, n, x) = @inbounds max(min(unsafe_trunc(Int, (xi - x[1]) / Δx) + 1, n - 1), 1)
 
 """
     interp1d(xi::FT, x, y, col) where {FT<:AbstractFloat}
 
 perform 1D linear interpolation.
 """
-@inline function interp1d(xi::FT, x, y, col) where {FT <: AbstractFloat}
+Base.@propagate_inbounds function interp1d(xi::FT, x, y, col) where {FT <: AbstractFloat}
     @inbounds Δx = x[2] - x[1]
     n = length(x)
     loc = loc_lower(xi, Δx, n, x)
@@ -36,7 +36,7 @@ Perform 2D linear interpolation.
 
 `fminor[2, 2] = fη2 * ftemp`
 """
-@inline function interp2d(
+Base.@propagate_inbounds function interp2d(
     fη1::FT,
     fη2::FT,
     ftemp::FT,
@@ -89,7 +89,7 @@ where,
 `fminor[2, itemp=2] = fη2 * ftemp`
 
 """
-@inline function interp3d(
+Base.@propagate_inbounds function interp3d(
     jη1::Int,
     jη2::Int,
     fη1::FT,
@@ -136,7 +136,15 @@ Increment TwoStream optical properties `op` for layer `glay`
 and column `gcol` with optical thickness `τ2`, single scattering
 albedo `ssa2` and symmetry parameter `g2`.
 """
-function increment!(op::TwoStream{FT}, τ2, ssa2, g2, glay, gcol, igpt) where {FT <: AbstractFloat}
+Base.@propagate_inbounds function increment!(
+    op::TwoStream{FT},
+    τ2,
+    ssa2,
+    g2,
+    glay,
+    gcol,
+    igpt,
+) where {FT <: AbstractFloat}
     τ1, ssa1, g1 = op.τ[glay, gcol], op.ssa[glay, gcol], op.g[glay, gcol]
     τ = τ1 + τ2
     ssa = τ1 * ssa1 + τ2 * ssa2

--- a/src/optics/Vmrs.jl
+++ b/src/optics/Vmrs.jl
@@ -65,7 +65,7 @@ Adapt.@adapt_structure Vmr
 
 Obtain volume mixing ratio of gas `ig` for layer `ilay` of column `icol`.
 """
-@inline function get_vmr(vmr::VmrGM{FT}, ig::Int, ilay::Int, icol::Int) where {FT <: AbstractFloat}
+Base.@propagate_inbounds function get_vmr(vmr::VmrGM{FT}, ig::Int, ilay::Int, icol::Int) where {FT <: AbstractFloat}
     if ig == 0
         return FT(1)
     elseif ig == 1 # h2o / h2o_foreign / h2o_self-continua

--- a/src/rte/RTESolver.jl
+++ b/src/rte/RTESolver.jl
@@ -127,7 +127,7 @@ function rte_lw_noscat_solve_CUDA!(
     nlev = nlay + 1
     n_gpt = length(major_gpt2bnd)
     if gcol ≤ ncol
-        for igpt in 1:n_gpt
+        @inbounds for igpt in 1:n_gpt
             igpt == 1 && set_flux_to_zero!(flux_lw, gcol)
             compute_optical_props!(op, as, src_lw, gcol, igpt, lookup_lw, lookup_lw_cld)
             rte_lw_noscat_source!(src_lw, op, gcol, nlay)
@@ -229,7 +229,7 @@ function rte_lw_2stream_solve_CUDA!(
         if as isa AtmosphericState && as.cld_mask_type isa AbstractCloudMask
             Optics.build_cloud_mask!(as.cld_mask_lw, as.cld_frac, as.random_lw, gcol, as.cld_mask_type)
         end
-        for igpt in 1:n_gpt
+        @inbounds for igpt in 1:n_gpt
             igpt == 1 && set_flux_to_zero!(flux_lw, gcol)
             compute_optical_props!(op, as, src_lw, gcol, igpt, lookup_lw, lookup_lw_cld)
             rte_lw_2stream_combine_sources!(src_lw, gcol, nlev, ncol)
@@ -377,7 +377,7 @@ function rte_sw_noscat_solve_CUDA!(
     n_gpt = length(solar_src_scaled)
     # setting references for flux_sw
     if gcol ≤ ncol
-        for igpt in 1:n_gpt
+        @inbounds for igpt in 1:n_gpt
             igpt == 1 && set_flux_to_zero!(flux_sw, gcol)
             compute_optical_props!(op, as, gcol, igpt, lookup_sw, lookup_sw_cld)
             rte_sw_noscat_solve_kernel!(flux, op, bcs_sw, igpt, solar_src_scaled, gcol, nlev)
@@ -485,7 +485,7 @@ function rte_sw_2stream_solve_CUDA!(
         if as isa AtmosphericState && as.cld_mask_type isa AbstractCloudMask
             Optics.build_cloud_mask!(as.cld_mask_sw, as.cld_frac, as.random_sw, gcol, as.cld_mask_type)
         end
-        for igpt in 1:n_gpt
+        @inbounds for igpt in 1:n_gpt
             igpt == 1 && set_flux_to_zero!(flux_sw, gcol)
             compute_optical_props!(op, as, gcol, igpt, lookup_sw, lookup_sw_cld)
             sw_two_stream!(op, src_sw, bcs_sw, gcol, nlay) # Cell properties: transmittance and reflectance for direct and diffuse radiation


### PR DESCRIPTION
This PR attempts to use `@propagate_inbounds` to elide bounds checks. This doesn't seem to be a clear win. Let's start by just applying `@inbounds` where it's missing. Closing