### PR TITLE
Improve dispatch for ClimaAtmos

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/optics/GrayAtmosphericStates.jl
+++ b/src/optics/GrayAtmosphericStates.jl
@@ -91,6 +91,12 @@ Adapt.@adapt_structure GrayAtmosphericState
 @inline get_ncol(as::GrayAtmosphericState) = size(as.p_lay, 2)
 # Number of layers and columns
 @inline get_dims(as::GrayAtmosphericState) = size(as.p_lay)
+
+# Dispatch to match AtmosphericState functions 
+@inline getview_p_lay(as::GrayAtmosphericState) = as.p_lay
+@inline getview_t_lay(as::GrayAtmosphericState) = as.t_lay
+@inline getview_col_dry(as::GrayAtmosphericState) = as.col_dry
+
 #---------------------------------------------------------------
 # This functions sets up a model temperature and pressure 
 # distributions for a gray atmosphere based on a pressure grid

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -99,17 +99,17 @@ This function computes the column amounts of dry or moist air.
 function compute_col_gas!(
     context,
     p_lev::FTA2D,
-    col_dry::FTA2D,
+    col_dry,
     param_set::RP.ARP,
     vmr_h2o::Union{AbstractArray{FT, 2}, Nothing} = nothing,
     lat::Union{AbstractArray{FT, 1}, Nothing} = nothing,
     max_threads::Int = Int(256),
 ) where {FT <: AbstractFloat, FTA2D <: AbstractArray{FT, 2}}
     nlay, ncol = size(col_dry)
-    mol_m_dry = FT(RP.molmass_dryair(param_set))
-    mol_m_h2o = FT(RP.molmass_water(param_set))
-    avogadro = FT(RP.avogad(param_set))
-    helmert1 = FT(RP.grav(param_set))
+    mol_m_dry = RP.molmass_dryair(param_set)
+    mol_m_h2o = RP.molmass_water(param_set)
+    avogadro = RP.avogad(param_set)
+    helmert1 = RP.grav(param_set)
     args = (p_lev, mol_m_dry, mol_m_h2o, avogadro, helmert1, vmr_h2o, lat)
     device = ClimaComms.device(context)
     if device isa ClimaComms.CUDADevice


### PR DESCRIPTION
This PR changes some dispatch to avoid needing type piracy in Atmos. We should also make a patch release for this.

Content
- Add methods for `getview_col_dry`, `getview_p_lay`, and `getview_t_lay` to dispatch on `GrayAtmosphericState`. 
- Remove type for `col_dry` in `compute_col_gas!`
- Remove `FT` cast for parameters in `compute_col_gas!`, they should already be the proper FT.