### PR TITLE
Bump to 0.14.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,22 @@
 RRTMGP.jl Release Notes
 ========================
 
+v0.14.0
+------
+
+- CUDA is now an extension. Some methods have changed.
+  ([#485](https://github.com/CliMA/RRTMGP.jl/pull/485)).
+
+v0.13.4
+------
+
+Identical to v0.13.2
+
+v0.13.3
+------
+
+Broken release. Do not use
+
 v0.13.2
 ------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.13.3"
+version = "0.14.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
0.13.4 was tagged in the `[0.13.4`](https://github.com/CliMA/RRTMGP.jl/tree/0.13.4) branch and reverts all the 0.13.3 changes.