### PR TITLE
Change data layout for optical properties.

### DIFF
--- a/src/optics/Optics.jl
+++ b/src/optics/Optics.jl
@@ -32,15 +32,15 @@ calculations accounting for extinction and emission
 $(DocStringExtensions.FIELDS)
 """
 struct OneScalar{D, V} <: AbstractOpticalProps
-    "storage for optical thickness"
+    "storage for optical thickness `(1, ncol, nlay)`"
     layerdata::D
-    "view into optical depth"
+    "view into optical depth `(ncol, nlay)`"
     τ::V
 end
 Adapt.@adapt_structure OneScalar
 
 function OneScalar(::Type{FT}, ncol::Int, nlay::Int, ::Type{DA}) where {FT <: AbstractFloat, DA}
-    layerdata = DA{FT, 3}(undef, 1, nlay, ncol)
+    layerdata = DA{FT, 3}(undef, 1, ncol, nlay)
     τ = view(layerdata, 1, :, :)
     V = typeof(τ)
     return OneScalar{typeof(layerdata), V}(layerdata, τ)
@@ -56,7 +56,7 @@ calculations accounting for extinction and emission
 $(DocStringExtensions.FIELDS)
 """
 struct TwoStream{D, V} <: AbstractOpticalProps
-    "storage for optical depth, single scattering albedo and asymmerty parameter"
+    "storage for optical depth, single scattering albedo and asymmerty parameter `(3, ncol, nlay)`"
     layerdata::D
     "view into optical depth"
     τ::V
@@ -68,7 +68,7 @@ end
 Adapt.@adapt_structure TwoStream
 
 function TwoStream(::Type{FT}, ncol::Int, nlay::Int, ::Type{DA}) where {FT <: AbstractFloat, DA}
-    layerdata = DA{FT, 3}(zeros(3, nlay, ncol))
+    layerdata = DA{FT, 3}(zeros(3, ncol, nlay))
     V = typeof(view(layerdata, 1, :, :))
     return TwoStream{typeof(layerdata), V}(
         layerdata,
@@ -190,7 +190,7 @@ Computes optical properties for the longwave problem.
         totplnk = view(lkp.planck.tot_planck, :, ibnd)
         as_layerdata = AtmosphericStates.getview_layerdata(as, gcol)
         t_lev_col = view(as.t_lev, :, gcol)
-        τ = view(op.τ, :, gcol)
+        τ = view(op.τ, gcol, :)
 
         lev_src_inc_prev = zero(t_sfc)
         lev_src_dec_prev = zero(t_sfc)
@@ -269,9 +269,9 @@ end
         totplnk = view(lkp.planck.tot_planck, :, ibnd)
         as_layerdata = AtmosphericStates.getview_layerdata(as, gcol)
         t_lev_col = view(as.t_lev, :, gcol)
-        τ = view(op.τ, :, gcol)
-        ssa = view(op.ssa, :, gcol)
-        g = view(op.g, :, gcol)
+        τ = view(op.τ, gcol, :)
+        ssa = view(op.ssa, gcol, :)
+        g = view(op.g, gcol, :)
     end
 
     lev_src_inc_prev = zero(t_sfc)
@@ -362,7 +362,7 @@ Computes optical properties for the shortwave problem.
         ibnd = lkp.band_data.major_gpt2bnd[igpt]
         t_sfc = as.t_sfc[gcol]
         as_layerdata = AtmosphericStates.getview_layerdata(as, gcol)
-        τ = view(op.τ, :, gcol)
+        τ = view(op.τ, gcol, :)
     end
     @inbounds for glay in 1:nlay
         col_dry, p_lay, t_lay = as_layerdata[1, glay], as_layerdata[2, glay], as_layerdata[3, glay]
@@ -387,9 +387,9 @@ end
         ibnd = lkp.band_data.major_gpt2bnd[igpt]
         t_sfc = as.t_sfc[gcol]
         as_layerdata = AtmosphericStates.getview_layerdata(as, gcol)
-        τ = view(op.τ, :, gcol)
-        ssa = view(op.ssa, :, gcol)
-        g = view(op.g, :, gcol)
+        τ = view(op.τ, gcol, :)
+        ssa = view(op.ssa, gcol, :)
+        g = view(op.g, gcol, :)
     end
     @inbounds for glay in 1:nlay
         col_dry, p_lay, t_lay = as_layerdata[1, glay], as_layerdata[2, glay], as_layerdata[3, glay]

--- a/src/optics/gray_optics_kernels.jl
+++ b/src/optics/gray_optics_kernels.jl
@@ -32,7 +32,7 @@ function compute_optical_props!(op::OneScalar, as::GrayAtmosphericState, sf::Sou
             p_lev_glayplus1 = p_lev[glay + 1, gcol]
             Δp = p_lev_glayplus1 - p_lev_glay
             p = p_lay[glay, gcol]
-            τ[glay, gcol] = compute_gray_optical_thickness_lw(otp, p0, Δp, p, lat)
+            τ[gcol, glay] = compute_gray_optical_thickness_lw(otp, p0, Δp, p, lat)
             p_lev_glay = p_lev_glayplus1
             # compute longwave source terms
             t_lev_inc = t_lev[glay + 1, gcol]
@@ -74,7 +74,7 @@ function compute_optical_props!(op::TwoStream, as::GrayAtmosphericState, sf::Sou
             p_lev_glayplus1 = p_lev[glay + 1, gcol]
             Δp = p_lev_glayplus1 - p_lev_glay
             p = p_lay[glay, gcol]
-            τ[glay, gcol] = compute_gray_optical_thickness_lw(otp, p0, Δp, p, lat)
+            τ[gcol, glay] = compute_gray_optical_thickness_lw(otp, p0, Δp, p, lat)
             p_lev_glay = p_lev_glayplus1
             # compute longwave source terms
             t_lev_inc = t_lev[glay + 1, gcol]
@@ -92,8 +92,8 @@ function compute_optical_props!(op::TwoStream, as::GrayAtmosphericState, sf::Sou
         lev_source[nlay + 1, gcol] = lev_src_inc_prev
     end
     zeroval = zero(FT)
-    map!(x -> zeroval, view(ssa, :, gcol), view(ssa, :, gcol))
-    map!(x -> zeroval, view(g, :, gcol), view(g, :, gcol))
+    map!(x -> zeroval, view(ssa, gcol, :), view(ssa, gcol, :))
+    map!(x -> zeroval, view(g, gcol, :), view(g, gcol, :))
     return nothing
 end
 
@@ -118,15 +118,15 @@ function compute_optical_props!(op::AbstractOpticalProps, as::GrayAtmosphericSta
         @inbounds p_lev_glayplus1 = p_lev[glay + 1, gcol]
         @inbounds Δp = p_lev_glayplus1 - p_lev_glay
         @inbounds p = p_lay[glay, gcol]
-        @inbounds τ[glay, gcol] = compute_gray_optical_thickness_sw(otp, p0, Δp, p, lat)
+        @inbounds τ[gcol, glay] = compute_gray_optical_thickness_sw(otp, p0, Δp, p, lat)
         p_lev_glay = p_lev_glayplus1
     end
     if op isa TwoStream
         (; ssa, g) = op
         FT = eltype(τ)
         zeroval = zero(FT)
-        map!(x -> zeroval, view(ssa, :, gcol), view(ssa, :, gcol))
-        map!(x -> zeroval, view(g, :, gcol), view(g, :, gcol))
+        map!(x -> zeroval, view(ssa, gcol, :), view(ssa, gcol, :))
+        map!(x -> zeroval, view(g, gcol, :), view(g, gcol, :))
     end
     return nothing
 end

--- a/src/rte/longwave1scalar.jl
+++ b/src/rte/longwave1scalar.jl
@@ -164,7 +164,7 @@ Transport for no-scattering longwave problem.
     # Downward propagation
     ilev = nlay
     @inbounds while ilev ≥ 1
-        τ_loc = τ[ilev, gcol] * Ds
+        τ_loc = τ[gcol, ilev] * Ds
         trans = exp(-τ_loc)
         lay_src = lay_source[ilev, gcol]
         intensity_dn_ilev =
@@ -183,7 +183,7 @@ Transport for no-scattering longwave problem.
 
     # Upward propagation
     @inbounds for ilev in 2:(nlay + 1)
-        τ_loc = τ[ilev - 1, gcol] * Ds
+        τ_loc = τ[gcol, ilev - 1] * Ds
         trans = exp(-τ_loc)
         lay_src = lay_source[ilev - 1, gcol]
         intensity_up_ilev =

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -196,7 +196,7 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
     @inbounds lev_src_bot = lev_source[1, gcol]
     @inbounds for ilev in 1:nlay
         lev_src_top = lev_source[ilev + 1, gcol]
-        τ_lay, ssa_lay, g_lay = τ[ilev, gcol], ssa[ilev, gcol], g[ilev, gcol]
+        τ_lay, ssa_lay, g_lay = τ[gcol, ilev], ssa[gcol, ilev], g[gcol, ilev]
         Rdif, Tdif, src_up, src_dn = lw_2stream_coeffs(τ_lay, ssa_lay, g_lay, lev_src_bot, lev_src_top)
         denom = FT(1) / (FT(1) - Rdif * albedo_ilev)  # Eq 10
         albedo_ilevplus1 = Rdif + Tdif * Tdif * albedo_ilev * denom # Equation 9
@@ -220,7 +220,7 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
     ilev = nlay
     @inbounds while ilev ≥ 1
         lev_src_bot, albedo_ilev, src_ilev = lev_source[ilev, gcol], albedo[ilev, gcol], src[ilev, gcol]
-        τ_lay, ssa_lay, g_lay = τ[ilev, gcol], ssa[ilev, gcol], g[ilev, gcol]
+        τ_lay, ssa_lay, g_lay = τ[gcol, ilev], ssa[gcol, ilev], g[gcol, ilev]
         Rdif, Tdif, _, src_dn = lw_2stream_coeffs(τ_lay, ssa_lay, g_lay, lev_src_bot, lev_src_top)
 
         denom = FT(1) / (FT(1) - Rdif * albedo_ilev)  # Eq 10

--- a/src/rte/shortwave1scalar.jl
+++ b/src/rte/shortwave1scalar.jl
@@ -103,7 +103,7 @@ function rte_sw_noscat!(
     @inbounds flux_dn_dir[gcol, nlev] = toa_flux[gcol] * solar_frac * cos_zenith[gcol]
     ilev = nlev - 1
     @inbounds while ilev ≥ 1
-        flux_dn_dir[gcol, ilev] = flux_dn_dir[gcol, ilev + 1] * exp(-τ[ilev, gcol] / cos_zenith[gcol])
+        flux_dn_dir[gcol, ilev] = flux_dn_dir[gcol, ilev + 1] * exp(-τ[gcol, ilev] / cos_zenith[gcol])
         flux_net[gcol, ilev] = -flux_dn_dir[gcol, ilev]
         ilev -= 1
     end

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -225,7 +225,7 @@ function rte_sw_2stream!(
     end
     τ_sum = FT(0)
     for ilay in 1:nlay
-        @inbounds τ_sum += τ[ilay, gcol]
+        @inbounds τ_sum += τ[gcol, ilay]
     end
     # Direct-beam and source for diffuse radiation
     flux_dn_dir_top = toa_flux * solar_frac * μ₀
@@ -243,7 +243,7 @@ function rte_sw_2stream!(
     τ_cum = τ_sum
     albedo_ilev, src_ilev = surface_albedo, sfc_source
     @inbounds for ilev in 1:nlay
-        τ_ilev, ssa_ilev, g_ilev = τ[ilev, gcol], ssa[ilev, gcol], g[ilev, gcol]
+        τ_ilev, ssa_ilev, g_ilev = τ[gcol, ilev], ssa[gcol, ilev], g[gcol, ilev]
         (Rdir, Tdir, _, Rdif, Tdif) = sw_2stream_coeffs(τ_ilev, ssa_ilev, g_ilev, μ₀)
         denom = FT(1) / (FT(1) - Rdif * albedo_ilev)  # Eq 10
         albedo_ilevplus1 = Rdif + Tdif * Tdif * albedo_ilev * denom # Equation 9
@@ -273,7 +273,7 @@ function rte_sw_2stream!(
 
     ilev = nlay
     @inbounds while ilev ≥ 1
-        τ_ilev, ssa_ilev, g_ilev = τ[ilev, gcol], ssa[ilev, gcol], g[ilev, gcol]
+        τ_ilev, ssa_ilev, g_ilev = τ[gcol, ilev], ssa[gcol, ilev], g[gcol, ilev]
         albedo_ilev, src_ilev = albedo[ilev, gcol], src[ilev, gcol]
         (_, Tdir, _, Rdif, Tdif) = sw_2stream_coeffs(τ_ilev, ssa_ilev, g_ilev, μ₀)
         denom = FT(1) / (FT(1) - Rdif * albedo_ilev)  # Eq 10

--- a/test/gray_atm_utils.jl
+++ b/test/gray_atm_utils.jl
@@ -176,7 +176,7 @@ function gray_atmos_sw_test(
     toa_flux = Array(toa_flux)
 
     # testing with exact solution
-    ot_tot = sum(τ[:, 1]) / cos_zenith[1]
+    ot_tot = sum(τ[1, :]) / cos_zenith[1]
     exact = (toa_flux[1] * cos_zenith[1]) * exp(-ot_tot)
 
     rel_toler = FT(0.001)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Change data layout for optical properties.
Use (ncol, nlev) ordering instead of (nlev, ncol).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
