### PR TITLE
Rename tests.

### DIFF
--- a/.buildkite/A100_pipeline/pipeline.yml
+++ b/.buildkite/A100_pipeline/pipeline.yml
@@ -68,8 +68,8 @@ steps:
           slurm_mem_per_cpu: 6G
 
       - label: "Flame Graph: All Sky"
-        command: "julia --color=yes --project=test perf/flame.jl all_sky.jl"
-        artifact_paths: "flame_graphs/all_sky/*"
+        command: "julia --color=yes --project=test perf/flame.jl cloudy_sky.jl"
+        artifact_paths: "flame_graphs/cloudy_sky/*"
         agents:
           slurm_ntasks: 1
           slurm_mem_per_cpu: 6G
@@ -113,8 +113,8 @@ steps:
           slurm_gres: "gpu:1"
           slurm_exclusive:
 
-      - label: "GPU all-sky DYAMOND benchmark"
-        command: "julia --color=yes --project=test test/all_sky_dyamond_gpu_benchmark.jl"
+      - label: "GPU cloudy-sky DYAMOND benchmark"
+        command: "julia --color=yes --project=test test/cloudy_sky_dyamond_gpu_benchmark.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,8 +68,8 @@ steps:
           slurm_mem_per_cpu: 6G
 
       - label: "Flame Graph: All Sky"
-        command: "julia --color=yes --project=test perf/flame.jl all_sky.jl"
-        artifact_paths: "flame_graphs/all_sky/*"
+        command: "julia --color=yes --project=test perf/flame.jl cloudy_sky.jl"
+        artifact_paths: "flame_graphs/cloudy_sky/*"
         agents:
           slurm_ntasks: 1
           slurm_mem_per_cpu: 6G
@@ -112,7 +112,7 @@ steps:
           slurm_gres: "gpu:1"
 
       - label: "GPU all-sky DYAMOND benchmark"
-        command: "julia --color=yes --project=test test/all_sky_dyamond_gpu_benchmark.jl"
+        command: "julia --color=yes --project=test test/cloudy_sky_dyamond_gpu_benchmark.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -91,15 +91,15 @@ end
 show(stdout, MIME("text/plain"), trial)
 println()
 
-@info "------------------------------------------------- Benchmark: all_sky"
+@info "------------------------------------------------- Benchmark: cloudy_sky"
 # @suppress_out begin
-include(joinpath(root_dir, "test", "all_sky_utils.jl"))
+include(joinpath(root_dir, "test", "cloudy_sky_utils.jl"))
 
 toler_lw_noscat = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.05))
 toler_lw_2stream = Dict(Float64 => Float64(5), Float32 => Float32(5))
 toler_sw = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.06))
 
-all_sky(
+cloudy_sky(
     ClimaComms.context(),
     TwoStreamLWRTE,
     TwoStreamSWRTE,
@@ -117,7 +117,7 @@ all_sky(
 solve_sw!(slv_sw, as, lookup_sw, lookup_sw_cld) # compile first
 solve_lw!(slv_lw, as, lookup_lw, lookup_lw_cld) # compile first
 
-@info "all_sky, lw, use_lut=true"
+@info "cloudy_sky, lw, use_lut=true"
 device = ClimaComms.device(ClimaComms.context())
 trial = if device isa ClimaComms.CUDADevice
     using CUDA
@@ -127,7 +127,7 @@ else
 end
 show(stdout, MIME("text/plain"), trial)
 println()
-@info "all_sky, sw, use_lut=true"
+@info "cloudy_sky, sw, use_lut=true"
 device = ClimaComms.device(ClimaComms.context())
 trial = if device isa ClimaComms.CUDADevice
     using CUDA
@@ -137,45 +137,3 @@ else
 end
 show(stdout, MIME("text/plain"), trial)
 println()
-
-#=
-# @suppress_out begin
-all_sky(
-    ClimaComms.context(),
-    TwoStream,
-    TwoStream,
-    TwoStreamLWRTE,
-    TwoStreamSWRTE,
-    FT;
-    use_lut = false,
-    cldfrac = FT(1),
-    exfiltrate = true,
-)
-# end
-
-(; slv_lw, slv_sw, as, lookup_sw, lookup_sw_cld, lookup_lw, lookup_lw_cld) = Infiltrator.exfiltrated
-
-solve_sw!(slv_sw, as, lookup_sw, lookup_sw_cld) # compile first
-solve_lw!(slv_lw, as, lookup_lw, lookup_lw_cld) # compile first
-
-@info "all_sky, lw, use_lut=false"
-device = ClimaComms.device(ClimaComms.context())
-trial = if device isa ClimaComms.CUDADevice
-    using CUDA
-    @benchmark CUDA.@sync solve_lw!($slv_lw, $as, $lookup_lw, $lookup_lw_cld)
-else
-    @benchmark solve_lw!($slv_lw, $as, $lookup_lw, $lookup_lw_cld)
-end
-show(stdout, MIME("text/plain"), trial)
-println()
-@info "all_sky, sw, use_lut=false"
-device = ClimaComms.device(ClimaComms.context())
-trial = if device isa ClimaComms.CUDADevice
-    using CUDA
-    @benchmark CUDA.@sync solve_sw!($slv_sw, $as, $lookup_sw, $lookup_sw_cld)
-else
-    @benchmark solve_sw!($slv_sw, $as, $lookup_sw, $lookup_sw_cld)
-end
-show(stdout, MIME("text/plain"), trial)
-println()
-=#

--- a/test/clear_sky_dyamond_gpu_benchmark.jl
+++ b/test/clear_sky_dyamond_gpu_benchmark.jl
@@ -25,7 +25,7 @@ using RRTMGP.ArtifactPaths
 # overriding some parameters to match with RRTMGP FORTRAN code
 
 include("reference_files.jl")
-include("read_rfmip_clear_sky.jl")
+include("read_clear_sky.jl")
 
 function benchmark_clear_sky(
     context,
@@ -62,7 +62,7 @@ function benchmark_clear_sky(
     input_file = get_input_filename(:gas, :lw) # all-sky atmos state
     ds_lw_in = Dataset(input_file, "r")
     (as, sfc_emis, sfc_alb_direct, cos_zenith, toa_flux, bot_at_1) =
-        setup_rfmip_as(context, ds_lw_in, idx_gases, expt_no, lookup_lw, ncol, FT, VMR, param_set)
+        setup_clear_sky_as(context, ds_lw_in, idx_gases, expt_no, lookup_lw, ncol, FT, VMR, param_set)
     close(ds_lw_in)
 
     nlay, _ = AtmosphericStates.get_dims(as)

--- a/test/clear_sky_utils.jl
+++ b/test/clear_sky_utils.jl
@@ -25,7 +25,7 @@ using RRTMGP.ArtifactPaths
 # overriding some parameters to match with RRTMGP FORTRAN code
 
 include("reference_files.jl")
-include("read_rfmip_clear_sky.jl")
+include("read_clear_sky.jl")
 #---------------------------------------------------------------
 function clear_sky(
     context,
@@ -63,7 +63,7 @@ function clear_sky(
     # reading rfmip data to atmospheric state
     ds_lw_in = Dataset(input_file, "r")
     (as, sfc_emis, sfc_alb_direct, cos_zenith, toa_flux, bot_at_1) =
-        setup_rfmip_as(context, ds_lw_in, idx_gases, expt_no, lookup_lw, ncol, FT, VMR, param_set)
+        setup_clear_sky_as(context, ds_lw_in, idx_gases, expt_no, lookup_lw, ncol, FT, VMR, param_set)
     close(ds_lw_in)
 
     nlay, _ = AtmosphericStates.get_dims(as)

--- a/test/cloudy_sky.jl
+++ b/test/cloudy_sky.jl
@@ -1,5 +1,5 @@
 FT = get(ARGS, 1, Float64) == "Float32" ? Float32 : Float64
-include("all_sky_utils.jl")
+include("cloudy_sky_utils.jl")
 
 context = ClimaComms.context()
 
@@ -8,7 +8,7 @@ toler_lw_2stream = Dict(Float64 => Float64(5), Float32 => Float32(5))
 toler_sw = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.06))
 
 @testset "Cloudy-sky (gas + clouds) calculations using lookup table method, with non-scattering LW and TwoStream SW solvers" begin
-    @time all_sky(
+    @time cloudy_sky(
         context,
         NoScatLWRTE,
         TwoStreamSWRTE,
@@ -22,7 +22,7 @@ toler_sw = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.06))
 end
 
 @testset "Cloudy-sky (gas + clouds) Two-stream calculations using lookup table method" begin
-    @time all_sky(
+    @time cloudy_sky(
         context,
         TwoStreamLWRTE,
         TwoStreamSWRTE,

--- a/test/cloudy_sky_dyamond_gpu_benchmark.jl
+++ b/test/cloudy_sky_dyamond_gpu_benchmark.jl
@@ -25,7 +25,7 @@ using RRTMGP.ArtifactPaths
 # overriding some parameters to match with RRTMGP FORTRAN code
 
 include("reference_files.jl")
-include("read_all_sky.jl")
+include("read_cloudy_sky.jl")
 
 function benchmark_all_sky(
     context,
@@ -70,7 +70,7 @@ function benchmark_all_sky(
     close(ds_sw_cld)
     # reading input file 
     ds_in = Dataset(input_file, "r")
-    as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, cos_zenith, toa_flux, bot_at_1 = setup_allsky_as(
+    as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, cos_zenith, toa_flux, bot_at_1 = setup_cloudy_sky_as(
         context,
         ds_in,
         idx_gases,

--- a/test/cloudy_sky_utils.jl
+++ b/test/cloudy_sky_utils.jl
@@ -24,9 +24,9 @@ using RRTMGP.ArtifactPaths
 # overriding some parameters to match with RRTMGP FORTRAN code
 
 include("reference_files.jl")
-include("read_all_sky.jl")
+include("read_cloudy_sky.jl")
 
-function all_sky(
+function cloudy_sky(
     context,
     ::Type{SLVLW},
     ::Type{SLVSW},
@@ -70,7 +70,7 @@ function all_sky(
     close(ds_sw_cld)
     # reading input file 
     ds_in = Dataset(input_file, "r")
-    as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, cos_zenith, toa_flux, bot_at_1 = setup_allsky_as(
+    as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, cos_zenith, toa_flux, bot_at_1 = setup_cloudy_sky_as(
         context,
         ds_in,
         idx_gases,

--- a/test/read_clear_sky.jl
+++ b/test/read_clear_sky.jl
@@ -4,7 +4,7 @@ function ncol_ds_clear_sky()
     return size(Array(ds_comp["rlu"]), 2)
 end
 
-function setup_rfmip_as(
+function setup_clear_sky_as(
     context,
     ds_lw_in,
     idx_gases,

--- a/test/read_cloudy_sky.jl
+++ b/test/read_cloudy_sky.jl
@@ -4,7 +4,7 @@ function ncol_ds_all_sky(use_lut)
     return size(Array(ds_comp["lw_flux_up"]), 1)
 end
 
-function setup_allsky_as(
+function setup_cloudy_sky_as(
     context,
     ds_in,
     idx_gases,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,9 +35,9 @@ printstyled("=================================\n\n", color = color1)
     toler_lw_2stream = Dict(Float64 => Float64(5), Float32 => Float32(5))
     toler_sw = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.06))
 
-    include("all_sky_utils.jl")
+    include("cloudy_sky_utils.jl")
     for FT in (Float32, Float64)
-        all_sky(
+        cloudy_sky(
             context,
             NoScatLWRTE,
             TwoStreamSWRTE,
@@ -48,7 +48,7 @@ printstyled("=================================\n\n", color = color1)
             use_lut = true,
             cldfrac = FT(1),
         )
-        all_sky(
+        cloudy_sky(
             context,
             TwoStreamLWRTE,
             TwoStreamSWRTE,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Rename:
`rfmip_clear_sky` => `clear_sky`
`all_sky` => `cloudy_sky`
`all_sky_with_aerosols` => `all_sky_with_aerosols` (no change)

Reason for change:
The name `all-sky` can be a bit confusing. In our most general case, we account for gases, clouds and aerosols for optics computation. However, in the atmospheric modeling community, `all-sky` generally means cloudy sky and an additional qualifier (e.g.: `all-sky-with-aerosols`) is used when aerosol optics contributions are also added. This PR hopes to make these names less ambiguous!

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
