### PR TITLE
Restructure cloud optics computations

### DIFF
--- a/src/optics/OpticsKernels.jl
+++ b/src/optics/OpticsKernels.jl
@@ -17,7 +17,7 @@ function compute_optical_props_kernel!(
     ibnd = lkp.major_gpt2bnd[igpt]
 
     compute_optical_props_kernel!(op, as, glay, gcol, sf, igpt, lkp) # longwave gas optics
-    add_cloud_optics_2stream(op, as, lkp, lkp_cld, glay, gcol, ibnd, igpt) # add cloud optics
+    add_cloud_optics_2stream(op, as, lkp, lkp_cld, glay, gcol, ibnd) # add cloud optics
     return nothing
 end
 
@@ -48,7 +48,7 @@ function compute_optical_props_kernel!(
     ibnd = lkp.major_gpt2bnd[igpt]
 
     compute_optical_props_kernel!(op, as, glay, gcol, igpt, lkp) # shortwave gas optics
-    add_cloud_optics_2stream(op, as, lkp, lkp_cld, glay, gcol, ibnd, igpt) # add cloud optics
+    add_cloud_optics_2stream(op, as, lkp, lkp_cld, glay, gcol, ibnd) # add cloud optics
     return nothing
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add @inbounds to cloud optics computations
Restructure `compute_cld_props` interface


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
