### PR TITLE
Always inline and remove use of StepRange

### DIFF
--- a/src/optics/CloudOptics.jl
+++ b/src/optics/CloudOptics.jl
@@ -221,14 +221,18 @@ function pade_eval(ibnd, re, irad, m, n, pade_coeffs, irgh::Union{Int, Nothing} 
     end
 
     @inbounds denom = coeffs[ibnd, irad, n + m]
-    @inbounds for i in (n + m - 1):-1:(1 + m)
+    i = (n + m - 1)
+    @inbounds while i ≥ (1 + m)
         denom = coeffs[ibnd, irad, i] + re * denom
+        i -= 1
     end
     denom = FT(1) + re * denom
 
     @inbounds numer = coeffs[ibnd, irad, m]
-    @inbounds for i in (m - 1):-1:2
+    i = (m - 1)
+    @inbounds while i ≥ 2
         numer = coeffs[ibnd, irad, i] + re * numer
+        i -= 1
     end
     @inbounds numer = coeffs[ibnd, irad, 1] + re * numer
 

--- a/src/optics/GrayAtmosphericStates.jl
+++ b/src/optics/GrayAtmosphericStates.jl
@@ -130,7 +130,7 @@ function setup_gray_as_pr_grid(
         max_threads = 256
         tx = min(ncol, max_threads)
         bx = cld(ncol, tx)
-        @cuda threads = (tx) blocks = (bx) setup_gray_as_pr_grid_CUDA!(ncol, args...)
+        @cuda always_inline = true threads = (tx) blocks = (bx) setup_gray_as_pr_grid_CUDA!(ncol, args...)
     else
         @inbounds begin
             ClimaComms.@threaded device for gcol in 1:ncol

--- a/src/optics/GrayUtils.jl
+++ b/src/optics/GrayUtils.jl
@@ -52,7 +52,7 @@ function update_profile_lw!(
         max_threads = 256
         tx = min(ncol, max_threads)
         bx = cld(ncol, tx)
-        @cuda threads = (tx) blocks = (bx) update_profile_lw_CUDA!(param_set, ncol, args...)
+        @cuda always_inline = true threads = (tx) blocks = (bx) update_profile_lw_CUDA!(param_set, ncol, args...)
     else
         @inbounds begin
             ClimaComms.@threaded device for gcol in 1:ncol
@@ -137,7 +137,7 @@ function compute_gray_heating_rate!(context, hr_lay, p_lev, ncol, nlay, flux_net
         max_threads = 256
         tx = min(ncol, max_threads)
         bx = cld(ncol, tx)
-        @cuda threads = (tx) blocks = (bx) compute_gray_heating_rate_CUDA!(ncol, args...)
+        @cuda always_inline = true threads = (tx) blocks = (bx) compute_gray_heating_rate_CUDA!(ncol, args...)
     else
         @inbounds begin
             ClimaComms.@threaded device for gcol in 1:ncol

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -115,7 +115,7 @@ function compute_col_gas!(
     if device isa ClimaComms.CUDADevice
         tx = min(nlay * ncol, max_threads)
         bx = cld(nlay * ncol, tx)
-        @cuda threads = (tx) blocks = (bx) compute_col_gas_CUDA!(col_dry, args...)
+        @cuda always_inline = true threads = (tx) blocks = (bx) compute_col_gas_CUDA!(col_dry, args...)
     else
         @inbounds begin
             ClimaComms.@threaded device for icnt in 1:(nlay * ncol)

--- a/src/rte/longwave1scalar.jl
+++ b/src/rte/longwave1scalar.jl
@@ -39,7 +39,7 @@ function rte_lw_noscat_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux_lw, src_lw, bcs_lw, op, nlay, ncol, as)
-    @cuda threads = (tx) blocks = (bx) rte_lw_noscat_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_lw_noscat_solve_CUDA!(args...)
     return nothing
 end
 
@@ -125,7 +125,7 @@ function rte_lw_noscat_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux, flux_lw, src_lw, bcs_lw, op, nlay, ncol, as, lookup_lw, lookup_lw_cld)
-    @cuda threads = (tx) blocks = (bx) rte_lw_noscat_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_lw_noscat_solve_CUDA!(args...)
     return nothing
 end
 

--- a/src/rte/longwave1scalar.jl
+++ b/src/rte/longwave1scalar.jl
@@ -244,7 +244,8 @@ Transport for no-scattering longwave problem.
 
     # Top of domain is index nlev
     # Downward propagation
-    @inbounds for ilev in nlay:-1:1
+    ilev = nlay
+    @inbounds while ilev ≥ 1
         τ_loc = τ[ilev, gcol] * Ds[1]
         trans = exp(-τ_loc)
         lay_src, lev_src_dec = lay_source[ilev, gcol], lev_source_dec[ilev, gcol]
@@ -252,6 +253,7 @@ Transport for no-scattering longwave problem.
             trans * intensity_dn_ilevplus1 + lw_noscat_source_dn(lev_src_dec, lay_src, τ_loc, trans, τ_thresh)
         intensity_dn_ilevplus1 = intensity_dn_ilev
         flux_dn[ilev, gcol] = intensity_dn_ilev * intensity_to_flux
+        ilev -= 1
     end
 
     # Surface reflection and emission

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -320,7 +320,8 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
 
     # From the top of the atmosphere downward -- compute fluxes
     @inbounds lev_src_top = lev_source[nlay + 1, gcol]
-    @inbounds for ilev in nlay:-1:1
+    ilev = nlay
+    @inbounds while ilev ≥ 1
         lev_src_bot, albedo_ilev, src_ilev = lev_source[ilev, gcol], albedo[ilev, gcol], src[ilev, gcol]
         τ_lay, ssa_lay, g_lay = τ[ilev, gcol], ssa[ilev, gcol], g[ilev, gcol]
         Rdif, Tdif, _, src_dn = lw_2stream_coeffs(τ_lay, ssa_lay, g_lay, lev_src_bot, lev_src_top)
@@ -335,5 +336,6 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
         flux_dn[ilev, gcol] = flux_dn_ilev
         flux_dn_ilevplus1 = flux_dn_ilev
         lev_src_top = lev_src_bot
+        ilev -= 1
     end
 end

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -38,7 +38,7 @@ function rte_lw_2stream_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux_lw, src_lw, bcs_lw, op, nlay, ncol, as)
-    @cuda threads = (tx) blocks = (bx) rte_lw_2stream_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_lw_2stream_solve_CUDA!(args...)
     return nothing
 end
 
@@ -136,7 +136,7 @@ function rte_lw_2stream_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux, flux_lw, src_lw, bcs_lw, op, nlay, ncol, as, lookup_lw, lookup_lw_cld)
-    @cuda threads = (tx) blocks = (bx) rte_lw_2stream_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_lw_2stream_solve_CUDA!(args...)
     return nothing
 end
 

--- a/src/rte/shortwave1scalar.jl
+++ b/src/rte/shortwave1scalar.jl
@@ -34,7 +34,7 @@ function rte_sw_noscat_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux_sw, op, bcs_sw, nlay, ncol, as)
-    @cuda threads = (tx) blocks = (bx) rte_sw_noscat_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_sw_noscat_solve_CUDA!(args...)
     return nothing
 end
 
@@ -101,7 +101,7 @@ function rte_sw_noscat_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux, flux_sw, op, bcs_sw, nlay, ncol, as, lookup_sw, lookup_sw_cld)
-    @cuda threads = (tx) blocks = (bx) rte_sw_noscat_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_sw_noscat_solve_CUDA!(args...)
     return nothing
 end
 

--- a/src/rte/shortwave1scalar.jl
+++ b/src/rte/shortwave1scalar.jl
@@ -160,8 +160,10 @@ function rte_sw_noscat!(
     (; flux_dn_dir, flux_net) = flux
     # downward propagation
     @inbounds flux_dn_dir[nlev, gcol] = toa_flux[gcol] * solar_frac * cos_zenith[gcol]
-    @inbounds for ilev in (nlev - 1):-1:1
+    ilev = nlev - 1
+    @inbounds while ilev ≥ 1
         flux_dn_dir[ilev, gcol] = flux_dn_dir[ilev + 1, gcol] * exp(-τ[ilev, gcol] / cos_zenith[gcol])
         flux_net[ilev, gcol] = -flux_dn_dir[ilev, gcol]
+        ilev -= 1
     end
 end

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -43,7 +43,7 @@ function rte_sw_2stream_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux_sw, op, bcs_sw, src_sw, nlay, ncol, as)
-    @cuda threads = (tx) blocks = (bx) rte_sw_2stream_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_sw_2stream_solve_CUDA!(args...)
     return nothing
 end
 
@@ -151,7 +151,7 @@ function rte_sw_2stream_solve!(
     tx = min(ncol, max_threads)
     bx = cld(ncol, tx)
     args = (flux, flux_sw, op, bcs_sw, src_sw, nlay, ncol, as, lookup_sw, lookup_sw_cld)
-    @cuda threads = (tx) blocks = (bx) rte_sw_2stream_solve_CUDA!(args...)
+    @cuda always_inline = true threads = (tx) blocks = (bx) rte_sw_2stream_solve_CUDA!(args...)
     return nothing
 end
 

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -376,7 +376,8 @@ function rte_sw_2stream!(
     @inbounds flux_dn[nlev, gcol] += flux_dn_dir_top
     τ_cum = FT(0)
 
-    @inbounds for ilev in nlay:-1:1
+    ilev = nlay
+    @inbounds while ilev ≥ 1
         τ_ilev, ssa_ilev, g_ilev = τ[ilev, gcol], ssa[ilev, gcol], g[ilev, gcol]
         albedo_ilev, src_ilev = albedo[ilev, gcol], src[ilev, gcol]
         (_, Tdir, _, Rdif, Tdif) = sw_2stream_coeffs(τ_ilev, ssa_ilev, g_ilev, μ₀)
@@ -391,6 +392,7 @@ function rte_sw_2stream!(
             src_ilev
         flux_dn[ilev, gcol] = flux_dn_ilev + flux_dn_dir_top * exp(-τ_cum / μ₀)
         flux_dn_ilevplus1 = flux_dn_ilev
+        ilev -= 1
     end
     return nothing
 end


### PR DESCRIPTION
This PR:

 - applies `always_inline = true` for the cuda launches
 - Removes use of `StepRange`

as suggested in https://cuda.juliagpu.org/dev/tutorials/performance/