### PR TITLE
Store `cos_zenith` instead of `zenith`

### DIFF
--- a/src/optics/BCs.jl
+++ b/src/optics/BCs.jl
@@ -29,8 +29,8 @@ Shortwave boundary conditions
 $(DocStringExtensions.FIELDS)
 """
 struct SwBCs{FT, FTA1D, FTA1DN, FTA2D}
-    "zenith angle `(ncol)`"
-    zenith::FTA1D
+    "cosine of zenith angle `(ncol)`"
+    cos_zenith::FTA1D
     "top of atmosphere flux `(ncol)`"
     toa_flux::FTA1D
     "surface albedo for specular (direct) radiation `(nbnd, ncol)`"
@@ -40,9 +40,9 @@ struct SwBCs{FT, FTA1D, FTA1DN, FTA2D}
     "surface albedo for diffuse radiation `(nbnd, ncol)`"
     sfc_alb_diffuse::FTA2D
 end
-SwBCs(zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse) =
-    SwBCs{eltype(zenith), typeof(zenith), typeof(inc_flux_diffuse), typeof(sfc_alb_direct)}(
-        zenith,
+SwBCs(cos_zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse) =
+    SwBCs{eltype(cos_zenith), typeof(cos_zenith), typeof(inc_flux_diffuse), typeof(sfc_alb_direct)}(
+        cos_zenith,
         toa_flux,
         sfc_alb_direct,
         inc_flux_diffuse,

--- a/src/rte/shortwave1scalar.jl
+++ b/src/rte/shortwave1scalar.jl
@@ -160,13 +160,13 @@ function rte_sw_noscat!(
     gcol::Int,
     nlev::Int,
 ) where {FT <: AbstractFloat}
-    (; toa_flux, zenith) = bcs_sw
+    (; toa_flux, cos_zenith) = bcs_sw
     τ = op.τ
     (; flux_dn_dir, flux_net) = flux
     # downward propagation
-    @inbounds flux_dn_dir[nlev, gcol] = toa_flux[gcol] * solar_frac * cos(zenith[gcol])
+    @inbounds flux_dn_dir[nlev, gcol] = toa_flux[gcol] * solar_frac * cos_zenith[gcol]
     @inbounds for ilev in (nlev - 1):-1:1
-        flux_dn_dir[ilev, gcol] = flux_dn_dir[ilev + 1, gcol] * exp(-τ[ilev, gcol] / cos(zenith[gcol]))
+        flux_dn_dir[ilev, gcol] = flux_dn_dir[ilev + 1, gcol] * exp(-τ[ilev, gcol] / cos_zenith[gcol])
         flux_net[ilev, gcol] = -flux_dn_dir[ilev, gcol]
     end
 end

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -287,9 +287,11 @@ function rte_sw_2stream!(
     gcol::Int,
 ) where {FT}
     nlay = nlev - 1
-    toa_flux = bcs_sw.toa_flux[gcol]
-    sfc_alb_direct = bcs_sw.sfc_alb_direct[ibnd, gcol]
-    μ₀ = cos(bcs_sw.zenith[gcol])
+    @inbounds begin
+        toa_flux = bcs_sw.toa_flux[gcol]
+        sfc_alb_direct = bcs_sw.sfc_alb_direct[ibnd, gcol]
+        μ₀ = bcs_sw.cos_zenith[gcol]
+    end
     τ_sum = FT(0)
     for ilay in 1:nlay
         @inbounds τ_sum += τ[ilay, gcol]

--- a/test/all_sky_utils.jl
+++ b/test/all_sky_utils.jl
@@ -69,7 +69,7 @@ function all_sky(
     close(ds_sw_cld)
     # reading input file 
     ds_in = Dataset(input_file, "r")
-    as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, zenith, toa_flux, bot_at_1 = setup_allsky_as(
+    as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, cos_zenith, toa_flux, bot_at_1 = setup_allsky_as(
         context,
         ds_in,
         idx_gases,
@@ -109,7 +109,7 @@ function all_sky(
     # setting up boundary conditions
     inc_flux_diffuse = nothing
 
-    bcs_sw = SwBCs(zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse)
+    bcs_sw = SwBCs(cos_zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse)
 
     fluxb_sw = FluxSW(ncol, nlay, FT, DA) # flux storage for bandwise calculations
     flux_sw = FluxSW(ncol, nlay, FT, DA)  # shortwave fluxes for band calculations    

--- a/test/clear_sky_utils.jl
+++ b/test/clear_sky_utils.jl
@@ -66,7 +66,7 @@ function clear_sky(
     # reading rfmip data to atmospheric state
     ds_lw_in = Dataset(input_file, "r")
 
-    (as, sfc_emis, sfc_alb_direct, zenith, toa_flux, usecol) =
+    (as, sfc_emis, sfc_alb_direct, cos_zenith, toa_flux, usecol) =
         setup_rfmip_as(context, ds_lw_in, idx_gases, exp_no, lookup_lw, FT, VMR, max_threads, param_set)
     close(ds_lw_in)
 
@@ -86,7 +86,7 @@ function clear_sky(
     src_sw = source_func_shortwave(FT, ncol, nlay, opc, DA)        # allocating shortwave source function object
     inc_flux_diffuse = nothing
     sfc_alb_diffuse = FTA2D(deepcopy(sfc_alb_direct))
-    bcs_sw = SwBCs(zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse)
+    bcs_sw = SwBCs(cos_zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse)
 
     fluxb_sw = FluxSW(ncol, nlay, FT, DA) # flux storage for bandwise calculations
     flux_sw = FluxSW(ncol, nlay, FT, DA)  # shortwave fluxes for band calculations

--- a/test/read_all_sky.jl
+++ b/test/read_all_sky.jl
@@ -41,13 +41,13 @@ function setup_allsky_as(
     sfc_emis = DA{FT, 2}(undef, nbnd_lw, ncol)
     sfc_alb_direct = DA{FT, 2}(undef, nbnd_sw, ncol)
     sfc_alb_diffuse = DA{FT, 2}(undef, nbnd_sw, ncol)
-    zenith = DA{FT, 1}(undef, ncol)
+    cos_zenith = DA{FT, 1}(undef, ncol)
     irrad = DA{FT, 1}(undef, ncol)
     # these values are taken from the example
     sfc_emis .= FT(0.98)
     sfc_alb_direct .= FT(0.06)
     sfc_alb_diffuse .= FT(0.06)
-    zenith .= acos(FT(0.86))
+    cos_zenith .= FT(0.86)
     irrad .= FT(lkp_sw.solar_src_tot)
 
 
@@ -181,7 +181,7 @@ function setup_allsky_as(
         sfc_emis,
         sfc_alb_direct,
         sfc_alb_diffuse,
-        zenith,
+        cos_zenith,
         irrad,
         bot_at_1,
     )

--- a/test/read_rfmip_clear_sky.jl
+++ b/test/read_rfmip_clear_sky.jl
@@ -43,7 +43,7 @@ function setup_rfmip_as(
         end
     end
 
-    zenith = DA{FT, 1}(zenith)
+    cos_zenith = DA{FT, 1}(cos.(zenith))
     irrad = DA{FT, 1}(irrad)
     #--------------------------------------------------------------
 
@@ -157,7 +157,7 @@ function setup_rfmip_as(
         ),
         sfc_emis,
         sfc_alb,
-        zenith,
+        cos_zenith,
         irrad,
         usecol,
     )

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -47,7 +47,7 @@ function sw_rfmip(context, ::Type{OPC}, ::Type{SRC}, ::Type{VMR}, ::Type{FT}) wh
     # reading rfmip data to atmospheric state
     ds_sw_in = Dataset(sw_input_file, "r")
 
-    (as, _, sfc_alb_direct, zenith, toa_flux, usecol) =
+    (as, _, sfc_alb_direct, cos_zenith, toa_flux, usecol) =
         setup_rfmip_as(context, ds_sw_in, idx_gases, exp_no, lookup_sw, FT, VMR, max_threads, param_set)
     close(ds_sw_in)
 
@@ -60,7 +60,7 @@ function sw_rfmip(context, ::Type{OPC}, ::Type{SRC}, ::Type{VMR}, ::Type{FT}) wh
     # setting up boundary conditions
     inc_flux_diffuse = nothing
     sfc_alb_diffuse = FTA2D(deepcopy(sfc_alb_direct))
-    bcs_sw = SwBCs{FT, FTA1D, Nothing, FTA2D}(zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse)
+    bcs_sw = SwBCs{FT, FTA1D, Nothing, FTA2D}(cos_zenith, toa_flux, sfc_alb_direct, inc_flux_diffuse, sfc_alb_diffuse)
     fluxb_sw = FluxSW(ncol, nlay, FT, DA) # flux storage for bandwise calculations
     flux_sw = FluxSW(ncol, nlay, FT, DA)  # shortwave fluxes for band calculations
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Store `cos_zenith` instead of `zenith` in shortwave boundary conditions

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
