### PR TITLE
Swap dimensions for some lookup data

### DIFF
--- a/src/optics/GasOptics.jl
+++ b/src/optics/GasOptics.jl
@@ -136,10 +136,12 @@ Compute optical thickness, single scattering albedo, and asymmetry parameter.
 
     jfη, col_mix = compute_interp_frac_η(n_η, ig, vmr_ref, (vmr1, vmr2), tropo, jftemp[1])
     # compute Planck fraction
-    pfrac = interp3d(jfη..., jftemp..., jfpress..., lkp.planck_fraction, igpt)
+    @inbounds planck_fraction = view(lkp.planck_fraction, :, :, :, igpt)
+    pfrac = interp3d(jfη..., jftemp..., jfpress..., planck_fraction)
 
     # computing τ_major
-    τ_major = interp3d(jfη..., jftemp..., jfpress..., lkp.kmajor, igpt, col_mix...) * col_dry
+    @inbounds kmajor = view(lkp.kmajor, :, :, :, igpt)
+    τ_major = interp3d(jfη..., jftemp..., jfpress..., kmajor, col_mix...) * col_dry
     # computing τ_minor
     τ_minor =
         compute_τ_minor(lkp, tropo, vmr, vmr_h2o, col_dry, p_lay, t_lay, jftemp..., jfη..., igpt, ibnd, glay, gcol)
@@ -168,7 +170,8 @@ end
     jfη, col_mix = compute_interp_frac_η(n_η, ig, vmr_ref, (vmr1, vmr2), tropo, jftemp[1])
 
     # computing τ_major
-    τ_major = interp3d(jfη..., jftemp..., jfpress..., lkp.kmajor, igpt, col_mix...) * col_dry
+    @inbounds kmajor = view(lkp.kmajor, :, :, :, igpt)
+    τ_major = interp3d(jfη..., jftemp..., jfpress..., kmajor, col_mix...) * col_dry
     # computing τ_minor
     τ_minor =
         compute_τ_minor(lkp, tropo, vmr, vmr_h2o, col_dry, p_lay, t_lay, jftemp..., jfη..., igpt, ibnd, glay, gcol)

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -87,9 +87,9 @@ struct LookUpLW{
     key_species::IA3D
     "major absorption coefficient `(n_gpt, n_η, n_p_ref, n_t_ref)`"
     kmajor::FTA4D
-    "minor absorption coefficient in lower atmosphere `(n_contrib_lower, n_η, n_t_ref)`"
+    "minor absorption coefficient in lower atmosphere `(n_η, n_t_ref, n_contrib_lower)`"
     kminor_lower::FTA3D
-    "minor absorption coefficient in upper atmosphere `(n_contrib_upper, n_η, n_t_ref)`"
+    "minor absorption coefficient in upper atmosphere `(n_η, n_t_ref, n_contrib_upper)`"
     kminor_upper::FTA3D
     kminor_start_lower::IA1D # not currently used
     kminor_start_upper::IA1D # not currently used
@@ -241,8 +241,8 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     key_species = IA3D(key_species)
 
     kmajor = FTA4D(Array(ds["kmajor"]))
-    kminor_lower = FTA3D(Array(ds["kminor_lower"]))
-    kminor_upper = FTA3D(Array(ds["kminor_upper"]))
+    kminor_lower = FTA3D(permutedims(Array(ds["kminor_lower"]), [2, 3, 1]))
+    kminor_upper = FTA3D(permutedims(Array(ds["kminor_upper"]), [2, 3, 1]))
     kminor_start_lower = IA1D(Array(ds["kminor_start_lower"]))
     kminor_start_upper = IA1D(Array(ds["kminor_start_upper"]))
 
@@ -474,9 +474,9 @@ struct LookUpSW{
     key_species::IA3D
     "major absorption coefficient `(n_gpt, n_η, n_p_ref, n_t_ref)`"
     kmajor::FTA4D
-    "minor absorption coefficient in lower atmosphere `(n_contrib_lower, n_η, n_t_ref)`"
+    "minor absorption coefficient in lower atmosphere `(n_η, n_t_ref, n_contrib_lower)`"
     kminor_lower::FTA3D
-    "minor absorption coefficient in upper atmosphere `(n_contrib_upper, n_η, n_t_ref)`"
+    "minor absorption coefficient in upper atmosphere `(n_η, n_t_ref, n_contrib_upper)`"
     kminor_upper::FTA3D
     kminor_start_lower::IA1D # not currently used
     kminor_start_upper::IA1D # not currently used
@@ -516,9 +516,9 @@ struct LookUpSW{
     t_ref::FTA1D
     "reference volume mixing ratios used by the lookup table `(2, n_gases, n_t_ref)`"
     vmr_ref::FTA3D
-    "Rayleigh absorption coefficient for lower atmosphere `(n_gpt, n_η, n_t_ref)`"
+    "Rayleigh absorption coefficient for lower atmosphere `(n_η, n_t_ref, n_gpt)`"
     rayl_lower::FTA3D
-    "Rayleigh absorption coefficient for upper atmosphere `(n_gpt, n_η, n_t_ref)`"
+    "Rayleigh absorption coefficient for upper atmosphere `(n_η, n_t_ref, n_gpt)`"
     rayl_upper::FTA3D
     "relative solar source contribution from each `g-point` `(n_gpt)`"
     solar_src_scaled::FTA1D
@@ -625,8 +625,8 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     key_species = IA3D(key_species)
 
     kmajor = FTA4D(Array(ds["kmajor"]))
-    kminor_lower = FTA3D(Array(ds["kminor_lower"]))
-    kminor_upper = FTA3D(Array(ds["kminor_upper"]))
+    kminor_lower = FTA3D(permutedims(Array(ds["kminor_lower"]), [2, 3, 1]))
+    kminor_upper = FTA3D(permutedims(Array(ds["kminor_upper"]), [2, 3, 1]))
     kminor_start_lower = IA1D(Array(ds["kminor_start_lower"]))
     kminor_start_upper = IA1D(Array(ds["kminor_start_upper"]))
 
@@ -717,8 +717,8 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     n_η = size(kmajor, 2)
 
-    rayl_lower = FTA3D(Array(ds["rayl_lower"]))
-    rayl_upper = FTA3D(Array(ds["rayl_upper"]))
+    rayl_lower = FTA3D(permutedims(Array(ds["rayl_lower"]), [2, 3, 1]))
+    rayl_upper = FTA3D(permutedims(Array(ds["rayl_upper"]), [2, 3, 1]))
 
     solar_src = Array(ds["solar_source"])
     solar_src_tot = FT(sum(solar_src))

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -85,7 +85,7 @@ struct LookUpLW{
     idx_scaling_gas_upper::IA1D
     "major absorbing species in each band `(2, n_atmos_layers, n_bnd)`"
     key_species::IA3D
-    "major absorption coefficient `(n_gpt, n_η, n_p_ref, n_t_ref)`"
+    "major absorption coefficient `(n_η, n_p_ref, n_t_ref, n_gpt)`"
     kmajor::FTA4D
     "minor absorption coefficient in lower atmosphere `(n_η, n_t_ref, n_contrib_lower)`"
     kminor_lower::FTA3D
@@ -93,7 +93,7 @@ struct LookUpLW{
     kminor_upper::FTA3D
     kminor_start_lower::IA1D # not currently used
     kminor_start_upper::IA1D # not currently used
-    "Planck fraction `(n_gpt, n_η, n_p_ref, n_t_ref)`"
+    "Planck fraction `(n_η, n_p_ref, n_t_ref, n_gpt)`"
     planck_fraction::FTA4D
     "reference temperatures for Planck source calculations `(n_t_plnk)`"
     t_planck::FTA1D
@@ -240,13 +240,13 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     key_species = IA3D(key_species)
 
-    kmajor = FTA4D(Array(ds["kmajor"]))
+    kmajor = FTA4D(permutedims(Array(ds["kmajor"]), [2, 3, 4, 1]))
     kminor_lower = FTA3D(permutedims(Array(ds["kminor_lower"]), [2, 3, 1]))
     kminor_upper = FTA3D(permutedims(Array(ds["kminor_upper"]), [2, 3, 1]))
     kminor_start_lower = IA1D(Array(ds["kminor_start_lower"]))
     kminor_start_upper = IA1D(Array(ds["kminor_start_upper"]))
 
-    planck_fraction = FTA4D(Array(ds["plank_fraction"]))
+    planck_fraction = FTA4D(permutedims(Array(ds["plank_fraction"]), [2, 3, 4, 1]))
     t_planck = FTA1D(Array(ds["temperature_Planck"]))
 
     totplnk = FTA2D(Array(ds["totplnk"]))
@@ -337,7 +337,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     t_ref = FTA1D(t_ref)
     vmr_ref = FTA3D(Array(ds["vmr_ref"]))
 
-    n_η = size(kmajor, 2)
+    n_η = size(kmajor, 1)
 
     return (
         LookUpLW{FT, UI8A1D, IA1D, IA2D, IA3D, FTA1D, FTA2D, FTA3D, FTA4D}(
@@ -472,7 +472,7 @@ struct LookUpSW{
     idx_scaling_gas_upper::IA1D
     "major absorbing species in each band `(2, n_atmos_layers, n_bnd)`"
     key_species::IA3D
-    "major absorption coefficient `(n_gpt, n_η, n_p_ref, n_t_ref)`"
+    "major absorption coefficient `(n_η, n_p_ref, n_t_ref, n_gpt)`"
     kmajor::FTA4D
     "minor absorption coefficient in lower atmosphere `(n_η, n_t_ref, n_contrib_lower)`"
     kminor_lower::FTA3D
@@ -624,7 +624,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     key_species = IA3D(key_species)
 
-    kmajor = FTA4D(Array(ds["kmajor"]))
+    kmajor = FTA4D(permutedims(Array(ds["kmajor"]), [2, 3, 4, 1]))
     kminor_lower = FTA3D(permutedims(Array(ds["kminor_lower"]), [2, 3, 1]))
     kminor_upper = FTA3D(permutedims(Array(ds["kminor_upper"]), [2, 3, 1]))
     kminor_start_lower = IA1D(Array(ds["kminor_start_lower"]))
@@ -715,7 +715,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     t_ref = FTA1D(t_ref)
     vmr_ref = FTA3D(Array(ds["vmr_ref"]))
 
-    n_η = size(kmajor, 2)
+    n_η = size(kmajor, 1)
 
     rayl_lower = FTA3D(permutedims(Array(ds["rayl_lower"]), [2, 3, 1]))
     rayl_upper = FTA3D(permutedims(Array(ds["rayl_upper"]), [2, 3, 1]))

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -153,17 +153,18 @@ Computes optical properties for the longwave problem.
     lkp_cld::Union{LookUpCld, PadeCld, Nothing} = nothing,
 )
     (; nlay, vmr) = as
-    (; t_planck, totplnk) = lkp
+    (; t_planck) = lkp
     (; lay_source, lev_source_inc, lev_source_dec, sfc_source) = sf
-    @inbounds t_sfc = as.t_sfc[gcol]
-    @inbounds ibnd = lkp.major_gpt2bnd[igpt]
-    col_dry_col = view(as.col_dry, :, gcol)
-    p_lay_col = view(as.p_lay, :, gcol)
-    t_lay_col = view(as.t_lay, :, gcol)
-    t_lev_col = view(as.t_lev, :, gcol)
-    τ = view(op.τ, :, gcol)
-
     @inbounds begin
+        t_sfc = as.t_sfc[gcol]
+        ibnd = lkp.major_gpt2bnd[igpt]
+        totplnk = view(lkp.totplnk, :, ibnd)
+        col_dry_col = view(as.col_dry, :, gcol)
+        p_lay_col = view(as.p_lay, :, gcol)
+        t_lay_col = view(as.t_lay, :, gcol)
+        t_lev_col = view(as.t_lev, :, gcol)
+        τ = view(op.τ, :, gcol)
+
         t_lev_dec = t_lev_col[1]
         for glay in 1:nlay
             col_dry = col_dry_col[glay]
@@ -174,11 +175,11 @@ Computes optical properties for the longwave problem.
             # compute longwave source terms
             t_lev_inc = t_lev_col[glay + 1]
 
-            lay_source[glay, gcol] = interp1d(t_lay, t_planck, totplnk, ibnd) * planckfrac
-            lev_source_inc[glay, gcol] = interp1d(t_lev_inc, t_planck, totplnk, ibnd) * planckfrac
-            lev_source_dec[glay, gcol] = interp1d(t_lev_dec, t_planck, totplnk, ibnd) * planckfrac
+            lay_source[glay, gcol] = interp1d(t_lay, t_planck, totplnk) * planckfrac
+            lev_source_inc[glay, gcol] = interp1d(t_lev_inc, t_planck, totplnk) * planckfrac
+            lev_source_dec[glay, gcol] = interp1d(t_lev_dec, t_planck, totplnk) * planckfrac
             if glay == 1
-                sfc_source[gcol] = interp1d(t_sfc, t_planck, totplnk, ibnd) * planckfrac
+                sfc_source[gcol] = interp1d(t_sfc, t_planck, totplnk) * planckfrac
             end
             t_lev_dec = t_lev_inc
         end
@@ -196,17 +197,20 @@ end
     lkp_cld::Union{LookUpCld, PadeCld, Nothing} = nothing,
 )
     (; nlay, vmr) = as
-    (; t_planck, totplnk) = lkp
+    (; t_planck) = lkp
     (; lev_source, sfc_source) = sf
-    @inbounds t_sfc = as.t_sfc[gcol]
-    @inbounds ibnd = lkp.major_gpt2bnd[igpt]
-    col_dry_col = view(as.col_dry, :, gcol)
-    p_lay_col = view(as.p_lay, :, gcol)
-    t_lay_col = view(as.t_lay, :, gcol)
-    t_lev_col = view(as.t_lev, :, gcol)
-    τ = view(op.τ, :, gcol)
-    ssa = view(op.ssa, :, gcol)
-    g = view(op.g, :, gcol)
+    @inbounds begin
+        t_sfc = as.t_sfc[gcol]
+        ibnd = lkp.major_gpt2bnd[igpt]
+        totplnk = view(lkp.totplnk, :, ibnd)
+        col_dry_col = view(as.col_dry, :, gcol)
+        p_lay_col = view(as.p_lay, :, gcol)
+        t_lay_col = view(as.t_lay, :, gcol)
+        t_lev_col = view(as.t_lev, :, gcol)
+        τ = view(op.τ, :, gcol)
+        ssa = view(op.ssa, :, gcol)
+        g = view(op.g, :, gcol)
+    end
 
     lev_src_inc_prev = zero(t_sfc)
     lev_src_dec_prev = zero(t_sfc)
@@ -223,10 +227,10 @@ end
             # compute longwave source terms
             t_lev_inc = t_lev_col[glay + 1]
 
-            lev_src_inc = interp1d(t_lev_inc, t_planck, totplnk, ibnd) * planckfrac
-            lev_src_dec = interp1d(t_lev_dec, t_planck, totplnk, ibnd) * planckfrac
+            lev_src_inc = interp1d(t_lev_inc, t_planck, totplnk) * planckfrac
+            lev_src_dec = interp1d(t_lev_dec, t_planck, totplnk) * planckfrac
             if glay == 1
-                sfc_source[gcol] = interp1d(t_sfc, t_planck, totplnk, ibnd) * planckfrac
+                sfc_source[gcol] = interp1d(t_sfc, t_planck, totplnk) * planckfrac
                 lev_source[glay, gcol] = lev_src_dec
             else
                 lev_source[glay, gcol] = sqrt(lev_src_inc_prev * lev_src_dec)

--- a/src/optics/OpticsUtils.jl
+++ b/src/optics/OpticsUtils.jl
@@ -2,16 +2,16 @@
 @inline loc_lower(xi, Δx, n, x) = @inbounds max(min(unsafe_trunc(Int, (xi - x[1]) / Δx) + 1, n - 1), 1)
 
 """
-    interp1d(xi::FT, x, y, col) where {FT<:AbstractFloat}
+    interp1d(xi::FT, x, y) where {FT<:AbstractFloat}
 
 perform 1D linear interpolation.
 """
-@inline function interp1d(xi::FT, x, y, col) where {FT <: AbstractFloat}
+@inline function interp1d(xi::FT, x, y) where {FT <: AbstractFloat}
     @inbounds Δx = x[2] - x[1]
     n = length(x)
     loc = loc_lower(xi, Δx, n, x)
     @inbounds factor = (xi - x[loc]) / Δx
-    return @inbounds (y[loc, col] * (FT(1) - factor) + y[loc + 1, col] * factor)
+    return @inbounds (y[loc] * (FT(1) - factor) + y[loc + 1] * factor)
 end
 
 """

--- a/src/optics/OpticsUtils.jl
+++ b/src/optics/OpticsUtils.jl
@@ -19,12 +19,11 @@ end
         fη1::FT,
         fη2::FT,
         ftemp::FT,
-        coeff::FTA3D,
-        igpt::Int,
+        coeff::FTA2D,
         jη1::Int,
         jη2::Int,
         jtemp::Int,
-    ) where {FT<:AbstractFloat,FTA3D<:AbstractArray{FT,3}}
+    ) where {FT,FTA2D}
 
 Perform 2D linear interpolation.
 
@@ -36,20 +35,11 @@ Perform 2D linear interpolation.
 
 `fminor[2, 2] = fη2 * ftemp`
 """
-@inline function interp2d(
-    fη1::FT,
-    fη2::FT,
-    ftemp::FT,
-    coeff::FTA3D,
-    igpt::Int,
-    jη1::Int,
-    jη2::Int,
-    jtemp::Int,
-) where {FT <: AbstractFloat, FTA3D <: AbstractArray{FT, 3}}
-    return @inbounds (FT(1) - fη1) * (1 - ftemp) * coeff[igpt, jη1, jtemp] +
-                     fη1 * (1 - ftemp) * coeff[igpt, jη1 + 1, jtemp] +
-                     (FT(1) - fη2) * ftemp * coeff[igpt, jη2, jtemp + 1] +
-                     fη2 * ftemp * coeff[igpt, jη2 + 1, jtemp + 1]
+@inline function interp2d(fη1::FT, fη2::FT, ftemp::FT, coeff::FTA2D, jη1::Int, jη2::Int, jtemp::Int) where {FT, FTA2D}
+    return @inbounds (FT(1) - fη1) * (1 - ftemp) * coeff[jη1, jtemp] +
+                     fη1 * (1 - ftemp) * coeff[jη1 + 1, jtemp] +
+                     (FT(1) - fη2) * ftemp * coeff[jη2, jtemp + 1] +
+                     fη2 * ftemp * coeff[jη2 + 1, jtemp + 1]
 end
 
 """

--- a/src/optics/OpticsUtils.jl
+++ b/src/optics/OpticsUtils.jl
@@ -52,8 +52,7 @@ end
         ftemp::FT,
         jpresst::Int,
         fpress::FT,
-        coeff::FTA4D,
-        igpt::Int,
+        coeff::FTA3D,
         s1::FT = FT(1),
         s2::FT = FT(1),
     ) where {FT<:AbstractFloat,FTA4D<:AbstractArray{FT,4}}
@@ -88,27 +87,22 @@ where,
     ftemp::FT,
     jpresst::Int,
     fpress::FT,
-    coeff::FTA4D,
-    igpt::Int,
+    coeff::FTA3D,
     s1::FT = FT(1),
     s2::FT = FT(1),
-) where {FT <: AbstractFloat, FTA4D <: AbstractArray{FT, 4}}
+) where {FT, FTA3D}
     omftemp = FT(1) - ftemp
     omfpress = FT(1) - fpress
     omfη1 = FT(1) - fη1
     omfη2 = FT(1) - fη2
     return @inbounds s1 * (
-        omfpress *
-        (omftemp * (omfη1 * coeff[igpt, jη1, jpresst - 1, jtemp] + fη1 * coeff[igpt, jη1 + 1, jpresst - 1, jtemp])) +
-        fpress * (omftemp * (omfη1 * coeff[igpt, jη1, jpresst, jtemp] + fη1 * coeff[igpt, jη1 + 1, jpresst, jtemp]))
+        omfpress * (omftemp * (omfη1 * coeff[jη1, jpresst - 1, jtemp] + fη1 * coeff[jη1 + 1, jpresst - 1, jtemp])) +
+        fpress * (omftemp * (omfη1 * coeff[jη1, jpresst, jtemp] + fη1 * coeff[jη1 + 1, jpresst, jtemp]))
     ) +
                      s2 * (
-        omfpress * (
-            ftemp *
-            (omfη2 * coeff[igpt, jη2, jpresst - 1, jtemp + 1] + fη2 * coeff[igpt, jη2 + 1, jpresst - 1, jtemp + 1])
-        ) +
-        fpress *
-        (ftemp * (omfη2 * coeff[igpt, jη2, jpresst, jtemp + 1] + fη2 * coeff[igpt, jη2 + 1, jpresst, jtemp + 1]))
+        omfpress *
+        (ftemp * (omfη2 * coeff[jη2, jpresst - 1, jtemp + 1] + fη2 * coeff[jη2 + 1, jpresst - 1, jtemp + 1])) +
+        fpress * (ftemp * (omfη2 * coeff[jη2, jpresst, jtemp + 1] + fη2 * coeff[jη2 + 1, jpresst, jtemp + 1]))
     )
 end
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Swap dimensions for `kmajor`, `kminor_upper`, `kminor_lower`, `planck_fraction`, `rayl_lower` and `rayl_upper` to move `igpt/ibnd` to the last dimension.
Update `interp1d`, `interp2d` and `interp3d` accordingly.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
