### PR TITLE
remove compute_optical_props_CUDA!.

### DIFF
--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -132,17 +132,6 @@ function compute_col_gas_CUDA!(col_dry, args...)
     return nothing
 end
 #-----------------------------------------------------------------------------
-function compute_optical_props_CUDA!(op, as, args...)
-    glx = threadIdx().x + (blockIdx().x - 1) * blockDim().x # global id
-    nlay, ncol = size(op.τ)
-    if glx ≤ nlay * ncol
-        glay = (glx % nlay == 0) ? nlay : (glx % nlay)
-        gcol = cld(glx, nlay)
-        compute_optical_props_kernel!(op, as, glay, gcol, args...)
-    end
-    return nothing
-end
-#-----------------------------------------------------------------------------
 """
     compute_optical_props!(
         op::AbstractOpticalProps{FT},


### PR DESCRIPTION
Its functionality has been replaced in `rte/RTESolver` by a single CUDA kernel launch for optical properties computation and rte solver.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
