### PR TITLE
Simplify type parameters for `AtmosphericState`

### DIFF
--- a/src/optics/AtmosphericStates.jl
+++ b/src/optics/AtmosphericStates.jl
@@ -19,7 +19,7 @@ export AbstractAtmosphericState,
     GrayOpticalThicknessOGorman2008,
     AbstractGrayOpticalThickness
 
-abstract type AbstractAtmosphericState{FT, FTA1D} end
+abstract type AbstractAtmosphericState end
 
 include("GrayAtmosphericStates.jl")
 
@@ -29,24 +29,15 @@ struct MaxRandomOverlap <: AbstractCloudMask end
 Adapt.@adapt_structure MaxRandomOverlap
 
 """
-    AtmosphericState{FT,FTA1D,FTA1DN,FTA2D,CLDP,CLDM,VMR} <:
-        AbstractAtmosphericState{FT,FTA1D}
+    AtmosphericState{FTA1D,FTA1DN,FTA2D,CLDP,CLDM,VMR} <:
+        AbstractAtmosphericState
 
 Atmospheric conditions, used to compute optical properties. 
 
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AtmosphericState{
-    FT <: AbstractFloat,
-    FTA1D <: AbstractArray{FT, 1},
-    FTA1DN <: Union{AbstractArray{FT, 1}, Nothing},
-    FTA2D <: AbstractArray{FT, 2},
-    CLDP <: Union{AbstractArray{FT, 2}, Nothing},
-    CLDM <: Union{AbstractArray{Bool, 2}, Nothing},
-    CMASK <: Union{AbstractCloudMask, Nothing},
-    VMR <: AbstractVmr{FT},
-} <: AbstractAtmosphericState{FT, FTA1D}
+struct AtmosphericState{FTA1D, FTA1DN, FTA2D, CLDP, CLDM, CMASK, VMR} <: AbstractAtmosphericState
     "longitude, in degrees (`ncol`), optional"
     lon::FTA1DN
     "latitude, in degrees (`ncol`), optional"

--- a/src/optics/GrayAtmosphericStates.jl
+++ b/src/optics/GrayAtmosphericStates.jl
@@ -66,7 +66,7 @@ struct GrayAtmosphericState{
     FTA1D <: AbstractArray{FT, 1},
     FTA2D <: AbstractArray{FT, 2},
     OTP <: AbstractGrayOpticalThickness,
-} <: AbstractAtmosphericState{FT, FTA1D}
+} <: AbstractAtmosphericState
     "latitude, in degrees, for each column; `(ncol,)`"
     lat::FTA1D
     "Layer pressures `[Pa, mb]`; `(nlay, ncol)`"

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -278,23 +278,23 @@ end
 """
     compute_optical_props!(
         op::AbstractOpticalProps,
-        as::AtmosphericState{FT},
+        as::AtmosphericState,
         gcol::Int,
         igpt::Int,
-        lkp::LookUpSW{FT},
+        lkp::LookUpSW,
         lkp_cld::Union{LookUpCld,PadeCld,Nothing} = nothing,
-    ) where {FT<:AbstractFloat}
+    )
 
 Computes optical properties for the shortwave problem.
 """
 @inline function compute_optical_props!(
     op::AbstractOpticalProps,
-    as::AtmosphericState{FT},
+    as::AtmosphericState,
     gcol::Int,
     igpt::Int,
     lkp::LookUpSW,
     lkp_cld::Union{LookUpCld, PadeCld, Nothing} = nothing,
-) where {FT <: AbstractFloat}
+)
     (; nlay, vmr) = as
     @inbounds ibnd = lkp.major_gpt2bnd[igpt]
     @inbounds t_sfc = as.t_sfc[gcol]

--- a/src/optics/RTE.jl
+++ b/src/optics/RTE.jl
@@ -67,7 +67,7 @@ struct Solver{C, AS, OP, SL, SS, BCL, BCS, FXBL, FXBS, FXL, FXS}
         FTA1D = typeof(as.t_sfc)
         FTA2D = typeof(as.p_lev)
         @assert targs[1] <: ClimaComms.AbstractCommsContext
-        @assert targs[2] <: AbstractAtmosphericState{FT, FTA1D}
+        @assert targs[2] <: AbstractAtmosphericState
         @assert targs[3] <: AbstractOpticalProps
         @assert targs[4] <: Union{AbstractSourceLW, Nothing}
         @assert targs[5] <: Union{SourceSW2Str, Nothing}

--- a/test/read_all_sky.jl
+++ b/test/read_all_sky.jl
@@ -146,16 +146,7 @@ function setup_allsky_as(
     ice_rgh = 2 # medium ice roughness
 
     return (
-        AtmosphericState{
-            FT,
-            typeof(t_sfc),
-            typeof(lat),
-            typeof(p_lev),
-            typeof(cld_r_eff_liq),
-            typeof(cld_mask_lw),
-            MaxRandomOverlap,
-            typeof(vmr),
-        }(
+        AtmosphericState(
             lon,
             lat,
             p_lay,

--- a/test/read_rfmip_clear_sky.jl
+++ b/test/read_rfmip_clear_sky.jl
@@ -123,16 +123,7 @@ function setup_rfmip_as(
     ice_rgh = 1
     #------------------
     return (
-        AtmosphericState{
-            FT,
-            typeof(t_sfc),
-            typeof(lat),
-            typeof(p_lev),
-            typeof(cld_r_eff_liq),
-            typeof(cld_mask_lw),
-            Nothing,
-            typeof(vmr),
-        }(
+        AtmosphericState(
             lon,
             lat,
             p_lay,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Simplify type parameters for `AtmosphericState`

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
