### PR TITLE
Add lower bound for cumulative optical thickness

### DIFF
--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -358,6 +358,7 @@ function rte_sw_2stream!(
         # radiation emitted at bottom of layer,
         # transmitted through the layer and reflected from layers below (Tdiff*src*albedo)
         τ_cum -= τ_ilev
+        τ_cum = max(τ_cum, FT(0))
         flux_dn_dir_ilevplus1 = flux_dn_dir_top * exp(-τ_cum / μ₀)
         src_up_ilev = Rdir * flux_dn_dir_ilevplus1 #flux_dn_dir[ilev + 1]
         src_dn_ilev = Tdir * flux_dn_dir_ilevplus1 #flux_dn_dir[ilev + 1]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add lower bound for cumulative optical thickness in 2-stream shortwave solver


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
