### PR TITLE
Store `ln(p_ref)` instead of `p_ref` in lookup tables

### DIFF
--- a/src/optics/GasOptics.jl
+++ b/src/optics/GasOptics.jl
@@ -60,11 +60,11 @@ end
 
 Compute interpolation fraction for pressure.
 """
-@inline function compute_interp_frac_press(Δ_ln_p_ref, p_ref, n_p_ref, p_lay, tropo)
+@inline function compute_interp_frac_press(Δ_ln_p_ref, ln_p_ref, n_p_ref, p_lay, tropo)
     log_p_lay = log(p_lay)
-    @inbounds jpress = Int(min(max(fld(log(p_ref[1]) - log_p_lay, Δ_ln_p_ref) + 1, 1), n_p_ref - 1) + 1)
+    @inbounds jpress = Int(min(max(fld(ln_p_ref[1] - log_p_lay, Δ_ln_p_ref) + 1, 1), n_p_ref - 1) + 1)
 
-    @inbounds fpress = (log(p_ref[jpress - 1]) - log_p_lay) / Δ_ln_p_ref
+    @inbounds fpress = (ln_p_ref[jpress - 1] - log_p_lay) / Δ_ln_p_ref
     jpress = jpress + tropo - 1
 
     return (jpress, fpress)
@@ -141,8 +141,8 @@ Compute optical thickness, single scattering albedo, and asymmetry parameter.
     (; Δ_t_ref, n_t_ref, t_ref) = lkp
     jftemp = compute_interp_frac_temp(Δ_t_ref, n_t_ref, t_ref, t_lay)
 
-    (; Δ_ln_p_ref, p_ref, n_p_ref) = lkp
-    jfpress = compute_interp_frac_press(Δ_ln_p_ref, p_ref, n_p_ref, p_lay, tropo)
+    (; Δ_ln_p_ref, ln_p_ref, n_p_ref) = lkp
+    jfpress = compute_interp_frac_press(Δ_ln_p_ref, ln_p_ref, n_p_ref, p_lay, tropo)
 
     (; n_η, vmr_ref) = lkp
     ig = view(lkp.key_species, 1:2, tropo, ibnd)
@@ -307,8 +307,8 @@ Computes Planck sources for the longwave problem.
     (; Δ_t_ref, n_t_ref, t_ref) = lkp
     jtemp, ftemp = compute_interp_frac_temp(Δ_t_ref, n_t_ref, t_ref, t_lay)
 
-    (; Δ_ln_p_ref, p_ref, n_p_ref) = lkp
-    jpresst, fpress = compute_interp_frac_press(Δ_ln_p_ref, p_ref, n_p_ref, p_lay, tropo)
+    (; Δ_ln_p_ref, ln_p_ref, n_p_ref) = lkp
+    jpresst, fpress = compute_interp_frac_press(Δ_ln_p_ref, ln_p_ref, n_p_ref, p_lay, tropo)
 
     (; n_η, vmr_ref) = lkp
     ig = view(lkp.key_species, 1:2, tropo, ibnd)
@@ -334,8 +334,8 @@ end
     (; Δ_t_ref, n_t_ref, t_ref) = lkp
     jtemp, ftemp = compute_interp_frac_temp(Δ_t_ref, n_t_ref, t_ref, t_lay)
 
-    (; Δ_ln_p_ref, p_ref, n_p_ref) = lkp
-    jpresst, fpress = compute_interp_frac_press(Δ_ln_p_ref, p_ref, n_p_ref, p_lay, tropo)
+    (; Δ_ln_p_ref, ln_p_ref, n_p_ref) = lkp
+    jpresst, fpress = compute_interp_frac_press(Δ_ln_p_ref, ln_p_ref, n_p_ref, p_lay, tropo)
 
     (; n_η, vmr_ref) = lkp
     ig = view(lkp.key_species, 1:2, tropo, ibnd)

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -129,8 +129,8 @@ struct LookUpLW{
     lower_scale_by_complement::IA1D
     "minor gas (upper atmosphere) scales by compliment `(n_min_absrb_upper)`"
     upper_scale_by_complement::IA1D
-    "reference pressures used by the lookup table `(n_p_ref)`"
-    p_ref::FTA1D
+    "log of reference pressures used by the lookup table `(n_p_ref)`"
+    ln_p_ref::FTA1D
     "reference temperatures used by the lookup table `(n_t_ref)`"
     t_ref::FTA1D
     "reference volume mixing ratios used by the lookup table `(2, n_gases, n_t_ref)`"
@@ -333,7 +333,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     Δ_t_ref = t_ref[2] - t_ref[1]
     Δ_ln_p_ref = log(p_ref[1]) - log(p_ref[2])
 
-    p_ref = FTA1D(p_ref)
+    ln_p_ref = FTA1D(log.(p_ref))
     t_ref = FTA1D(t_ref)
     vmr_ref = FTA3D(Array(ds["vmr_ref"]))
 
@@ -391,7 +391,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
             minor_upper_scales_with_density,
             lower_scale_by_complement,
             upper_scale_by_complement,
-            p_ref,
+            ln_p_ref,
             t_ref,
             vmr_ref,
         ),
@@ -510,8 +510,8 @@ struct LookUpSW{
     lower_scale_by_complement::IA1D
     "minor gas (upper atmosphere) scales by compliment `(n_min_absrb_upper)`"
     upper_scale_by_complement::IA1D
-    "reference pressures used by the lookup table `(n_p_ref)`"
-    p_ref::FTA1D
+    "log of reference pressures used by the lookup table `(n_p_ref)`"
+    ln_p_ref::FTA1D
     "reference temperatures used by the lookup table `(n_t_ref)`"
     t_ref::FTA1D
     "reference volume mixing ratios used by the lookup table `(2, n_gases, n_t_ref)`"
@@ -711,7 +711,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     Δ_t_ref = t_ref[2] - t_ref[1]
     Δ_ln_p_ref = log(p_ref[1]) - log(p_ref[2])
 
-    p_ref = FTA1D(p_ref)
+    ln_p_ref = FTA1D(log.(p_ref))
     t_ref = FTA1D(t_ref)
     vmr_ref = FTA3D(Array(ds["vmr_ref"]))
 
@@ -773,7 +773,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
             minor_upper_scales_with_density,
             lower_scale_by_complement,
             upper_scale_by_complement,
-            p_ref,
+            ln_p_ref,
             t_ref,
             vmr_ref,
             rayl_lower,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Store `ln(p_ref)` instead of `p_ref` in lookup tables

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
