### PR TITLE
Change data layout for fluxes.

### DIFF
--- a/ext/cuda/rte_longwave_1scalar.jl
+++ b/ext/cuda/rte_longwave_1scalar.jl
@@ -36,7 +36,7 @@ function rte_lw_noscat_solve_CUDA!(
         compute_optical_props!(op, as, src_lw, gcol)
         rte_lw_noscat_one_angle!(src_lw, bcs_lw, op, Ds, w_μ, gcol, flux_lw, igpt, ibnd, nlay, nlev)
         @inbounds for ilev in 1:nlev
-            flux_net[ilev, gcol] = flux_up[ilev, gcol] - flux_dn[ilev, gcol]
+            flux_net[gcol, ilev] = flux_up[gcol, ilev] - flux_dn[gcol, ilev]
         end
     end
     return nothing
@@ -108,7 +108,7 @@ function rte_lw_noscat_solve_CUDA!(
         end
         @inbounds begin
             for ilev in 1:nlev
-                flux_net_lw[ilev, gcol] = flux_up_lw[ilev, gcol] - flux_dn_lw[ilev, gcol]
+                flux_net_lw[gcol, ilev] = flux_up_lw[gcol, ilev] - flux_dn_lw[gcol, ilev]
             end
         end
     end

--- a/ext/cuda/rte_longwave_2stream.jl
+++ b/ext/cuda/rte_longwave_2stream.jl
@@ -32,7 +32,7 @@ function rte_lw_2stream_solve_CUDA!(
         rte_lw_2stream!(op, flux_lw, src_lw, bcs_lw, gcol, igpt, ibnd, nlev, ncol)
         @inbounds begin
             for ilev in 1:nlev
-                flux_net[ilev, gcol] = flux_up[ilev, gcol] - flux_dn[ilev, gcol]
+                flux_net[gcol, ilev] = flux_up[gcol, ilev] - flux_dn[gcol, ilev]
             end
         end
     end
@@ -97,18 +97,18 @@ function rte_lw_2stream_solve_CUDA!(
             compute_optical_props!(op, as, src_lw, gcol, igpt, lookup_lw, lookup_lw_cld, lookup_lw_aero)
             rte_lw_2stream!(op, flux, src_lw, bcs_lw, gcol, igpt, ibnd, nlev, ncol)
             if igpt == 1
-                map!(x -> x, view(flux_up_lw, :, gcol), view(flux_up, :, gcol))
-                map!(x -> x, view(flux_dn_lw, :, gcol), view(flux_dn, :, gcol))
+                map!(x -> x, view(flux_up_lw, gcol, :), view(flux_up, gcol, :))
+                map!(x -> x, view(flux_dn_lw, gcol, :), view(flux_dn, gcol, :))
             else
                 for ilev in 1:nlev
-                    @inbounds flux_up_lw[ilev, gcol] += flux_up[ilev, gcol]
-                    @inbounds flux_dn_lw[ilev, gcol] += flux_dn[ilev, gcol]
+                    @inbounds flux_up_lw[gcol, ilev] += flux_up[gcol, ilev]
+                    @inbounds flux_dn_lw[gcol, ilev] += flux_dn[gcol, ilev]
                 end
             end
         end
         @inbounds begin
             for ilev in 1:nlev
-                flux_net_lw[ilev, gcol] = flux_up_lw[ilev, gcol] - flux_dn_lw[ilev, gcol]
+                flux_net_lw[gcol, ilev] = flux_up_lw[gcol, ilev] - flux_dn_lw[gcol, ilev]
             end
         end
     end

--- a/ext/cuda/rte_shortwave_1scalar.jl
+++ b/ext/cuda/rte_shortwave_1scalar.jl
@@ -79,28 +79,28 @@ function rte_sw_noscat_solve_CUDA!(
                 solar_frac = lookup_sw.solar_src_scaled[igpt]
                 rte_sw_noscat!(flux, op, bcs_sw, igpt, n_gpt, solar_frac, gcol, nlev)
                 if igpt == 1
-                    map!(x -> x, view(flux_up_sw, :, gcol), view(flux_up, :, gcol))
-                    map!(x -> x, view(flux_dn_sw, :, gcol), view(flux_dn, :, gcol))
+                    map!(x -> x, view(flux_up_sw, gcol, :), view(flux_up, gcol, :))
+                    map!(x -> x, view(flux_dn_sw, gcol, :), view(flux_dn, gcol, :))
                 else
                     for ilev in 1:nlev
-                        flux_up_sw[ilev, gcol] += flux_up[ilev, gcol]
-                        flux_dn_sw[ilev, gcol] += flux_dn[ilev, gcol]
+                        flux_up_sw[gcol, ilev] += flux_up[gcol, ilev]
+                        flux_dn_sw[gcol, ilev] += flux_dn[gcol, ilev]
                     end
                 end
             end
             if μ₀ <= 0
                 for ilev in 1:nlev
-                    flux_up_sw[ilev, gcol] = FT(0)
+                    flux_up_sw[gcol, ilev] = FT(0)
                 end
                 for ilev in 1:nlev
-                    flux_dn_sw[ilev, gcol] = FT(0)
+                    flux_dn_sw[gcol, ilev] = FT(0)
                 end
                 for ilev in 1:nlev
-                    flux_net_sw[ilev, gcol] = FT(0)
+                    flux_net_sw[gcol, ilev] = FT(0)
                 end
             else
                 for ilev in 1:nlev
-                    flux_net_sw[ilev, gcol] = flux_up_sw[ilev, gcol] - flux_dn_sw[ilev, gcol]
+                    flux_net_sw[gcol, ilev] = flux_up_sw[gcol, ilev] - flux_dn_sw[gcol, ilev]
                 end
             end
         end

--- a/ext/cuda/rte_shortwave_2stream.jl
+++ b/ext/cuda/rte_shortwave_2stream.jl
@@ -38,18 +38,18 @@ function rte_sw_2stream_solve_CUDA!(
             # call shortwave rte solver
             rte_sw_2stream!(op, src_sw, bcs_sw, flux_sw, solar_frac, igpt, n_gpt, ibnd, nlev, gcol)
             for ilev in 1:nlev
-                flux_net_sw[ilev, gcol] = flux_up_sw[ilev, gcol] - flux_dn_sw[ilev, gcol]
+                flux_net_sw[gcol, ilev] = flux_up_sw[gcol, ilev] - flux_dn_sw[gcol, ilev]
             end
         end
         if μ₀ ≤ 0 # zero out columns with zenith angle ≥ π/2
             for ilev in 1:nlev
-                flux_up_sw[ilev, gcol] = FT(0)
+                flux_up_sw[gcol, ilev] = FT(0)
             end
             for ilev in 1:nlev
-                flux_dn_sw[ilev, gcol] = FT(0)
+                flux_dn_sw[gcol, ilev] = FT(0)
             end
             for ilev in 1:nlev
-                flux_net_sw[ilev, gcol] = FT(0)
+                flux_net_sw[gcol, ilev] = FT(0)
             end
         end
     end
@@ -125,25 +125,25 @@ function rte_sw_2stream_solve_CUDA!(
                 # rte shortwave solver
                 rte_sw_2stream!(op, src_sw, bcs_sw, flux, solar_frac, igpt, n_gpt, ibnd, nlev, gcol)
                 if igpt == 1
-                    map!(x -> x, view(flux_up_sw, :, gcol), view(flux_up, :, gcol))
-                    map!(x -> x, view(flux_dn_sw, :, gcol), view(flux_dn, :, gcol))
+                    map!(x -> x, view(flux_up_sw, gcol, :), view(flux_up, gcol, :))
+                    map!(x -> x, view(flux_dn_sw, gcol, :), view(flux_dn, gcol, :))
                 else
                     for ilev in 1:nlev
-                        flux_up_sw[ilev, gcol] += flux_up[ilev, gcol]
-                        flux_dn_sw[ilev, gcol] += flux_dn[ilev, gcol]
+                        flux_up_sw[gcol, ilev] += flux_up[gcol, ilev]
+                        flux_dn_sw[gcol, ilev] += flux_dn[gcol, ilev]
                     end
                 end
             end
             if μ₀ ≤ 0 # zero out columns with zenith angle ≥ π/2
                 for ilev in 1:nlev
-                    flux_up_sw[ilev, gcol] = FT(0)
+                    flux_up_sw[gcol, ilev] = FT(0)
                 end
                 for ilev in 1:nlev
-                    flux_dn_sw[ilev, gcol] = FT(0)
+                    flux_dn_sw[gcol, ilev] = FT(0)
                 end
             end
             for ilev in 1:nlev
-                flux_net_sw[ilev, gcol] = flux_up_sw[ilev, gcol] - flux_dn_sw[ilev, gcol]
+                flux_net_sw[gcol, ilev] = flux_up_sw[gcol, ilev] - flux_dn_sw[gcol, ilev]
             end
         end
     end

--- a/src/optics/Fluxes.jl
+++ b/src/optics/Fluxes.jl
@@ -17,20 +17,20 @@ Upward, downward and net longwave fluxes at each level.
 $(DocStringExtensions.FIELDS)
 """
 struct FluxLW{FT <: AbstractFloat, FTA2D <: AbstractArray{FT, 2}} <: AbstractFlux{FT, FTA2D}
-    "upward flux `[W/m²]` `(nlev,ncol)`"
+    "upward flux `[W/m²]` `(ncol, nlev)`"
     flux_up::FTA2D
-    "downward flux `[W/m²]` `(nlev,ncol)`"
+    "downward flux `[W/m²]` `(ncol, nlev)`"
     flux_dn::FTA2D
-    "net flux `[W/m²]` `(nlev,ncol)`"
+    "net flux `[W/m²]` `(ncol, nlev)`"
     flux_net::FTA2D
 end
 FluxLW(flux_up, flux_dn, flux_net) = FluxLW{eltype(flux_up), typeof(flux_up)}(flux_up, flux_dn, flux_net)
 Adapt.@adapt_structure FluxLW
 
 function FluxLW(ncol::Int, nlay::Int, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
-    flux_up = DA{FT}(undef, nlay + 1, ncol)
-    flux_dn = DA{FT}(undef, nlay + 1, ncol)
-    flux_net = DA{FT}(undef, nlay + 1, ncol)
+    flux_up = DA{FT}(undef, ncol, nlay + 1)
+    flux_dn = DA{FT}(undef, ncol, nlay + 1)
+    flux_net = DA{FT}(undef, ncol, nlay + 1)
     return FluxLW{FT, typeof(flux_net)}(flux_up, flux_dn, flux_net)
 end
 
@@ -43,13 +43,13 @@ Upward, downward and net shortwave fluxes at each level.
 $(DocStringExtensions.FIELDS)
 """
 struct FluxSW{FT <: AbstractFloat, FTA2D <: AbstractArray{FT, 2}} <: AbstractFlux{FT, FTA2D}
-    "upward flux `[W/m²]` `(nlev,ncol)`"
+    "upward flux `[W/m²]` `(ncol, nlev)`"
     flux_up::FTA2D
-    "downward flux `[W/m²]` `(nlev,ncol)`"
+    "downward flux `[W/m²]` `(ncol, nlev)`"
     flux_dn::FTA2D
-    "net flux `[W/m²]` `(nlev,ncol)`"
+    "net flux `[W/m²]` `(ncol, nlev)`"
     flux_net::FTA2D
-    "direct downward flux `[W/m²]` `(nlev,ncol)`"
+    "direct downward flux `[W/m²]` `(ncol, nlev)`"
     flux_dn_dir::FTA2D
 end
 FluxSW(flux_up, flux_dn, flux_net, flux_dn_dir) =
@@ -57,10 +57,10 @@ FluxSW(flux_up, flux_dn, flux_net, flux_dn_dir) =
 Adapt.@adapt_structure FluxSW
 
 function FluxSW(ncol::Int, nlay::Int, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
-    flux_up = DA{FT}(undef, nlay + 1, ncol)
-    flux_dn = DA{FT}(undef, nlay + 1, ncol)
-    flux_net = DA{FT}(undef, nlay + 1, ncol)
-    flux_dn_dir = DA{FT}(undef, nlay + 1, ncol)
+    flux_up = DA{FT}(undef, ncol, nlay + 1)
+    flux_dn = DA{FT}(undef, ncol, nlay + 1)
+    flux_net = DA{FT}(undef, ncol, nlay + 1)
+    flux_dn_dir = DA{FT}(undef, ncol, nlay + 1)
     return FluxSW{FT, typeof(flux_net)}(flux_up, flux_dn, flux_net, flux_dn_dir)
 end
 
@@ -84,11 +84,11 @@ Set longwave flux for column `gcol` to zero
 """
 function set_flux_to_zero!(flux::FluxLW{FT}, gcol::Int) where {FT <: AbstractFloat}
     (; flux_up, flux_dn, flux_net) = flux
-    nlev = size(flux_up, 1)
+    nlev = size(flux_up, 2)
     @inbounds for ilev in 1:nlev
-        flux_up[ilev, gcol] = FT(0)
-        flux_dn[ilev, gcol] = FT(0)
-        flux_net[ilev, gcol] = FT(0)
+        flux_up[gcol, ilev] = FT(0)
+        flux_dn[gcol, ilev] = FT(0)
+        flux_net[gcol, ilev] = FT(0)
     end
     return nothing
 end
@@ -114,12 +114,12 @@ Set shortwave flux for column `gcol` to zero
 """
 function set_flux_to_zero!(flux::FluxSW{FT}, gcol::Int) where {FT <: AbstractFloat}
     (; flux_up, flux_dn, flux_net, flux_dn_dir) = flux
-    nlev = size(flux_up, 1)
+    nlev = size(flux_up, 2)
     @inbounds for ilev in 1:nlev
-        flux_up[ilev, gcol] = FT(0)
-        flux_dn[ilev, gcol] = FT(0)
-        flux_net[ilev, gcol] = FT(0)
-        flux_dn_dir[ilev, gcol] = FT(0)
+        flux_up[gcol, ilev] = FT(0)
+        flux_dn[gcol, ilev] = FT(0)
+        flux_net[gcol, ilev] = FT(0)
+        flux_dn_dir[gcol, ilev] = FT(0)
     end
     return nothing
 end
@@ -147,11 +147,11 @@ flux1 .+= flux2
 function add_to_flux!(flux1::FluxLW, flux2::FluxLW, gcol::Int)
     flux_up1, flux_dn1, flux_net1 = flux1.flux_up, flux1.flux_dn, flux1.flux_net
     flux_up2, flux_dn2, flux_net2 = flux2.flux_up, flux2.flux_dn, flux2.flux_net
-    nlev = size(flux_up1, 1)
+    nlev = size(flux_up1, 2)
     @inbounds for ilev in 1:nlev
-        flux_up1[ilev, gcol] += flux_up2[ilev, gcol]
-        flux_dn1[ilev, gcol] += flux_dn2[ilev, gcol]
-        flux_net1[ilev, gcol] += flux_net2[ilev, gcol]
+        flux_up1[gcol, ilev] += flux_up2[gcol, ilev]
+        flux_dn1[gcol, ilev] += flux_dn2[gcol, ilev]
+        flux_net1[gcol, ilev] += flux_net2[gcol, ilev]
     end
     return nothing
 end
@@ -180,12 +180,12 @@ flux1 .+= flux2
 function add_to_flux!(flux1::FluxSW, flux2::FluxSW, gcol)
     flux_up1, flux_dn1, flux_net1, flux_dn_dir1 = flux1.flux_up, flux1.flux_dn, flux1.flux_net, flux1.flux_dn_dir
     flux_up2, flux_dn2, flux_net2, flux_dn_dir2 = flux2.flux_up, flux2.flux_dn, flux2.flux_net, flux2.flux_dn_dir
-    nlev = size(flux_up1, 1)
+    nlev = size(flux_up1, 2)
     @inbounds for ilev in 1:nlev
-        flux_up1[ilev, gcol] += flux_up2[ilev, gcol]
-        flux_dn1[ilev, gcol] += flux_dn2[ilev, gcol]
-        flux_net1[ilev, gcol] += flux_net2[ilev, gcol]
-        flux_dn_dir1[ilev, gcol] += flux_dn_dir2[ilev, gcol]
+        flux_up1[gcol, ilev] += flux_up2[gcol, ilev]
+        flux_dn1[gcol, ilev] += flux_dn2[gcol, ilev]
+        flux_net1[gcol, ilev] += flux_net2[gcol, ilev]
+        flux_dn_dir1[gcol, ilev] += flux_dn_dir2[gcol, ilev]
     end
     return nothing
 end

--- a/src/optics/GrayUtils.jl
+++ b/src/optics/GrayUtils.jl
@@ -101,11 +101,11 @@ function update_profile_lw_kernel!(
         t_lev[nlay + 1, gcol] = FT(2) * t_lay[nlay, gcol] - t_lev[nlay, gcol]
 
         for glev in 1:nlev
-            T_ex_lev[glev, gcol] = sqrt(sqrt((flux_dn[glev, gcol] + (flux_net[glev, gcol] * ft_1by2)) / sbc))
+            T_ex_lev[glev, gcol] = sqrt(sqrt((flux_dn[gcol, glev] + (flux_net[gcol, glev] * ft_1by2)) / sbc))
         end
 
         for glev in 2:nlev
-            flux_grad[glev - 1, gcol] = abs(flux_net[glev, gcol] - flux_net[glev - 1, gcol])
+            flux_grad[gcol, glev - 1] = abs(flux_net[gcol, glev] - flux_net[gcol, glev - 1])
         end
     end
 end
@@ -146,7 +146,7 @@ end
 function compute_gray_heating_rate_kernel!(hr_lay, flux_net, p_lev, grav_, cp_d_, nlay, gcol)
     for ilay in 1:nlay
         @inbounds hr_lay[ilay, gcol] =
-            grav_ * (flux_net[ilay + 1, gcol] - flux_net[ilay, gcol]) / (p_lev[ilay + 1, gcol] - p_lev[ilay, gcol]) /
+            grav_ * (flux_net[gcol, ilay + 1] - flux_net[gcol, ilay]) / (p_lev[ilay + 1, gcol] - p_lev[ilay, gcol]) /
             cp_d_
     end
     return nothing

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -16,7 +16,7 @@ function rte_lw_2stream_solve!(
             compute_optical_props!(op, as, src_lw, gcol)
             rte_lw_2stream!(op, flux_lw, src_lw, bcs_lw, gcol, igpt, ibnd, nlev, ncol)
             for ilev in 1:nlev
-                flux_net[ilev, gcol] = flux_up[ilev, gcol] - flux_dn[ilev, gcol]
+                flux_net[gcol, ilev] = flux_up[gcol, ilev] - flux_dn[gcol, ilev]
             end
         end
     end
@@ -65,19 +65,19 @@ function rte_lw_2stream_solve!(
                 compute_optical_props!(op, as, src_lw, gcol, igpt, lookup_lw, lookup_lw_cld, lookup_lw_aero)
                 rte_lw_2stream!(op, flux, src_lw, bcs_lw, gcol, igpt, ibnd, nlev, ncol)
                 if igpt == 1
-                    map!(x -> x, view(flux_up_lw, :, gcol), view(flux_up, :, gcol))
-                    map!(x -> x, view(flux_dn_lw, :, gcol), view(flux_dn, :, gcol))
+                    map!(x -> x, view(flux_up_lw, gcol, :), view(flux_up, gcol, :))
+                    map!(x -> x, view(flux_dn_lw, gcol, :), view(flux_dn, gcol, :))
                 else
                     for ilev in 1:nlev
-                        @inbounds flux_up_lw[ilev, gcol] += flux_up[ilev, gcol]
-                        @inbounds flux_dn_lw[ilev, gcol] += flux_dn[ilev, gcol]
+                        @inbounds flux_up_lw[gcol, ilev] += flux_up[gcol, ilev]
+                        @inbounds flux_dn_lw[gcol, ilev] += flux_dn[gcol, ilev]
                     end
                 end
             end
         end
         ClimaComms.@threaded device for gcol in 1:ncol
             for ilev in 1:nlev
-                flux_net_lw[ilev, gcol] = flux_up_lw[ilev, gcol] - flux_dn_lw[ilev, gcol]
+                flux_net_lw[gcol, ilev] = flux_up_lw[gcol, ilev] - flux_dn_lw[gcol, ilev]
             end
         end
     end
@@ -183,7 +183,7 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
     (; inc_flux, sfc_emis) = bcs_lw
     FT = eltype(τ)
     @inbounds flux_dn_ilevplus1 = isnothing(inc_flux) ? FT(0) : inc_flux[gcol, igpt]
-    @inbounds flux_dn[nlev, gcol] = flux_dn_ilevplus1
+    @inbounds flux_dn[gcol, nlev] = flux_dn_ilevplus1
     # Albedo of lowest level is the surface albedo...
     @inbounds albedo_ilev = FT(1) - sfc_emis[ibnd, gcol]
     @inbounds albedo[1, gcol] = albedo_ilev
@@ -211,7 +211,7 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
     end
 
     # Eq 12, at the top of the domain upwelling diffuse is due to ...
-    @inbounds flux_up[nlev, gcol] =
+    @inbounds flux_up[gcol, nlev] =
         flux_dn_ilevplus1 * albedo[nlev, gcol] + # ... reflection of incident diffuse and
         src[nlev, gcol]                          # scattering by the direct beam below
 
@@ -227,10 +227,10 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
         flux_dn_ilev = (Tdif * flux_dn_ilevplus1 + # Equation 13
                         Rdif * src_ilev +
                         src_dn) * denom
-        flux_up[ilev, gcol] =
+        flux_up[gcol, ilev] =
             flux_dn_ilev * albedo_ilev + # Equation 12
             src_ilev
-        flux_dn[ilev, gcol] = flux_dn_ilev
+        flux_dn[gcol, ilev] = flux_dn_ilev
         flux_dn_ilevplus1 = flux_dn_ilev
         lev_src_top = lev_src_bot
         ilev -= 1

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -23,7 +23,7 @@ function rte_sw_2stream_solve!(
                 # call shortwave rte solver
                 rte_sw_2stream!(op, src_sw, bcs_sw, flux_sw, solar_frac, igpt, n_gpt, ibnd, nlev, gcol)
                 for ilev in 1:nlev
-                    flux_net_sw[ilev, gcol] = flux_up_sw[ilev, gcol] - flux_dn_sw[ilev, gcol]
+                    flux_net_sw[gcol, ilev] = flux_up_sw[gcol, ilev] - flux_dn_sw[gcol, ilev]
                 end
             else
                 set_flux_to_zero!(flux_sw, gcol)
@@ -80,12 +80,12 @@ function rte_sw_2stream_solve!(
                     # call rte shortwave solver
                     rte_sw_2stream!(op, src_sw, bcs_sw, flux, solar_frac, igpt, n_gpt, ibnd, nlev, gcol)
                     if igpt == 1
-                        map!(x -> x, view(flux_up_sw, :, gcol), view(flux_up, :, gcol))
-                        map!(x -> x, view(flux_dn_sw, :, gcol), view(flux_dn, :, gcol))
+                        map!(x -> x, view(flux_up_sw, gcol, :), view(flux_up, gcol, :))
+                        map!(x -> x, view(flux_dn_sw, gcol, :), view(flux_dn, gcol, :))
                     else
                         for ilev in 1:nlev
-                            @inbounds flux_up_sw[ilev, gcol] += flux_up[ilev, gcol]
-                            @inbounds flux_dn_sw[ilev, gcol] += flux_dn[ilev, gcol]
+                            @inbounds flux_up_sw[gcol, ilev] += flux_up[gcol, ilev]
+                            @inbounds flux_dn_sw[gcol, ilev] += flux_dn[gcol, ilev]
                         end
                     end
                 else
@@ -97,7 +97,7 @@ function rte_sw_2stream_solve!(
         ClimaComms.@threaded device for gcol in 1:ncol
             if cos_zenith[gcol] > 0
                 for ilev in 1:nlev
-                    flux_net_sw[ilev, gcol] = flux_up_sw[ilev, gcol] - flux_dn_sw[ilev, gcol]
+                    flux_net_sw[gcol, ilev] = flux_up_sw[gcol, ilev] - flux_dn_sw[gcol, ilev]
                 end
             end
         end
@@ -230,10 +230,10 @@ function rte_sw_2stream!(
     # Direct-beam and source for diffuse radiation
     flux_dn_dir_top = toa_flux * solar_frac * μ₀
     flux_dn_dir_bot = flux_dn_dir_top * exp(-τ_sum / μ₀) # store value at surface
-    @inbounds flux_dn_dir[1, gcol] = flux_dn_dir_bot # store value at surface
+    @inbounds flux_dn_dir[gcol, 1] = flux_dn_dir_bot # store value at surface
     sfc_source = flux_dn_dir_bot * sfc_alb_direct
 
-    @inbounds flux_dn[nlev, gcol] = FT(0) # set to incoming flux when provided?
+    @inbounds flux_dn[gcol, nlev] = FT(0) # set to incoming flux when provided?
     # Albedo of lowest level is the surface albedo...
     @inbounds surface_albedo = albedo[1, gcol] = bcs_sw.sfc_alb_diffuse[ibnd, gcol]
     # ... and source of diffuse radiation is surface emission
@@ -262,13 +262,13 @@ function rte_sw_2stream!(
         src_ilev = src_ilevplus1
     end
     # Eq 12, at the top of the domain upwelling diffuse is due to ...
-    @inbounds flux_up[nlev, gcol] =
-        flux_dn[nlev, gcol] * albedo[nlev, gcol] + # ... reflection of incident diffuse and
+    @inbounds flux_up[gcol, nlev] =
+        flux_dn[gcol, nlev] * albedo[nlev, gcol] + # ... reflection of incident diffuse and
         src[nlev, gcol]                          # scattering by the direct beam below
 
     # From the top of the atmosphere downward -- compute fluxes
-    @inbounds flux_dn_ilevplus1 = flux_dn[nlev, gcol]
-    @inbounds flux_dn[nlev, gcol] += flux_dn_dir_top
+    @inbounds flux_dn_ilevplus1 = flux_dn[gcol, nlev]
+    @inbounds flux_dn[gcol, nlev] += flux_dn_dir_top
     τ_cum = FT(0)
 
     ilev = nlay
@@ -282,10 +282,10 @@ function rte_sw_2stream!(
         flux_dn_ilev = (Tdif * flux_dn_ilevplus1 + # Equation 13
                         Rdif * src_ilev +
                         src_dn_ilev) * denom
-        flux_up[ilev, gcol] =
+        flux_up[gcol, ilev] =
             flux_dn_ilev * albedo_ilev + # Equation 12
             src_ilev
-        flux_dn[ilev, gcol] = flux_dn_ilev + flux_dn_dir_top * exp(-τ_cum / μ₀)
+        flux_dn[gcol, ilev] = flux_dn_ilev + flux_dn_dir_top * exp(-τ_cum / μ₀)
         flux_dn_ilevplus1 = flux_dn_ilev
         ilev -= 1
     end

--- a/test/all_sky_utils.jl
+++ b/test/all_sky_utils.jl
@@ -127,9 +127,9 @@ function all_sky(
     rel_err_flux_net_lw = abs.(flux_net_lw .- comp_flux_net_lw)
 
     for gcol in 1:ncol, glev in 1:nlev
-        den = abs(comp_flux_net_lw[glev, gcol])
+        den = abs(comp_flux_net_lw[gcol, glev])
         if den > 10 * eps(FT)
-            rel_err_flux_net_lw[glev, gcol] /= den
+            rel_err_flux_net_lw[gcol, glev] /= den
         end
     end
     max_rel_err_flux_net_lw = maximum(rel_err_flux_net_lw)
@@ -154,9 +154,9 @@ function all_sky(
     rel_err_flux_net_sw = abs.(flux_net_sw .- comp_flux_net_sw)
 
     for gcol in 1:ncol, glev in 1:nlev
-        den = abs(comp_flux_net_sw[glev, gcol])
+        den = abs(comp_flux_net_sw[gcol, glev])
         if den > 10 * eps(FT)
-            rel_err_flux_net_sw[glev, gcol] /= den
+            rel_err_flux_net_sw[gcol, glev] /= den
         end
     end
     max_rel_err_flux_net_sw = maximum(rel_err_flux_net_sw)

--- a/test/all_sky_with_aerosols_utils.jl
+++ b/test/all_sky_with_aerosols_utils.jl
@@ -132,9 +132,9 @@ function all_sky_with_aerosols(
     rel_err_flux_net_lw = abs.(flux_net_lw .- comp_flux_net_lw)
 
     for gcol in 1:ncol, glev in 1:nlev
-        den = abs(comp_flux_net_lw[glev, gcol])
+        den = abs(comp_flux_net_lw[gcol, glev])
         if den > 10 * eps(FT)
-            rel_err_flux_net_lw[glev, gcol] /= den
+            rel_err_flux_net_lw[gcol, glev] /= den
         end
     end
     max_rel_err_flux_net_lw = maximum(rel_err_flux_net_lw)
@@ -162,9 +162,9 @@ function all_sky_with_aerosols(
     rel_err_flux_net_sw = abs.(flux_net_sw .- comp_flux_net_sw)
 
     for gcol in 1:ncol, glev in 1:nlev
-        den = abs(comp_flux_net_sw[glev, gcol])
+        den = abs(comp_flux_net_sw[gcol, glev])
         if den > 10 * eps(FT)
-            rel_err_flux_net_sw[glev, gcol] /= den
+            rel_err_flux_net_sw[gcol, glev] /= den
         end
     end
     max_rel_err_flux_net_sw = maximum(rel_err_flux_net_sw)

--- a/test/clear_sky_utils.jl
+++ b/test/clear_sky_utils.jl
@@ -111,9 +111,9 @@ function clear_sky(
     rel_err_flux_net_lw = abs.(flux_net_lw .- comp_flux_net_lw)
 
     for gcol in 1:ncol, glev in 1:nlev
-        den = abs(comp_flux_net_lw[glev, gcol])
+        den = abs(comp_flux_net_lw[gcol, glev])
         if den > 10 * eps(FT)
-            rel_err_flux_net_lw[glev, gcol] /= den
+            rel_err_flux_net_lw[gcol, glev] /= den
         end
     end
     max_rel_err_flux_net_lw = maximum(rel_err_flux_net_lw)
@@ -139,8 +139,8 @@ function clear_sky(
     nnightcol = 0
     for gcol in 1:ncol
         if cos_zenith[gcol] ≤ 0
-            test_flux_up_sw = maximum(abs.(flux_up_sw[:, gcol])) ≈ FT(0)
-            test_flux_dn_sw = maximum(abs.(flux_dn_sw[:, gcol])) ≈ FT(0)
+            test_flux_up_sw = maximum(abs.(flux_up_sw[gcol, :])) ≈ FT(0)
+            test_flux_dn_sw = maximum(abs.(flux_dn_sw[gcol, :])) ≈ FT(0)
             if !(test_flux_up_sw && test_flux_dn_sw)
                 test_night_cols = false
             end
@@ -156,9 +156,9 @@ function clear_sky(
     rel_err_flux_net_sw = abs.(flux_net_sw .- comp_flux_net_sw)
 
     for gcol in 1:ncol, glev in 1:nlev
-        den = abs(comp_flux_net_sw[glev, gcol])
+        den = abs(comp_flux_net_sw[gcol, glev])
         if den > 10 * eps(FT)
-            rel_err_flux_net_sw[glev, gcol] /= den
+            rel_err_flux_net_sw[gcol, glev] /= den
         end
     end
 

--- a/test/gray_atm_utils.jl
+++ b/test/gray_atm_utils.jl
@@ -68,7 +68,7 @@ function gray_atmos_lw_equil(context, ::Type{SLVLW}, ::Type{FT}; exfiltrate = fa
     #----------------------------------------------------
     hr_lay = DA{FT}(undef, nlay, ncol)
     T_ex_lev = DA{FT}(undef, nlev, ncol)
-    flux_grad = DA{FT}(undef, nlay, ncol)
+    flux_grad = DA{FT}(undef, ncol, nlay)
     flux_grad_err = FT(0)
     exfiltrate && Infiltrator.@exfiltrate
     device = ClimaComms.device(context)

--- a/test/read_all_sky.jl
+++ b/test/read_all_sky.jl
@@ -189,8 +189,8 @@ function load_comparison_data(use_lut, bot_at_1, ncol)
     close(ds_comp_lw)
     close(ds_comp_sw)
     nlev, ncol_ds = size(comp_flux_up_lw)
-    return comp_flux_up_lw[:, 1:ncol],
-    comp_flux_dn_lw[:, 1:ncol],
-    comp_flux_up_sw[:, 1:ncol],
-    comp_flux_dn_sw[:, 1:ncol]
+    return Array(transpose(comp_flux_up_lw[:, 1:ncol])),
+    Array(transpose(comp_flux_dn_lw[:, 1:ncol])),
+    Array(transpose(comp_flux_up_sw[:, 1:ncol])),
+    Array(transpose(comp_flux_dn_sw[:, 1:ncol]))
 end

--- a/test/read_all_sky_with_aerosols.jl
+++ b/test/read_all_sky_with_aerosols.jl
@@ -226,5 +226,8 @@ function load_comparison_data(use_lut, bot_at_1, ncol)
     comp_flux_up_sw = hcat(repeat(comp_flux_up_sw_ref, 1, nrepeat), comp_flux_up_sw_ref[:, 1:rem])
     comp_flux_dn_sw = hcat(repeat(comp_flux_dn_sw_ref, 1, nrepeat), comp_flux_dn_sw_ref[:, 1:rem])
 
-    return comp_flux_up_lw, comp_flux_dn_lw, comp_flux_up_sw, comp_flux_dn_sw
+    return Array(transpose(comp_flux_up_lw)),
+    Array(transpose(comp_flux_dn_lw)),
+    Array(transpose(comp_flux_up_sw)),
+    Array(transpose(comp_flux_dn_sw))
 end

--- a/test/read_rfmip_clear_sky.jl
+++ b/test/read_rfmip_clear_sky.jl
@@ -151,10 +151,12 @@ function load_comparison_data(expt_no, bot_at_1, ncol)
     flux_dn_file_lw = get_reference_filename(:gas, :lw, :flux_dn)
     flux_up_file_sw = get_reference_filename(:gas, :sw, :flux_up)
     flux_dn_file_sw = get_reference_filename(:gas, :sw, :flux_dn)
+
     ds_comp_lw_up = Dataset(flux_up_file_lw, "r")
     ds_comp_lw_dn = Dataset(flux_dn_file_lw, "r")
     ds_comp_sw_up = Dataset(flux_up_file_sw, "r")
     ds_comp_sw_dn = Dataset(flux_dn_file_sw, "r")
+
     ncol_ds = size(Array(ds_comp_lw_up["rlu"]), 2)
     nrepeat = cld(ncol, ncol_ds)
 
@@ -162,13 +164,16 @@ function load_comparison_data(expt_no, bot_at_1, ncol)
     comp_flux_dn_lw = repeat(_orient_data(Array(ds_comp_lw_dn["rld"][:, :, expt_no]), bot_at_1), 1, nrepeat)
     comp_flux_up_sw = repeat(_orient_data(Array(ds_comp_sw_up["rsu"][:, :, expt_no]), bot_at_1), 1, nrepeat)
     comp_flux_dn_sw = repeat(_orient_data(Array(ds_comp_sw_dn["rsd"][:, :, expt_no]), bot_at_1), 1, nrepeat)
+
     close(ds_comp_lw_up)
     close(ds_comp_lw_dn)
     close(ds_comp_sw_up)
     close(ds_comp_sw_dn)
+
     nlev, ncol_ds = size(comp_flux_up_lw)
-    return comp_flux_up_lw[:, 1:ncol],
-    comp_flux_dn_lw[:, 1:ncol],
-    comp_flux_up_sw[:, 1:ncol],
-    comp_flux_dn_sw[:, 1:ncol]
+
+    return Array(transpose(comp_flux_up_lw[:, 1:ncol])),
+    Array(transpose(comp_flux_dn_lw[:, 1:ncol])),
+    Array(transpose(comp_flux_up_sw[:, 1:ncol])),
+    Array(transpose(comp_flux_dn_sw[:, 1:ncol]))
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Change data layout for fluxes.
Use `(ncol, nlev)` ordering instead of `(nlev, ncol)`.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
