### PR TITLE
Compute and store `aero_mask`.

### DIFF
--- a/ext/cuda/rte_longwave_1scalar.jl
+++ b/ext/cuda/rte_longwave_1scalar.jl
@@ -88,7 +88,10 @@ function rte_lw_noscat_solve_CUDA!(
         flux_up_lw = flux_lw.flux_up
         flux_dn_lw = flux_lw.flux_dn
         flux_net_lw = flux_lw.flux_net
-        cloud_state = as.cloud_state
+        (; cloud_state, aerosol_state) = as
+        if aerosol_state isa AerosolState
+            Optics.compute_aero_mask!(view(aerosol_state.aero_mask, :, gcol), view(aerosol_state.aero_mass, :, :, gcol))
+        end
         @inbounds for igpt in 1:n_gpt
             ibnd = major_gpt2bnd[igpt]
             if cloud_state isa CloudState

--- a/ext/cuda/rte_longwave_2stream.jl
+++ b/ext/cuda/rte_longwave_2stream.jl
@@ -81,7 +81,10 @@ function rte_lw_2stream_solve_CUDA!(
         flux_dn_lw = flux_lw.flux_dn
         flux_net_lw = flux_lw.flux_net
         (; flux_up, flux_dn) = flux
-        cloud_state = as.cloud_state
+        (; cloud_state, aerosol_state) = as
+        if aerosol_state isa AerosolState
+            Optics.compute_aero_mask!(view(aerosol_state.aero_mask, :, gcol), view(aerosol_state.aero_mass, :, :, gcol))
+        end
         @inbounds for igpt in 1:n_gpt
             ibnd = major_gpt2bnd[igpt]
             if cloud_state isa CloudState

--- a/ext/cuda/rte_shortwave_2stream.jl
+++ b/ext/cuda/rte_shortwave_2stream.jl
@@ -100,9 +100,15 @@ function rte_sw_2stream_solve_CUDA!(
         flux_up = flux.flux_up
         flux_dn = flux.flux_dn
         FT = eltype(flux_up)
-        cloud_state = as.cloud_state
+        (; cloud_state, aerosol_state) = as
         μ₀ = bcs_sw.cos_zenith[gcol]
         @inbounds begin
+            if aerosol_state isa AerosolState
+                Optics.compute_aero_mask!(
+                    view(aerosol_state.aero_mask, :, gcol),
+                    view(aerosol_state.aero_mass, :, :, gcol),
+                )
+            end
             for igpt in 1:n_gpt
                 # set cloud mask, if applicable
                 if cloud_state isa CloudState

--- a/src/optics/AtmosphericStates.jl
+++ b/src/optics/AtmosphericStates.jl
@@ -111,11 +111,13 @@ end
 Adapt.@adapt_structure CloudState
 
 """
-    AerosolState{D}
+    AerosolState{B, D}
 
 Aerosol state, used to compute optical properties.
 """
-struct AerosolState{D}
+struct AerosolState{B, D}
+    "aerosol mask, = true if any aerosol is present"
+    aero_mask::B
     "aerosol size (microns)"
     aero_size::D
     "aerosol mass column (kg/m2)"

--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -238,11 +238,12 @@ Computes optical properties for the longwave problem.
             )
         end
         if !isnothing(lkp_aero)
+            aero_mask = view(as.aerosol_state.aero_mask, :, gcol)
             aero_size = view(as.aerosol_state.aero_size, :, :, gcol)
             aero_mass = view(as.aerosol_state.aero_mass, :, :, gcol)
             rel_hum = AtmosphericStates.getview_rel_hum(as, gcol)
 
-            add_aerosol_optics_1scalar!(τ, aero_size, aero_mass, rel_hum, lkp_aero, ibnd)
+            add_aerosol_optics_1scalar!(τ, aero_mask, aero_size, aero_mass, rel_hum, lkp_aero, ibnd)
         end
     end
     return nothing
@@ -324,11 +325,12 @@ end
         )
     end
     if !isnothing(lkp_aero)
+        aero_mask = view(as.aerosol_state.aero_mask, :, gcol)
         aero_size = view(as.aerosol_state.aero_size, :, :, gcol)
         aero_mass = view(as.aerosol_state.aero_mass, :, :, gcol)
         rel_hum = AtmosphericStates.getview_rel_hum(as, gcol)
 
-        add_aerosol_optics_2stream!(τ, ssa, g, aero_size, aero_mass, rel_hum, lkp_aero, ibnd)
+        add_aerosol_optics_2stream!(τ, ssa, g, aero_mask, aero_size, aero_mass, rel_hum, lkp_aero, ibnd)
     end
     return nothing
 end
@@ -418,11 +420,23 @@ end
         )
     end
     if !isnothing(lkp_aero)
+        aero_mask = view(as.aerosol_state.aero_mask, :, gcol)
         aero_size = view(as.aerosol_state.aero_size, :, :, gcol)
         aero_mass = view(as.aerosol_state.aero_mass, :, :, gcol)
         rel_hum = AtmosphericStates.getview_rel_hum(as, gcol)
 
-        add_aerosol_optics_2stream!(τ, ssa, g, aero_size, aero_mass, rel_hum, lkp_aero, ibnd, delta_scaling = true)
+        add_aerosol_optics_2stream!(
+            τ,
+            ssa,
+            g,
+            aero_mask,
+            aero_size,
+            aero_mass,
+            rel_hum,
+            lkp_aero,
+            ibnd,
+            delta_scaling = true,
+        )
     end
     return nothing
 end

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -39,13 +39,21 @@ function rte_lw_2stream_solve!(
     nlev = nlay + 1
     (; major_gpt2bnd) = lookup_lw.band_data
     n_gpt = length(major_gpt2bnd)
-    cloud_state = as.cloud_state
+    (; cloud_state, aerosol_state) = as
     bld_cld_mask = cloud_state isa CloudState
     flux_up_lw = flux_lw.flux_up
     flux_dn_lw = flux_lw.flux_dn
     flux_net_lw = flux_lw.flux_net
     (; flux_up, flux_dn) = flux
     @inbounds begin
+        if aerosol_state isa AerosolState
+            ClimaComms.@threaded device for gcol in 1:ncol
+                Optics.compute_aero_mask!(
+                    view(aerosol_state.aero_mask, :, gcol),
+                    view(aerosol_state.aero_mass, :, :, gcol),
+                )
+            end
+        end
         for igpt in 1:n_gpt
             ClimaComms.@threaded device for gcol in 1:ncol
                 ibnd = major_gpt2bnd[igpt]

--- a/test/read_all_sky_with_aerosols.jl
+++ b/test/read_all_sky_with_aerosols.jl
@@ -104,6 +104,7 @@ function setup_allsky_with_aerosols_as(
     # repeat the input data to set problem size to ncols
     nrepeat = Int(cld(ncol, ncol_ref))
     aerosol_state = AerosolState(
+        DA{Bool}(undef, nlay, ncol),
         DA(repeat(aero_size, 1, 1, nrepeat)[:, :, 1:ncol]),
         DA(repeat(aero_mass, 1, 1, nrepeat)[:, :, 1:ncol]),
     )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
Compute and store `aero_mask`.
This replaces the existing strategy where `aero_mask` is computed on the fly, resulting it being computed redundantly once per `g-point`.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
