### PR TITLE
Add rrtmgp-lookup-data artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,6 @@
+[rrtmgp-lookup-data]
+git-tree-sha1 = "9a2a6c0f3934a2328502635dfc7927e20b9d6327"
+
+    [[rrtmgp-lookup-data.download]]
+    url = "https://data.caltech.edu/records/ppv8a-4q131/files/rrtmgp-lookup-data.tar.gz?download=1"
+    sha256 = "f5003a657559cce4fca6cff1d6b2e9fd3f744e656cd7aa434903e7e753650260"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.10.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -14,6 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Adapt = "3.3"
+Artifacts = "1"
 CUDA = "4, 5"
 ClimaComms = "0.5.1"
 DocStringExtensions = "0.8, 0.9"

--- a/artifacts/rrtmgp-lookup-data/.gitignore
+++ b/artifacts/rrtmgp-lookup-data/.gitignore
@@ -1,0 +1,2 @@
+!Manifest.toml
+*.tar.gz

--- a/artifacts/rrtmgp-lookup-data/Manifest.toml
+++ b/artifacts/rrtmgp-lookup-data/Manifest.toml
@@ -1,0 +1,137 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.0"
+manifest_format = "2.0"
+project_hash = "e9a44db05df01f368f2022ded4412f72c4fbaea1"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.4.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+1"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.1.10"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.10.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.52.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/artifacts/rrtmgp-lookup-data/Project.toml
+++ b/artifacts/rrtmgp-lookup-data/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/artifacts/rrtmgp-lookup-data/README.md
+++ b/artifacts/rrtmgp-lookup-data/README.md
@@ -1,0 +1,15 @@
+# RRTMGP lookup data
+
+This is repackaged data from v1.0 of [rte-rrtmgp](https://github.com/earth-system-radiation/rte-rrtmgp), 
+
+> Robert Pincus, Benjamin R. Hillman, Matt Norman, fomics, & Chiel van Heerwaarden. (2019). RobertPincus/rte-rrtmgp: (Re-)release for 10.1029/2019MS001621 (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.3403173
+
+suitable for use as a Julia artifact with RRTMGP.jl
+
+Specifically
+- `rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc` => `clearsky_lw.nc`
+- `rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc` => `clearsky_sw.nc`
+- `extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc` => `cloudysky_lw.nc`
+- `extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-sw.nc` => `cloudysky_sw.nc`
+
+Note: data for versions up to v1.6 are stored in the above repository; data for later versions are stored in a separate repository https://github.com/earth-system-radiation/rrtmgp-data.

--- a/artifacts/rrtmgp-lookup-data/create_artifact.jl
+++ b/artifacts/rrtmgp-lookup-data/create_artifact.jl
@@ -1,0 +1,32 @@
+using Pkg.Artifacts, Downloads
+
+rrtmgp_repo = "https://github.com/earth-system-radiation/rte-rrtmgp"
+rrtmgp_commit_sha1 = "ed5b0113109fcd23a010a90c61f21bad551146ef" # v1.0
+
+
+artifact_tree_sha1 = create_artifact() do dir
+    Downloads.download(
+        "$rrtmgp_repo/raw/$rrtmgp_commit_sha1/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc",
+        joinpath(dir, "clearsky_lw.nc"),
+    )
+    Downloads.download(
+        "$rrtmgp_repo/raw/$rrtmgp_commit_sha1/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc",
+        joinpath(dir, "clearsky_sw.nc"),
+    )
+    Downloads.download(
+        "$rrtmgp_repo/raw/$rrtmgp_commit_sha1/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc",
+        joinpath(dir, "cloudysky_lw.nc"),
+    )
+    Downloads.download(
+        "$rrtmgp_repo/raw/$rrtmgp_commit_sha1/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-sw.nc",
+        joinpath(dir, "cloudysky_sw.nc"),
+    )
+
+    cp(joinpath(@__DIR__, "README.md"), joinpath(dir, "README.md"))
+end
+
+artifact_path = joinpath(@__DIR__, "rrtmgp-lookup-data.tar.gz")
+
+artifact_archive_sha256 = archive_artifact(artifact_tree_sha1, artifact_path)
+
+@info "Created artifact" artifact_path artifact_tree_sha1 artifact_archive_sha256

--- a/src/RRTMGP.jl
+++ b/src/RRTMGP.jl
@@ -1,5 +1,8 @@
 module RRTMGP
 
+using Artifacts
+lookup_data() = artifact"rrtmgp-lookup-data"
+
 # we may be hitting a slow path:
 # https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1
 pow_fast(x, y) = exp(y * log(x))

--- a/test/reference_files.jl
+++ b/test/reference_files.jl
@@ -39,6 +39,11 @@ function get_ref_filename(ftype, optics_type; λ = nothing, opc = nothing, flux_
             fname *= "_" * String(lut_pade)
         end
     end
+    if ftype == :lookup_tables
+        dir = RRTMGP.lookup_data()
+    else
+        dir = joinpath(artifact"RRTMGPReferenceData", "RRTMGPReferenceData", String(ftype))
+    end
 
-    return joinpath(artifact"RRTMGPReferenceData", "RRTMGPReferenceData", String(ftype), fname * ".nc")
+    return joinpath(dir, fname * ".nc")
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds script for creating RRTMGP lookup data tables artifact, and adds this to the package Artifacts.toml.

Fixes #401 (does not deal with test data, as this is not needed for the main project).


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
