### PR TITLE
Fix typo in `compute_relative_humidity_kernel!`

### DIFF
--- a/src/optics/gas_optics.jl
+++ b/src/optics/gas_optics.jl
@@ -65,9 +65,8 @@ function compute_relative_humidity_kernel!(
     glay::Int,
     gcol::Int,
 ) where {FT}
-    mmr_h2o =
     # Convert h2o vmr to mmr
-        mmr_h2o = vmr_h2o[glay, gcol] * mwd
+    mmr_h2o = vmr_h2o[glay, gcol] * mwd
     q_lay = mmr_h2o / (FT(1) + mmr_h2o)
     q_tmp = max(q_lay_min, q_lay)
     es_tmp = exp((FT(17.67) * (t_lay[glay, gcol] - t_ref)) / (t_lay[glay, gcol] - FT(29.65)))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Fix typo (dangling line) in compute_relative_humidity_kernel!
Reapply PR https://github.com/CliMA/RRTMGP.jl/pull/537




<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
