### PR TITLE
Remove explicit Array call with single element CommonData var

### DIFF
--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -660,8 +660,8 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
 
     a_offset = FT(0.1495954)
     b_offset = FT(0.00066696)
-    mg_index = FT(max(ds["mg_default"][], 0))
-    sb_index = FT(max(ds["sb_default"][], 0))
+    mg_index = FT(max(ds["mg_default"][1], 0))
+    sb_index = FT(max(ds["sb_default"][1], 0))
     solar_src =
         Array(ds["solar_source_quiet"]) .+ (mg_index - a_offset) .* Array(ds["solar_source_facular"]) .+
         (sb_index - b_offset) .* Array(ds["solar_source_sunspot"])
@@ -769,13 +769,13 @@ function LookUpCld(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     ])
     bounds = DA([
         # liquid particle size lower bound for LUT interpolation
-        FT(ds["radliq_lwr"][]),
+        FT(ds["radliq_lwr"][1]),
         # liquid particle size upper bound for LUT interpolation
-        FT(ds["radliq_upr"][]),
+        FT(ds["radliq_upr"][1]),
         # ice particle size lower bound for LUT interpolation
-        FT(ds["diamice_lwr"][]) / 2,
+        FT(ds["diamice_lwr"][1]) / 2,
         # ice particle size upper bound for LUT interpolation
-        FT(ds["diamice_upr"][]) / 2,
+        FT(ds["diamice_upr"][1]) / 2,
     ])
     liqdata = DA(vcat(Array(ds["extliq"]), Array(ds["ssaliq"]), Array(ds["asyliq"])))
     icedata = DA(vcat(Array(ds["extice"]), Array(ds["ssaice"]), Array(ds["asyice"])))
@@ -824,12 +824,12 @@ end
 """
     LookUpAerosolMerra{D, D1, D2, D3, D4, W} <: AbstractLookUp
 
-Merra lookup table for aersols. 
+Merra lookup table for aersols.
 
 This struct stores the lookup tables for determing extinction coeffient,
 single-scattering albedo, and asymmetry parameter g as a function of aerosol
 particle size, relative humidity and band. Data is provided for dust, sea salt,
-sulfate, black carbon (hydrophobic and hydrophilic) and organic carbon 
+sulfate, black carbon (hydrophobic and hydrophilic) and organic carbon
 (hydrophobic and hydrophilic).
 
 

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -146,9 +146,9 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     n_contrib_lower = Int(ds.dim["contributors_lower"])
     n_contrib_upper = Int(ds.dim["contributors_upper"])
 
-    p_ref_tropo = FT(Array(ds["press_ref_trop"])[1])
-    t_ref_absrb = FT(Array(ds["absorption_coefficient_ref_T"])[1]) # not currently used
-    p_ref_absrb = FT(Array(ds["absorption_coefficient_ref_P"])[1]) # not currently used
+    p_ref_tropo = FT(ds["press_ref_trop"][1])
+    t_ref_absrb = FT(ds["absorption_coefficient_ref_T"][1]) # not currently used
+    p_ref_absrb = FT(ds["absorption_coefficient_ref_P"][1]) # not currently used
 
     gases_major = STA(undef, n_maj_absrb)
     gases_minor = STA(undef, n_min_absrb)
@@ -470,9 +470,9 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     n_contrib_lower = Int(ds.dim["contributors_lower"])
     n_contrib_upper = Int(ds.dim["contributors_upper"])
 
-    p_ref_tropo = FT(Array(ds["press_ref_trop"])[1])
-    t_ref_absrb = FT(Array(ds["absorption_coefficient_ref_T"])[1]) # not currently used
-    p_ref_absrb = FT(Array(ds["absorption_coefficient_ref_P"])[1]) # not currently used
+    p_ref_tropo = FT(ds["press_ref_trop"][1])
+    t_ref_absrb = FT(ds["absorption_coefficient_ref_T"][1]) # not currently used
+    p_ref_absrb = FT(ds["absorption_coefficient_ref_P"][1]) # not currently used
 
     gases_major = STA(undef, n_maj_absrb)
     gases_minor = STA(undef, n_min_absrb)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Addresses [this](https://github.com/CliMA/ClimaAtmos.jl/issues/3676) issue in ClimaAtmos. 

It seems that [this](https://github.com/JuliaLang/julia/commit/75cb2f60af7e1d0a2dd5472ff2390600aa083db2) commit
to JuliaLang, changes the behavior of "all(())" when the Static.jl package is imported. 

```
treddy@Tejas-MacBook-Air ClimaAtmos.jl % julia +nightly --project
[ Info: Precompiling Revise [295af30f-e4ad-537b-8983-00126c2a3abe] (cache misses: incompatible header (2))
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.13.0-DEV.169 (2025-03-05)
 _/ |\__'_|_|_|\__'_|  |  Commit 3d628934767 (0 days old master)
|__/                   |

julia> all(())
true
julia> using ClimaAtmos
julia> all(())
ERROR: MethodError: all(::Tuple{}) is ambiguous.

Candidates:
  all(::Tuple{Vararg{Static.True}})
    @ Static ~/.julia/packages/Static/1Mvph/src/Static.jl:520
  all(::Tuple{Vararg{Static.False}})
    @ Static ~/.julia/packages/Static/1Mvph/src/Static.jl:522

Possible fix, define
  all(::Tuple{})

Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
 [2] top-level scope
   @ REPL:1
```
[These](https://github.com/SciML/Static.jl/blob/2e254a37b294f63407d2b486b6d09d2806e7a216/src/Static.jl#L524-L526) lines in Static.jl cause any of an empty tuple to be ambiguous. 

This should probably be fixed in  CommonDataTypes.jl or Static.jl. Should I open an issue in one of those packages?

Another easy temporary fix is  to define `any(::Tuple{}) = true`.

You can see that using this branch fixes the atmos nightly lookahead [here](https://github.com/CliMA/ClimaAtmos.jl/actions/runs/13686805764/job/38274588300)

----
- [ ] I have read and checked the items on the review checklist.
