### PR TITLE
Update climacommon to 2024_10_09

### DIFF
--- a/.buildkite/A100_pipeline/pipeline.yml
+++ b/.buildkite/A100_pipeline/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: clima
-  modules: climacommon/2024_04_05
+  modules: climacommon/2024_10_09
 
 env:
   OPENBLAS_NUM_THREADS: 1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: new-central
-  modules: climacommon/2024_05_27
+  modules: climacommon/2024_10_09
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

The most recent version of climacommon uses the newly released Julia 1.11.0.