### PR TITLE
Add back stand-alone clear-sky lw & sw tests

### DIFF
--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -54,8 +54,8 @@ function sw_rfmip(context, ::Type{OPC}, ::Type{SRC}, ::Type{VMR}, ::Type{FT}) wh
     ncol, nlay, ngpt = as.ncol, as.nlay, lookup_sw.n_gpt
     nlev = nlay + 1
     op = OPC(FT, ncol, nlay, DA)            # allocating optical properties object
-    src_sw = SRC(FT, DA, nlay, ncol)        # allocating longwave source function object
-    #src_sw = source_func_shortwave(FT, ncol, nlay, opc, DA)        # allocating longwave source function object
+    #src_sw = SRC(FT, DA, nlay, ncol)        # allocating longwave source function object
+    src_sw = source_func_shortwave(FT, ncol, nlay, opc, DA)        # allocating longwave source function object
 
     # setting up boundary conditions
     inc_flux_diffuse = nothing
@@ -68,10 +68,6 @@ function sw_rfmip(context, ::Type{OPC}, ::Type{SRC}, ::Type{VMR}, ::Type{FT}) wh
     slv = Solver(context, as, op, nothing, src_sw, nothing, bcs_sw, nothing, fluxb_sw, nothing, flux_sw)
     #--------------------------------------------------
     solve_sw!(slv, max_threads, lookup_sw)
-
-    for i in 1:10
-        @time solve_sw!(slv, max_threads, lookup_sw)
-    end
 
     # reading comparison data
     flip_ind = nlev:-1:1
@@ -108,6 +104,5 @@ function sw_rfmip(context, ::Type{OPC}, ::Type{SRC}, ::Type{VMR}, ::Type{FT}) wh
     return nothing
 end
 
-context = ClimaComms.context()
-sw_rfmip(context, TwoStream, SourceSW2Str, VmrGM, Float64) # two-stream solver should be used for the short-wave problem
+sw_rfmip(ClimaComms.context(), TwoStream, SourceSW2Str, VmrGM, Float64) # two-stream solver should be used for the short-wave problem
 #sw_rfmip(OneScalar, VmrGM, Float64, Int, array_type()) # this only computes flux_dn_dir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,16 @@ println("================================================================\n\n\n"
 end
 println("================================================================\n\n\n")
 
+@testset "RRTMGP stand-alone clear-sky lw solver tests" begin
+    include("rfmip_clear_sky_lw.jl")
+end
+println("================================================================\n\n\n")
+
+@testset "RRTMGP stand-alone clear-sky sw solver tests" begin
+    include("rfmip_clear_sky_sw.jl")
+end
+println("================================================================\n\n\n")
+
 @testset "Aqua" begin
     include("aqua.jl")
 end

--- a/test/runtests_gpu.jl
+++ b/test/runtests_gpu.jl
@@ -14,3 +14,13 @@ println("================================================================\n\n\n"
     include("all_sky.jl")
 end
 println("================================================================\n\n\n")
+
+@testset "RRTMGP stand-alone clear-sky lw solver tests" begin
+    include("rfmip_clear_sky_lw.jl")
+end
+println("================================================================\n\n\n")
+
+@testset "RRTMGP stand-alone clear-sky sw solver tests" begin
+    include("rfmip_clear_sky_sw.jl")
+end
+println("================================================================\n\n\n")


### PR DESCRIPTION
Add back stand-alone clear-sky lw & sw tests.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
