### PR TITLE
Add nsys profiler to GPU benchmarks

### DIFF
--- a/.buildkite/A100_pipeline/pipeline.yml
+++ b/.buildkite/A100_pipeline/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: clima
-  modules: climacommon/2024_10_08
+  modules: climacommon/2024_12_16 nsight-systems/2024.6.1
 
 env:
   OPENBLAS_NUM_THREADS: 1
@@ -105,7 +105,12 @@ steps:
           slurm_exclusive:
 
       - label: "GPU clear-sky DYAMOND benchmark"
-        command: "julia --color=yes --project=test test/clear_sky_dyamond_gpu_benchmark.jl"
+        command:
+          - mkdir -p clear_sky_dyamond_gpu_benchmark
+          - >
+            nsys profile --trace=nvtx,cuda,osrt --output=clear_sky_dyamond_gpu_benchmark/report
+            julia --color=yes --project=test test/clear_sky_dyamond_gpu_benchmark.jl
+        artifact_paths: "clear_sky_dyamond_gpu_benchmark/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -114,7 +119,12 @@ steps:
           slurm_exclusive:
 
       - label: "GPU cloudy-sky DYAMOND benchmark"
-        command: "julia --color=yes --project=test test/cloudy_sky_dyamond_gpu_benchmark.jl"
+        command:
+          - mkdir -p cloudy_sky_dyamond_gpu_benchmark
+          - >
+            nsys profile --trace=nvtx,cuda,osrt --output=cloudy_sky_dyamond_gpu_benchmark/report
+            julia --color=yes --project=test test/cloudy_sky_dyamond_gpu_benchmark.jl
+        artifact_paths: "cloudy_sky_dyamond_gpu_benchmark/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -123,7 +133,12 @@ steps:
           slurm_exclusive:
 
       - label: "GPU all-sky with aerosols DYAMOND benchmark"
-        command: "julia --color=yes --project=test test/all_sky_with_aerosols_dyamond_gpu_benchmark.jl"
+        command:
+          - mkdir -p all_sky_with_aerosols_dyamond_gpu_benchmark
+          - >
+            nsys profile --trace=nvtx,cuda,osrt --output=all_sky_with_aerosols_dyamond_gpu_benchmark/report
+            julia --color=yes --project=test test/all_sky_with_aerosols_dyamond_gpu_benchmark.jl
+        artifact_paths: "all_sky_with_aerosols_dyamond_gpu_benchmark/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add nsys profiler to GPU benchmarks

## Summary of Changes
This pull request adds the `nsys` profiler to the GPU benchmarks in the `.buildkite/A100_pipeline/pipeline.yml` file. The changes involve modifying the `pipeline.yml` file to include the `nsight-systems/2024.6.1` module and adding `nsys profile` commands to the clear-sky, cloudy-sky, and all-sky DYAMOND GPU benchmark steps. This will enable profiling of these benchmarks using NVIDIA's Nsight Systems profiler.

### Highlights
* **Profiling**: Adds `nsys` profiling to GPU benchmarks to trace `nvtx`, `cuda`, and `osrt` events.
* **Module Update**: Includes the `nsight-systems/2024.6.1` module in the Buildkite pipeline.
* **Benchmark Commands**: Modifies benchmark commands to use `nsys profile` for generating profiling reports.

### Changelog
* **.buildkite/A100_pipeline/pipeline.yml**
  * Added `nsight-systems/2024.6.1` to the list of modules used by the Buildkite agent.
  * Modified the 'GPU clear-sky DYAMOND benchmark' step to use `nsys profile` to generate a profiling report.
  * Modified the 'GPU cloudy-sky DYAMOND benchmark' step to use `nsys profile` to generate a profiling report.
  * Modified the 'GPU all-sky with aerosols DYAMOND benchmark' step to use `nsys profile` to generate a profiling report.
  
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
