### PR TITLE
Update climacommon to 2024_05_27

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: new-central
-  modules: climacommon/2024_04_30
+  modules: climacommon/2024_05_27
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

Over the weekend, a new version of MPITrampoline was released. This version is incompatible with the version of MPIwrapper we were using, so we had to install a new version of MPIwrapper. The most recent version of climacommon uses this updated version of MPIwrapper.