### PR TITLE
small fix for aerosol size bin

### DIFF
--- a/src/optics/aerosol_optics.jl
+++ b/src/optics/aerosol_optics.jl
@@ -282,6 +282,7 @@ function locate_merra_size_bin(size_bin_limits, aerosize)
                 bin = ibin
                 break
             end
+            bin = nbins
         end
     end
     return bin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Right now, the aerosols are assigned bin 1 when the size is larger than the largest size bin. I think it is safer to assign them to the last size bin.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
