### PR TITLE
Fix noscatter shortwave solve

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,22 @@
 RRTMGP.jl Release Notes
 ========================
 
+main
+------
+- Fix undefined variable in `rte_sw_noscat_solve!` ([#504](https://github.com/CliMA/RRTMGP.jl/pull/504))
+- Add support for OneScalar cloud optics. ([#505](https://github.com/CliMA/RRTMGP.jl/pull/505))
+
+v0.15.1
+------
+- Force optical thickness to be non-negative ([#502](https://github.com/CliMA/RRTMGP.jl/pull/502))
+
 v0.15.0
 ------
-- Solver struct has been split to allow for independent RTE solver schemes for longwave and shortwave problems ([#492]((https://github.com/CliMA/RRTMGP.jl/pull/492)))
-- Simplify arguments for solve_lw! and solve_sw!. ([#493]((https://github.com/CliMA/RRTMGP.jl/pull/493)))
-- Update Artifacts to use lookup tables and reference data from ([#495]((https://github.com/CliMA/RRTMGP.jl/pull/495)))
-- Move AngularDiscretization to `NoScatLWRTE` ([#496]((https://github.com/CliMA/RRTMGP.jl/pull/496)))
-- Update longwave secants and weights ([#498]((https://github.com/CliMA/RRTMGP.jl/pull/498)))
+- Solver struct has been split to allow for independent RTE solver schemes for longwave and shortwave problems ([#492](https://github.com/CliMA/RRTMGP.jl/pull/492))
+- Simplify arguments for solve_lw! and solve_sw!. ([#493](https://github.com/CliMA/RRTMGP.jl/pull/493))
+- Update Artifacts to use lookup tables and reference data from ([#495](https://github.com/CliMA/RRTMGP.jl/pull/495))
+- Move AngularDiscretization to `NoScatLWRTE` ([#496](https://github.com/CliMA/RRTMGP.jl/pull/496))
+- Update longwave secants and weights ([#498](https://github.com/CliMA/RRTMGP.jl/pull/498))
 
 v0.14.0
 ------

--- a/ext/cuda/rte_shortwave_1scalar.jl
+++ b/ext/cuda/rte_shortwave_1scalar.jl
@@ -75,7 +75,7 @@ function rte_sw_noscat_solve_CUDA!(
         μ₀ = bcs_sw.cos_zenith[gcol]
         @inbounds begin
             for igpt in 1:n_gpt
-                compute_optical_props!(op, as, gcol, igpt, lookup_sw, lookup_sw_cld)
+                compute_optical_props!(op, as, gcol, igpt, lookup_sw, nothing)
                 solar_frac = lookup_sw.solar_src_scaled[igpt]
                 rte_sw_noscat!(flux, op, bcs_sw, igpt, n_gpt, solar_frac, gcol, nlev)
                 if igpt == 1

--- a/src/rte/shortwave1scalar.jl
+++ b/src/rte/shortwave1scalar.jl
@@ -45,7 +45,7 @@ function rte_sw_noscat_solve!(
         for igpt in 1:n_gpt
             ClimaComms.@threaded device for gcol in 1:ncol
                 if cos_zenith[gcol] > 0
-                    compute_optical_props!(op, as, gcol, igpt, lookup_sw, lookup_sw_cld)
+                    compute_optical_props!(op, as, gcol, igpt, lookup_sw, nothing)
                     solar_frac = lookup_sw.solar_src_scaled[igpt]
                     rte_sw_noscat!(flux, op, bcs_sw, igpt, n_gpt, solar_frac, gcol, nlev)
                     if igpt == 1


### PR DESCRIPTION
Currently, `rte_sw_noscat_solve!` can break because the variable `lookup_sw_cld` is not defined. This PR replaces it with `nothing` 