### PR TITLE
Update climacommon to 2024_04_05

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,12 @@
 agents:
   queue: new-central
-  modules: climacommon/2024_03_18
+  modules: climacommon/2024_04_05
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
   OPENBLAS_NUM_THREADS: 1
   JULIA_NVTX_CALLBACKS: gc
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100
-  JULIA_CPU_TARGET: 'broadwell;skylake;icelake;cascadelake;epyc'
   SLURM_KILL_BAD_EXIT: 1
 
 steps:


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖 Good news! I found a way to reduce unnecessary precompilations! Have you ever noticed that when you move to a GPU node from a CPU one (or viceversa), everything has to be recompiled again? Or sometimes it seems that you are always precompiling... Well, this is partially because the nodes on the Caltech cluster have different architectures, and Julia compiles for the native one, but when you move to a new architecture, the compiled code has to be invalidated and recompiled again. With the latest version of climacommon, I force Julia to always compile for all the possible targets in our cluster. Buildkite pipelines partially do this with the JULIA_TARGET_CPU, but the strings there are incorrect. This PR fixes that too. 