### PR TITLE
F32 accuracy improvements (#2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,27 @@ RRTMGP.jl Release Notes
 
 main
 ------
-
+- Float32 accuracy overhaul of the RTE kernels: series-switch threshold for the
+  longwave no-scattering source at eps^(1/4) (was 100·eps), exact `γ1 − γ2`
+  identities in the two-stream `k`, expm1-based thin-layer factors, a consistent
+  off-resonance evaluation of the shortwave direct reflectance/transmittance,
+  exact non-cancelling delta-scaling forms, an addition-built direct-beam
+  profile, and a continuous gas-optics η interpolation at η = 1. Measured
+  Float32↔Float64 broadband agreement improves ~25–80× on the longwave
+  no-scattering path (to ~4e-4 W/m²) and ~8× on cloudy longwave two-stream; a
+  new ratcheting f32↔f64 consistency test (test/float32_consistency.jl) locks
+  the gains, and the Float32 longwave no-scattering reference tolerances
+  tighten from 0.05 to 5e-3 W/m².
+- New `RRTMGP.Numerics` module: every numerical guard constant (`k_min`,
+  `τ_thresh`, `resonance_window`, `μ₀_min`) in one place with its derivation.
+- New opt-in input validation: set `RRTMGP.check_values[] = true` to have
+  `update_fluxes!` validate solver inputs (pressures/temperatures positive and
+  finite, `cos_zenith ∈ [-1, 1]`, emissivity/albedos ∈ [0, 1], VMRs ≥ 0) via
+  `validate_inputs`; off by default and allocation-free when off.
+- Lookup loaders now assert the canonical gas slots the kernels hard-code
+  (h2o → 1, o3 → 3) and that `temperature_Planck` is in Kelvin (the g128 file
+  variants store an integer index, which would silently corrupt the Planck
+  interpolation).
 - **Breaking:** the public API is now centered on `RRTMGPSolver` plus a complete set of named
   getters (`layer_temperature`, `level_pressure`, `net_flux`, ...), built on the functional
   `solve_lw!`/`solve_sw!` core. Hosts exchange every input and output through the getters — a

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,12 +8,15 @@ main
   identities in the two-stream `k`, expm1-based thin-layer factors, a consistent
   off-resonance evaluation of the shortwave direct reflectance/transmittance,
   exact non-cancelling delta-scaling forms, an addition-built direct-beam
-  profile, and a continuous gas-optics η interpolation at η = 1. Measured
-  Float32↔Float64 broadband agreement improves ~25–80× on the longwave
-  no-scattering path (to ~4e-4 W/m²) and ~8× on cloudy longwave two-stream; a
-  new ratcheting f32↔f64 consistency test (test/float32_consistency.jl) locks
-  the gains, and the Float32 longwave no-scattering reference tolerances
-  tighten from 0.05 to 5e-3 W/m².
+  profile, a continuous gas-optics η interpolation at η = 1, and a restructured
+  longwave two-stream source (exact `1 ∓ Rdif − Tdif` factorizations, so no term
+  divides by τ and thin layers keep their real O(τ) emission instead of being
+  zeroed below a threshold). Measured Float32↔Float64 broadband agreement
+  improves 25–90×: every longwave path now sits at its ~2–5e-4 W/m²
+  interpolation-noise floor (from 1.1e-2–3.4e-2). A new ratcheting f32↔f64
+  consistency test (test/float32_consistency.jl) locks the gains, and the
+  Float32 longwave no-scattering reference tolerances tighten from 0.05 to
+  5e-3 W/m².
 - New `RRTMGP.Numerics` module: every numerical guard constant (`k_min`,
   `τ_thresh`, `resonance_window`, `μ₀_min`) in one place with its derivation.
 - New opt-in input validation: set `RRTMGP.check_values[] = true` to have

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,6 +48,24 @@ RRTMGP.update_lw_fluxes!
 RRTMGP.update_net_fluxes!
 ```
 
+## Input validation
+
+```@docs
+RRTMGP.check_values
+RRTMGP.validate_inputs
+```
+
+## Numerical policy
+
+```@docs
+RRTMGP.Numerics
+RRTMGP.Numerics.k_min
+RRTMGP.Numerics.τ_thresh
+RRTMGP.Numerics.resonance_window
+RRTMGP.Numerics.μ₀_min
+RRTMGP.Numerics.pow_fast
+```
+
 ## Spectrally-resolved fluxes
 
 Optional per-band fluxes, enabled with `spectral_fluxes = true` when constructing the

--- a/ext/lookup_constructors.jl
+++ b/ext/lookup_constructors.jl
@@ -2,6 +2,19 @@ import RRTMGP.LookUpTables:
     LookUpAerosolMerra, LookUpLW, LookUpSW, LookUpCld, LookUpPlanck
 import RRTMGP.LookUpTables: LookUpMinor, ReferencePoints, BandData
 
+# The RTE/optics kernels hard-code the water-vapor and ozone slots of the gas
+# index (`get_vmr` for the global-mean storage maps ig == 1 → vmr_h2o and
+# ig == 3 → vmr_o3, matching the canonical RRTMGP gas ordering). Fail loudly at
+# load time if a lookup artifact ever reorders the gases.
+function _assert_canonical_gas_slots(idx_gases)
+    idx_gases["h2o"] == 1 && idx_gases["o3"] == 3 || error(
+        "unexpected gas ordering in lookup table: the solver kernels require " *
+        "h2o → 1 and o3 → 3, got h2o → $(idx_gases["h2o"]), " *
+        "o3 → $(idx_gases["o3"]).",
+    )
+    return nothing
+end
+
 function LookUpAerosolMerra(
     ds,
     ::Type{FT},
@@ -120,7 +133,7 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     idx_h2o = idx_gases["h2o"]
     idx_gases["h2o_frgn"] = idx_h2o # water vapor - foreign
     idx_gases["h2o_self"] = idx_h2o # water vapor - self-continua
-
+    _assert_canonical_gas_slots(idx_gases)
 
     n_gases = n_maj_absrb
 
@@ -175,7 +188,17 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     kminor_start_upper = IA1D(Array(ds["kminor_start_upper"])) # not currently used
     planck_fraction =
         FTA4D(permutedims(Array(ds["plank_fraction"]), [2, 3, 4, 1]))
-    t_planck = FTA1D(Array(ds["temperature_Planck"]))
+    t_planck_data = Array(ds["temperature_Planck"])
+    # Some reduced-resolution gas files (the g128 variants) store
+    # `temperature_Planck` as an integer INDEX (0…n) rather than Kelvin;
+    # interpolating against that would silently clamp every temperature to the
+    # last Planck entry. Require plausible Kelvin values.
+    (100 <= first(t_planck_data) && last(t_planck_data) <= 500) || error(
+        "`temperature_Planck` in the longwave lookup file does not look like " *
+        "Kelvin (range $(first(t_planck_data))…$(last(t_planck_data))); " *
+        "this file is not usable with RRTMGP.jl's Planck interpolation.",
+    )
+    t_planck = FTA1D(t_planck_data)
 
     tot_planck = FTA2D(Array(ds["totplnk"]))
 
@@ -429,6 +452,7 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     idx_h2o = idx_gases["h2o"]
     idx_gases["h2o_frgn"] = idx_h2o # water vapor - foreign
     idx_gases["h2o_self"] = idx_h2o # water vapor - self-continua
+    _assert_canonical_gas_slots(idx_gases)
 
     n_gases = n_maj_absrb
 

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -1,0 +1,74 @@
+"""
+    Numerics
+
+The numerical policy of RRTMGP.jl in one place: every floating-point guard
+constant used by the optics/RTE kernels, with its derivation, plus small
+numerical utilities. All constants scale with the working precision `FT`
+(compare `epsilon(1._wp)`-based parameters in the Fortran reference,
+rte-rrtmgp), so kernels behave consistently at Float32 and Float64.
+"""
+module Numerics
+
+"""
+    k_min(::Type{FT})
+
+Floor for the two-stream diffusion eigenvalue `k = sqrt((γ1−γ2)(γ1+γ2))`,
+applied under the square root. `k → 0` for isotropic, conservative scattering
+(ssa → 1, the (γ1−γ2) factor vanishes); flooring `k²` at `sqrt(eps(FT))` keeps
+`k` ≥ eps^(1/4) so the `e^{−2kτ}` cancellations in the diffuse
+reflectance/transmittance stay resolvable. The relative error with respect to
+the conservative-scattering limit is < 0.1% down to τ ~ 1e-9 (see the analogous
+`min_k = 1e4·epsilon` bound and note in rte-rrtmgp, credited to Chiel van
+Heerwaarden; swirl-lm floors `k` itself at 1e-2 for the same reason).
+"""
+@inline k_min(::Type{FT}) where {FT} = sqrt(eps(FT))
+
+"""
+    τ_thresh(::Type{FT})
+
+Optical-depth threshold at which the longwave no-scattering source factor
+`fact = (1 − T)/τ − T` (Clough et al. 1992, Eq 13) switches to its 3rd-order
+series `τ(1/2 − τ/3 + τ²/8)`. The direct form loses ~eps/τ² to cancellation;
+the series truncates at ~τ³. The two error curves cross at τ ~ eps^(1/4)
+(≈ 1.9e-2 at Float32, ≈ 1.2e-4 at Float64) — matching rte-rrtmgp's
+`tau_thresh = sqrt(sqrt(epsilon(tau)))`, credited to Peter Blossey and
+Dmitry Alexeev.
+"""
+@inline τ_thresh(::Type{FT}) where {FT} = sqrt(sqrt(eps(FT)))
+
+"""
+    resonance_window(::Type{FT})
+
+Half-width of the window around the removable singularity of the shortwave
+direct reflectance/transmittance (Meador & Weaver 1980, Eqs 14–15) at
+k·μ₀ = 1, inside which k·μ₀ is nudged off resonance. At the window edge
+|1 − k²μ₀²| = sqrt(eps), the directly computed denominator still carries
+≤ sqrt(eps) relative rounding, matching the O(sqrt(eps)) perturbation from
+the nudge — the balanced choice.
+"""
+@inline resonance_window(::Type{FT}) where {FT} = sqrt(eps(FT))
+
+"""
+    μ₀_min(::Type{FT})
+
+Floor for the cosine of the solar zenith angle wherever the shortwave solvers
+divide by μ₀ (`exp(−τ/μ₀)` arguments). Columns with μ₀ ≤ 0 are excluded from
+the solve and zeroed, so the floor only guards against division by a
+zero/denormal μ₀ at the day–night terminator; the resulting exp argument
+overflows negative and the flux underflows to zero, as it should. (The Fortran
+reference uses sqrt(eps) for its round-earth path, where deep layers with
+μ₀ ≤ 0 are computed nominally and masked afterwards; RRTMGP.jl skips those
+columns instead, so a smaller floor suffices.)
+"""
+@inline μ₀_min(::Type{FT}) where {FT} = eps(FT)
+
+"""
+    pow_fast(x, y)
+
+`x^y` via `exp(y·log(x))` for `x > 0`. Julia's generic `x^y` hits a slow path
+for bases very close to 1, which the gray optical-depth profile evaluates
+often.
+"""
+@inline pow_fast(x, y) = exp(y * log(x))
+
+end # module

--- a/src/RRTMGP.jl
+++ b/src/RRTMGP.jl
@@ -1,13 +1,12 @@
 module RRTMGP
 using Artifacts
 
-# we may be hitting a slow path:
-# https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1
-pow_fast(x, y) = exp(y * log(x))
-
 get_artifact_path() = joinpath(artifact"rrtmgp-data", "rrtmgp-data-1.9")
 
 import ClimaComms
+include("Numerics.jl")
+import .Numerics
+import .Numerics: pow_fast
 include("Parameters.jl")
 import .Parameters as RP
 
@@ -32,6 +31,7 @@ include(joinpath("api", "grid_adaptation.jl"))
 
 include(joinpath("api", "api.jl"))
 include(joinpath("api", "getters.jl"))
+include(joinpath("api", "validation.jl"))
 include(joinpath("api", "standalone.jl"))
 
 end # module

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -475,6 +475,9 @@ host calls it every radiation step. CI asserts `@allocated == 0` and
 See also `update_lw_fluxes!`, `update_sw_fluxes!`, and `update_net_fluxes!`.
 """
 function update_fluxes!(s::RRTMGPSolver, seedval = nothing)
+    # opt-in input validation (see `check_values`/`validate_inputs`); a single
+    # branch when off, so the zero-allocation contract is unaffected
+    check_values[] && validate_inputs(s)
     _maybe_reset_rng_seed!(_radiation_method(s), seedval)
     as = _atmospheric_state(s)
     p_min = get_p_min(as, _lw_lookup(s))

--- a/src/api/validation.jl
+++ b/src/api/validation.jl
@@ -1,0 +1,71 @@
+#####
+##### Optional input validation (opt-in, in the spirit of rte-rrtmgp's
+##### mo_rte_config check_values)
+#####
+
+"""
+    check_values
+
+Global toggle for input validation: when enabled with
+`RRTMGP.check_values[] = true`, [`update_fluxes!`](@ref) calls
+[`validate_inputs`](@ref) before each solve. Off by default — the checks
+reduce over device arrays, so they are intended for development and debugging,
+not for production time-stepping (with the toggle off they cost one branch and
+keep `update_fluxes!` allocation-free).
+"""
+const check_values = Ref(false)
+
+@noinline _validation_error(name::Symbol) = error(
+    "RRTMGP input validation failed: `$name` contains values outside its \
+     physical range (or non-finite values). Inspect the corresponding getter \
+     on the solver.",
+)
+
+_all(f::F, x::AbstractArray) where {F} = mapreduce(f, &, x; init = true)
+_check(f::F, x::AbstractArray, name::Symbol) where {F} =
+    _all(f, x) || _validation_error(name)
+_check(f, x::Nothing, name::Symbol) = true
+
+_in_unit_interval(v) = isfinite(v) & (zero(v) ≤ v ≤ one(v))
+_in_cos_range(v) = isfinite(v) & (-one(v) ≤ v ≤ one(v))
+_positive_finite(v) = isfinite(v) & (v > zero(v))
+_nonnegative_finite(v) = isfinite(v) & (v ≥ zero(v))
+
+_check_vmr(::Nothing) = true
+_check_vmr(vmr::Vmrs.VmrGM) = begin
+    _check(_nonnegative_finite, vmr.vmr_h2o, :vmr_h2o)
+    _check(_nonnegative_finite, vmr.vmr_o3, :vmr_o3)
+    _check(_nonnegative_finite, vmr.vmr, :vmr)
+end
+_check_vmr(vmr::Vmrs.Vmr) = _check(_nonnegative_finite, vmr.vmr, :vmr)
+
+"""
+    validate_inputs(s::RRTMGPSolver)
+
+Validate the solver's host-provided inputs against their physical ranges,
+raising an informative error on the first violation:
+
+- level/layer pressures and temperatures: positive and finite,
+- `cos_zenith ∈ [-1, 1]`, `toa_flux ≥ 0`,
+- surface emissivity and the two shortwave surface albedos ∈ [0, 1],
+- gas volume mixing ratios ≥ 0 (spectral states).
+
+Runs automatically inside [`update_fluxes!`](@ref) when
+[`check_values`](@ref)`[] = true`; can also be called directly at any time.
+Reduces over the solver's device arrays (not allocation-free).
+"""
+function validate_inputs(s::RRTMGPSolver)
+    as = _atmospheric_state(s)
+    _check(_positive_finite, as.p_lev, :level_pressure)
+    _check(_positive_finite, as.t_lev, :level_temperature)
+    _check(_positive_finite, getview_p_lay(as), :layer_pressure)
+    _check(_positive_finite, getview_t_lay(as), :layer_temperature)
+    _check(_positive_finite, as.t_sfc, :surface_temperature)
+    _check(_in_cos_range, s.sws.bcs.cos_zenith, :cos_zenith)
+    _check(_nonnegative_finite, s.sws.bcs.toa_flux, :toa_flux)
+    _check(_in_unit_interval, s.lws.bcs.sfc_emis, :surface_emissivity)
+    _check(_in_unit_interval, s.sws.bcs.sfc_alb_direct, :direct_sw_surface_albedo)
+    _check(_in_unit_interval, s.sws.bcs.sfc_alb_diffuse, :diffuse_sw_surface_albedo)
+    hasproperty(as, :vmr) && _check_vmr(as.vmr)
+    return nothing
+end

--- a/src/optics/GrayUtils.jl
+++ b/src/optics/GrayUtils.jl
@@ -43,7 +43,6 @@ function update_profile_lw!(
     ncol,
 )
     # updating t_lay and t_lev based on heating rate
-    # TODO: it looks like we should probably reorder these args and eliminate one method?
     @inbounds begin
         ClimaComms.@threaded device for gcol in 1:ncol
             update_profile_lw_kernel!(

--- a/src/optics/gas_optics.jl
+++ b/src/optics/gas_optics.jl
@@ -154,7 +154,10 @@ Compute interpolation fraction for binary species parameter.
     #η = col_mix1 > 0 ? vmr1 / col_mix1 : FT(0.5) # rte-rrtmgp uses col_mix1 > tiny(col_mix1)
     loc_η = FT(η * (n_η - 1))
     jη1 = min(unsafe_trunc(Int, loc_η) + 1, n_η - 1)
-    fη1 = loc_η - unsafe_trunc(Int, loc_η)
+    # Fraction relative to the (clamped) cell, so η = 1 lands on the last table
+    # node (fη = 1) instead of jumping back a full cell (fη = 0). At Float32, η
+    # rounds to exactly 1 far more often than at Float64.
+    fη1 = loc_η - (jη1 - 1)
 
     itemp = 2
     @inbounds η_half =
@@ -168,7 +171,7 @@ Compute interpolation fraction for binary species parameter.
     #η = col_mix2 > 0 ? vmr1 / col_mix2 : FT(0.5) # rte-rrtmgp uses col_mix2 > tiny(col_mix2)
     loc_η = FT(η * (n_η - 1))
     jη2 = min(unsafe_trunc(Int, loc_η) + 1, n_η - 1)
-    fη2 = loc_η - unsafe_trunc(Int, loc_η)
+    fη2 = loc_η - (jη2 - 1) # cell-relative; continuous at η = 1 (see fη1)
 
     return ((jη1, jη2, fη1, fη2), (col_mix1, col_mix2))
 end

--- a/src/optics/optics_utils.jl
+++ b/src/optics/optics_utils.jl
@@ -208,10 +208,18 @@ delta-scale two stream optical properties.
 """
 function delta_scale(τ, ssa, g)
     FT = typeof(τ)
-    f = g * g
-    wf = ssa * f
-    τ_s = (FT(1) - wf) * τ
-    ssa_s = (ssa - wf) / max(eps(FT), FT(1) - wf)
-    g_s = (g - f) / max(eps(FT), FT(1) - f)
+    # Exact, non-cancelling forms of the f = g² similarity scaling:
+    #   τ' = (1 − ssa·g²)·τ, ssa' = ssa(1 − g²)/(1 − ssa·g²), g' = g/(1 + g),
+    # where 1 − ssa·g² = (1 − ssa) + ssa(1 − g)(1 + g) is a sum of nonnegative
+    # terms and g' = (g − g²)/(1 − g²) reduces exactly to g/(1 + g). The old
+    # (ssa − wf)/(1 − wf) and (g − f)/(1 − f) forms subtracted near-1 quantities
+    # (bright, strongly forward-scattering clouds) and needed eps-guards; these
+    # need none (g ≥ 0 for cloud/aerosol phase functions; the guards below only
+    # protect the pathological ssa = g = 1).
+    ssa_one_minus_g2 = ssa * (FT(1) - g) * (FT(1) + g) # = ssa(1 − g²) ≥ 0
+    one_minus_wf = (FT(1) - ssa) + ssa_one_minus_g2    # = 1 − ssa·g² ≥ 0
+    τ_s = one_minus_wf * τ
+    ssa_s = ssa_one_minus_g2 / max(eps(FT), one_minus_wf)
+    g_s = g / max(eps(FT), FT(1) + g)
     return (τ_s, ssa_s, g_s)
 end

--- a/src/optics/optics_utils.jl
+++ b/src/optics/optics_utils.jl
@@ -8,7 +8,10 @@ This function assumes `Δx` is uniform.
 @inline function loc_lower(xi, Δx, n, x)
     @inbounds xi ≤ x[1] && return 1
     @inbounds xi >= x[n] && return n - 1
-    return @inbounds unsafe_trunc(Int, (xi - x[1]) / Δx) + 1
+    # The quotient can round UP to exactly n - 1 for xi < x[n] (Float32
+    # especially), which would return n and read one past the end under
+    # `@inbounds`; clamp to the last valid lower index.
+    return @inbounds min(unsafe_trunc(Int, (xi - x[1]) / Δx) + 1, n - 1)
 end
 
 """

--- a/src/rte/RTESolver.jl
+++ b/src/rte/RTESolver.jl
@@ -3,6 +3,7 @@ module RTESolver
 import ClimaComms
 using Adapt
 
+import ..Numerics
 using ..AngularDiscretizations
 using ..Vmrs
 using ..AtmosphericStates

--- a/src/rte/longwave1scalar.jl
+++ b/src/rte/longwave1scalar.jl
@@ -207,13 +207,7 @@ Transport for no-scattering longwave problem.
     (; flux_up, flux_dn) = flux
 
     τ = op.τ
-    # Switch `fact` to its 3rd-order series when the cancellation error of the
-    # direct form, ~eps/τ², reaches the series truncation error, ~τ³: at
-    # τ ~ eps^(1/4) (matches rte-rrtmgp, credited to Peter Blossey & Dmitry
-    # Alexeev). At Float32 this is ~1.9e-2; the previous 100·eps(FT) threshold
-    # left τ ∈ [1e-5, 2e-2] in the cancellation-dominated branch, with O(1)
-    # relative errors in `fact` just above threshold.
-    τ_thresh = sqrt(sqrt(eps(FT)))
+    τ_thresh = Numerics.τ_thresh(FT) # see Numerics for the eps^(1/4) derivation
 
     intensity_to_flux = FT(π) * w_μ
     flux_to_intensity = FT(1) / intensity_to_flux

--- a/src/rte/longwave1scalar.jl
+++ b/src/rte/longwave1scalar.jl
@@ -207,7 +207,13 @@ Transport for no-scattering longwave problem.
     (; flux_up, flux_dn) = flux
 
     τ = op.τ
-    τ_thresh = 100 * eps(FT) # or abs(eps(FT))?
+    # Switch `fact` to its 3rd-order series when the cancellation error of the
+    # direct form, ~eps/τ², reaches the series truncation error, ~τ³: at
+    # τ ~ eps^(1/4) (matches rte-rrtmgp, credited to Peter Blossey & Dmitry
+    # Alexeev). At Float32 this is ~1.9e-2; the previous 100·eps(FT) threshold
+    # left τ ∈ [1e-5, 2e-2] in the cancellation-dominated branch, with O(1)
+    # relative errors in `fact` just above threshold.
+    τ_thresh = sqrt(sqrt(eps(FT)))
 
     intensity_to_flux = FT(π) * w_μ
     flux_to_intensity = FT(1) / intensity_to_flux

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -162,12 +162,10 @@ total source function at levels using linear-in-tau approximation.
     # Equations are developed in Meador and Weaver, 1980,
     #    doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     #
-    # -------------------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------------------------------    
     # setting references
     k_min = Numerics.k_min(FT)
     lw_diff_sec = FT(1.66) # Fu et al. 1997 diffusivity secant
-    τ_thresh = 100 * eps(FT)# tau(icol,ilay) > 1.0e-8_wp used in rte-rrtmgp
-    # this is chosen to prevent catastrophic cancellation in src_up and src_dn calculation
 
     γ1 = lw_diff_sec * (1 - FT(0.5) * ssa * (1 + g))
     γ2 = lw_diff_sec * FT(0.5) * ssa * (1 - g)
@@ -177,31 +175,51 @@ total source function at levels using linear-in-tau approximation.
     k = sqrt(max(lw_diff_sec * (FT(1) - ssa) * (γ1 + γ2), k_min))
 
     e1 = exp(-τ * k)
+    om1 = -expm1(-τ * k) # = 1 − e1, accurate for small kτ
     coeff = e1 * e1 # = exp(-2τk)
-    # 1 − e^{−2kτ} via expm1 and the exact factorization (1 − e)(1 + e);
-    # the naive 1 − e² loses ~eps/(2kτ) relative accuracy for thin layers.
-    one_minus_e2kt = (-expm1(-τ * k)) * (1 + e1)
+    # 1 − e^{−2kτ} via the exact factorization (1 − e)(1 + e); the naive
+    # 1 − e² loses ~eps/(2kτ) relative accuracy for thin layers.
+    one_minus_e2kt = om1 * (1 + e1)
     # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
     RT_term = 1 / (k * (1 + coeff) + γ1 * one_minus_e2kt)
 
     Rdif = RT_term * γ2 * one_minus_e2kt # Equation 25
     Tdif = RT_term * 2 * k * e1 # Equation 26
 
-    # Source function for diffuse radiation
-    # Compute LW source function for upward and downward emission at levels using linear-in-tau assumption
-    # This version straight from ECRAD
-    # Source is provided as W/m2-str; factor of pi converts to flux units
-    # lw_source_2str
-
-    if τ > τ_thresh
-        # Toon et al. (JGR 1989) Eqs 26-27
-        Z = (lev_src_bot - lev_src_top) / (τ * (γ1 + γ2))
-        Zup_top = Z + lev_src_top
-        Zup_bottom = Z + lev_src_bot
-        Zdn_top = -Z + lev_src_top
-        Zdn_bottom = -Z + lev_src_bot
-        src_up = pi * (Zup_top - Rdif * Zdn_top - Tdif * Zup_bottom)
-        src_dn = pi * (Zdn_bottom - Rdif * Zup_bottom - Tdif * Zdn_top)
+    # Source function for diffuse radiation: linear-in-τ (Toon et al. 1989,
+    # JGR, Eqs 26-27, as in ecRad's lw_source_2str), refactored so nothing
+    # divides by τ alone. Sources are W/m²-str; π converts to flux units.
+    #
+    # With B_t/B_b the level sources and Z = (B_b − B_t)/(τ(γ1+γ2)), the
+    # Toon sources are algebraically
+    #   src_up/π = B_t·(1 − Rdif − Tdif) + Tdif·(B_t − B_b) + Z·(1 + Rdif − Tdif)
+    #   src_dn/π = B_b·(1 − Rdif − Tdif) + Tdif·(B_b − B_t) − Z·(1 + Rdif − Tdif)
+    # and the coefficient combinations factor exactly (om2 = om1(1 + e1)):
+    #   1 ∓ Rdif − Tdif = om1·(k·om1 + (γ1 ∓ γ2)(1 + e1))·RT_term
+    # so, with γ1 − γ2 ≡ lw_diff_sec(1 − ssa),
+    #   Z·(1 + Rdif − Tdif) = ΔB·(om1/τ)·(k·om1 + (γ1+γ2)(1+e1))·RT_term/(γ1+γ2)
+    # where om1/τ → k as τ → 0 and stays accurate via expm1. Every factor is
+    # a product/sum of non-cancelling terms, bounding the absolute source
+    # error by ~eps·ΔB for ALL τ. The direct Toon form loses
+    # ~eps·ΔB/(τ(γ1+γ2)) — unbounded as τ → 0 — and required zeroing the
+    # source below a τ threshold, discarding the real O(τ) emission of thin
+    # layers; only a genuinely empty layer (τ = 0: Rdif = 0, Tdif = 1, no
+    # emission) short-circuits here.
+    if τ > FT(0)
+        ΔB = lev_src_bot - lev_src_top
+        γ_sum = γ1 + γ2
+        one_p_e1 = 1 + e1
+        # layer emissivity factor, 1 − Rdif − Tdif
+        emis_fac =
+            om1 *
+            (k * om1 + lw_diff_sec * (FT(1) - ssa) * one_p_e1) *
+            RT_term
+        # Z·(1 + Rdif − Tdif), as ΔB times a well-conditioned factor
+        ΔBz =
+            ΔB * (om1 / τ) * (k * om1 + γ_sum * one_p_e1) * RT_term /
+            max(γ_sum, eps(FT))
+        src_up = FT(π) * (lev_src_top * emis_fac - Tdif * ΔB + ΔBz)
+        src_dn = FT(π) * (lev_src_bot * emis_fac + Tdif * ΔB - ΔBz)
     else
         src_up = FT(0)
         src_dn = FT(0)

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -172,7 +172,10 @@ total source function at levels using linear-in-tau approximation.
 
     γ1 = lw_diff_sec * (1 - FT(0.5) * ssa * (1 + g))
     γ2 = lw_diff_sec * FT(0.5) * ssa * (1 - g)
-    k = sqrt(max((γ1 + γ2) * (γ1 - γ2), k_min))
+    # γ1 − γ2 ≡ lw_diff_sec·(1 − ssa) exactly (Fu et al. Eqs 2.9–2.10); the
+    # identity avoids the near-1 cancellation at ssa → 1 (see the shortwave
+    # counterpart in sw_2stream_coeffs).
+    k = sqrt(max(lw_diff_sec * (FT(1) - ssa) * (γ1 + γ2), k_min))
 
     coeff = exp(-2 * τ * k)
     # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -162,11 +162,10 @@ total source function at levels using linear-in-tau approximation.
     # Equations are developed in Meador and Weaver, 1980,
     #    doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     #
-    # -------------------------------------------------------------------------------------------------    
+    # -------------------------------------------------------------------------------------------------
     # setting references
-    #k_min = FT === Float64 ? FT(1e-12) : FT(1e-4) used in RRTMGP-RTE FORTRAN code
-    k_min = sqrt(eps(FT)) #FT(1e4 * eps(FT))
-    lw_diff_sec = FT(1.66)
+    k_min = Numerics.k_min(FT)
+    lw_diff_sec = FT(1.66) # Fu et al. 1997 diffusivity secant
     τ_thresh = 100 * eps(FT)# tau(icol,ilay) > 1.0e-8_wp used in rte-rrtmgp
     # this is chosen to prevent catastrophic cancellation in src_up and src_dn calculation
 

--- a/src/rte/longwave2stream.jl
+++ b/src/rte/longwave2stream.jl
@@ -177,12 +177,16 @@ total source function at levels using linear-in-tau approximation.
     # counterpart in sw_2stream_coeffs).
     k = sqrt(max(lw_diff_sec * (FT(1) - ssa) * (γ1 + γ2), k_min))
 
-    coeff = exp(-2 * τ * k)
+    e1 = exp(-τ * k)
+    coeff = e1 * e1 # = exp(-2τk)
+    # 1 − e^{−2kτ} via expm1 and the exact factorization (1 − e)(1 + e);
+    # the naive 1 − e² loses ~eps/(2kτ) relative accuracy for thin layers.
+    one_minus_e2kt = (-expm1(-τ * k)) * (1 + e1)
     # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
-    RT_term = 1 / (k * (1 + coeff) + γ1 * (1 - coeff))
+    RT_term = 1 / (k * (1 + coeff) + γ1 * one_minus_e2kt)
 
-    Rdif = RT_term * γ2 * (1 - coeff) # Equation 25
-    Tdif = RT_term * 2 * k * exp(-τ * k) # Equation 26
+    Rdif = RT_term * γ2 * one_minus_e2kt # Equation 25
+    Tdif = RT_term * 2 * k * e1 # Equation 26
 
     # Source function for diffuse radiation
     # Compute LW source function for upward and downward emission at levels using linear-in-tau assumption

--- a/src/rte/shortwave1scalar.jl
+++ b/src/rte/shortwave1scalar.jl
@@ -150,7 +150,7 @@ No-scattering solver for the shortwave problem.
     @inbounds while ilev ≥ 1
         flux_dn_dir[ilev, gcol] =
             flux_dn_dir[ilev + 1, gcol] *
-            exp(-τ[ilev, gcol] / max(cos_zenith[gcol], eps(FT)))
+            exp(-τ[ilev, gcol] / max(cos_zenith[gcol], Numerics.μ₀_min(FT)))
         flux_dn[ilev, gcol] = flux_dn_dir[ilev, gcol]
         flux_up[ilev, gcol] = FT(0)
         flux_net[ilev, gcol] = -flux_dn_dir[ilev, gcol]

--- a/src/rte/shortwave1scalar.jl
+++ b/src/rte/shortwave1scalar.jl
@@ -149,7 +149,8 @@ No-scattering solver for the shortwave problem.
     ilev = nlev - 1
     @inbounds while ilev ≥ 1
         flux_dn_dir[ilev, gcol] =
-            flux_dn_dir[ilev + 1, gcol] * exp(-τ[ilev, gcol] / cos_zenith[gcol])
+            flux_dn_dir[ilev + 1, gcol] *
+            exp(-τ[ilev, gcol] / max(cos_zenith[gcol], eps(FT)))
         flux_dn[ilev, gcol] = flux_dn_dir[ilev, gcol]
         flux_up[ilev, gcol] = FT(0)
         flux_net[ilev, gcol] = -flux_dn_dir[ilev, gcol]

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -183,7 +183,7 @@ Equations are developed in Meador and Weaver, 1980,
 doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
 """
 @inline function sw_2stream_coeffs(τ::FT, ssa::FT, g::FT, μ₀::FT) where {FT}
-    k_min = sqrt(eps(FT)) #FT(1e4 * eps(FT)) # Suggestion from Chiel van Heerwaarden
+    k_min = Numerics.k_min(FT)
     # Zdunkowski Practical Improved Flux Method "PIFM"
     #  (Zdunkowski et al., 1980;  Contributions to Atmospheric Physics 53, 147-66)
     γ1 = (FT(8) - ssa * (FT(5) + FT(3) * g)) * FT(0.25)
@@ -212,7 +212,7 @@ doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     Tdif = RT_term * FT(2) * k * exp_minusktau # Eqn. 26
 
     # Transmittance of direct, unscattered beam. Also used below
-    T₀ = Tnoscat = exp(-τ / max(μ₀, eps(FT)))
+    T₀ = Tnoscat = exp(-τ / max(μ₀, Numerics.μ₀_min(FT)))
 
     # Direct reflect and transmission
     k_μ = k * μ₀
@@ -221,11 +221,9 @@ doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     # off resonance so numerator and denominator stay mutually consistent
     # (the old guard divided by a bare eps(FT), which amplified the O(eps)
     # numerator noise at resonance to O(1) and discarded the denominator's
-    # sign). Window sqrt(eps): at its edge the directly-computed 1 − k²μ₀²
-    # still carries ≤ sqrt(eps) relative rounding, matching the O(sqrt(eps))
-    # perturbation from the nudge itself.
-    if abs(FT(1) - k_μ2) < sqrt(eps(FT))
-        k_μ2 = FT(1) - sqrt(eps(FT))
+    # sign). See Numerics.resonance_window for the sqrt(eps) choice.
+    if abs(FT(1) - k_μ2) < Numerics.resonance_window(FT)
+        k_μ2 = FT(1) - Numerics.resonance_window(FT)
         k_μ = sqrt(k_μ2)
     end
     k_γ3 = k * γ3
@@ -277,7 +275,7 @@ end
     for ilev in nlay:-1:lev
         τ_sum += τ[ilev]
     end
-    return flux_dn_dir_top * exp(-τ_sum / max(μ₀, eps(eltype(τ))))
+    return flux_dn_dir_top * exp(-τ_sum / max(μ₀, Numerics.μ₀_min(eltype(τ))))
 end
 
 """
@@ -323,7 +321,7 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
     # repeated subtraction — accumulating ~nlay·eps·τ_sum error exactly
     # where τ_cum → 0, near TOA — and re-exponentiated in both passes.)
     flux_dn_dir_top = toa_flux * solar_frac * μ₀
-    inv_μ₀ = FT(1) / max(μ₀, eps(FT))
+    inv_μ₀ = FT(1) / max(μ₀, Numerics.μ₀_min(FT))
     @inbounds flux_dn_dir[nlev, gcol] = flux_dn_dir_top
     τ_cum = FT(0)
     @inbounds for ilev in nlay:-1:1

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -268,16 +268,6 @@ doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     return (Rdir, Tdir, Tnoscat, Rdif, Tdif)
 end
 
-# Direct-beam and source for diffuse radiation
-@inline function get_flux_dn_dir(τ, μ₀, flux_dn_dir_top, lev)
-    nlay = length(τ)
-    τ_sum = zero(eltype(τ))
-    for ilev in nlay:-1:lev
-        τ_sum += τ[ilev]
-    end
-    return flux_dn_dir_top * exp(-τ_sum / max(μ₀, Numerics.μ₀_min(eltype(τ))))
-end
-
 """
     rte_sw_2stream!(
         (; τ, ssa, g)::TwoStream,

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -192,7 +192,10 @@ doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     γ4 = FT(1) - γ3
     α1 = γ1 * γ4 + γ2 * γ3                          # Eq. 16
     α2 = γ1 * γ3 + γ2 * γ4                          # Eq. 17
-    k = sqrt(max((γ1 - γ2) * (γ1 + γ2), k_min))
+    # For PIFM, γ1 − γ2 ≡ 2(1 − ssa) exactly; use the identity rather than the
+    # difference of two rounded O(1) numbers, which loses ~eps absolute and
+    # gives O(1%) errors in k for bright scattering (ssa → 1) at Float32.
+    k = sqrt(max(FT(2) * (FT(1) - ssa) * (γ1 + γ2), k_min))
 
     exp_minusktau = exp(-τ * k)
     exp_minus2ktau = exp_minusktau * exp_minusktau

--- a/src/rte/shortwave2stream.jl
+++ b/src/rte/shortwave2stream.jl
@@ -199,30 +199,41 @@ doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
 
     exp_minusktau = exp(-τ * k)
     exp_minus2ktau = exp_minusktau * exp_minusktau
+    # 1 − e^{−kτ} via expm1 (accurate for small kτ), and 1 − e^{−2kτ} from it
+    # by the exact factorization (1 − e)(1 + e) — the naive 1 − e² loses
+    # ~eps/(2kτ) relative accuracy for optically thin layers.
+    om1 = -expm1(-τ * k)
+    one_minus_e2kt = om1 * (FT(1) + exp_minusktau)
 
     # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
-    RT_term =
-        FT(1) /
-        (k * (FT(1) + exp_minus2ktau) + γ1 * (FT(1) - exp_minus2ktau))
+    RT_term = FT(1) / (k * (FT(1) + exp_minus2ktau) + γ1 * one_minus_e2kt)
 
-    Rdif = RT_term * γ2 * (FT(1) - exp_minus2ktau) # Eqn. 25
-    Tdif = RT_term * FT(2) * k * exp_minusktau     # Eqn. 26
+    Rdif = RT_term * γ2 * one_minus_e2kt       # Eqn. 25
+    Tdif = RT_term * FT(2) * k * exp_minusktau # Eqn. 26
 
     # Transmittance of direct, unscattered beam. Also used below
     T₀ = Tnoscat = exp(-τ / max(μ₀, eps(FT)))
 
     # Direct reflect and transmission
     k_μ = k * μ₀
+    k_μ2 = k_μ * k_μ
+    # Equations 14-15 have a removable singularity at k·μ₀ = 1. Nudge k·μ₀
+    # off resonance so numerator and denominator stay mutually consistent
+    # (the old guard divided by a bare eps(FT), which amplified the O(eps)
+    # numerator noise at resonance to O(1) and discarded the denominator's
+    # sign). Window sqrt(eps): at its edge the directly-computed 1 − k²μ₀²
+    # still carries ≤ sqrt(eps) relative rounding, matching the O(sqrt(eps))
+    # perturbation from the nudge itself.
+    if abs(FT(1) - k_μ2) < sqrt(eps(FT))
+        k_μ2 = FT(1) - sqrt(eps(FT))
+        k_μ = sqrt(k_μ2)
+    end
     k_γ3 = k * γ3
     k_γ4 = k * γ4
 
     # Equation 14, multiplying top and bottom by exp(-k*tau)
     #   and rearranging to avoid div by 0.
-    if abs(FT(1) - k_μ * k_μ) ≥ eps(FT)
-        RT_term = ssa * RT_term / (FT(1) - k_μ * k_μ)
-    else
-        RT_term = ssa * RT_term / eps(FT)
-    end
+    RT_term = ssa * RT_term / (FT(1) - k_μ2)
 
     Rdir_unconstrained =
         RT_term * (
@@ -306,14 +317,20 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
         sfc_alb_direct = bcs_sw.sfc_alb_direct[ibnd, gcol]
         μ₀ = bcs_sw.cos_zenith[gcol]
     end
-    τ_sum = FT(0)
-    for ilay in 1:nlay
-        @inbounds τ_sum += τ[ilay, gcol]
-    end
-    # Direct-beam and source for diffuse radiation
+    # Direct-beam profile, computed top-down with an addition-built
+    # cumulative optical depth and stored for the two passes below. (The
+    # previous scheme summed τ once, then recovered per-level values by
+    # repeated subtraction — accumulating ~nlay·eps·τ_sum error exactly
+    # where τ_cum → 0, near TOA — and re-exponentiated in both passes.)
     flux_dn_dir_top = toa_flux * solar_frac * μ₀
-    flux_dn_dir_bot = flux_dn_dir_top * exp(-τ_sum / max(μ₀, eps(FT))) # store value at surface
-    @inbounds flux_dn_dir[1, gcol] = flux_dn_dir_bot # store value at surface
+    inv_μ₀ = FT(1) / max(μ₀, eps(FT))
+    @inbounds flux_dn_dir[nlev, gcol] = flux_dn_dir_top
+    τ_cum = FT(0)
+    @inbounds for ilev in nlay:-1:1
+        τ_cum += τ[ilev, gcol]
+        flux_dn_dir[ilev, gcol] = flux_dn_dir_top * exp(-τ_cum * inv_μ₀)
+    end
+    flux_dn_dir_bot = @inbounds flux_dn_dir[1, gcol] # surface value
     sfc_source = flux_dn_dir_bot * sfc_alb_direct
 
     @inbounds flux_dn[nlev, gcol] = FT(0) # set to incoming flux when provided?
@@ -324,7 +341,6 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
     @inbounds src[1, gcol] = sfc_source
     # From bottom to top of atmosphere --
     #   compute albedo and source of upward radiation
-    τ_cum = τ_sum
     albedo_ilev, src_ilev = surface_albedo, sfc_source
     @inbounds for ilev in 1:nlay
         τ_ilev, ssa_ilev, g_ilev =
@@ -333,16 +349,13 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
             sw_2stream_coeffs(τ_ilev, ssa_ilev, g_ilev, μ₀)
         denom = FT(1) / (FT(1) - Rdif * albedo_ilev)  # Eq 10
         albedo_ilevplus1 = Rdif + Tdif * Tdif * albedo_ilev * denom # Equation 9
-        # 
+        #
         # Equation 11 -- source is emitted upward radiation at top of layer plus
         # radiation emitted at bottom of layer,
         # transmitted through the layer and reflected from layers below (Tdiff*src*albedo)
-        τ_cum -= τ_ilev
-        τ_cum = max(τ_cum, FT(0))
-        flux_dn_dir_ilevplus1 =
-            flux_dn_dir_top * exp(-τ_cum / max(μ₀, eps(FT)))
-        src_up_ilev = Rdir * flux_dn_dir_ilevplus1 #flux_dn_dir[ilev + 1]
-        src_dn_ilev = Tdir * flux_dn_dir_ilevplus1 #flux_dn_dir[ilev + 1]
+        flux_dn_dir_ilevplus1 = flux_dn_dir[ilev + 1, gcol]
+        src_up_ilev = Rdir * flux_dn_dir_ilevplus1
+        src_dn_ilev = Tdir * flux_dn_dir_ilevplus1
         src_ilevplus1 =
             src_up_ilev +
             Tdif * denom * (src_ilev + albedo_ilev * src_dn_ilev)
@@ -359,7 +372,6 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
     # From the top of the atmosphere downward -- compute fluxes
     @inbounds flux_dn_ilevplus1 = flux_dn[nlev, gcol]
     @inbounds flux_dn[nlev, gcol] += flux_dn_dir_top
-    τ_cum = FT(0)
 
     ilev = nlay
     @inbounds while ilev ≥ 1
@@ -369,9 +381,7 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
         (_, Tdir, _, Rdif, Tdif) =
             sw_2stream_coeffs(τ_ilev, ssa_ilev, g_ilev, μ₀)
         denom = FT(1) / (FT(1) - Rdif * albedo_ilev)  # Eq 10
-        src_dn_ilev =
-            Tdir * flux_dn_dir_top * exp(-τ_cum / max(μ₀, eps(FT)))
-        τ_cum += τ_ilev
+        src_dn_ilev = Tdir * flux_dn_dir[ilev + 1, gcol]
         flux_dn_ilev =
             (Tdif * flux_dn_ilevplus1 + # Equation 13
              Rdif * src_ilev +
@@ -379,8 +389,7 @@ Equations are after Shonk and Hogan 2008, doi:10.1175/2007JCLI1940.1 (SH08)
         flux_up[ilev, gcol] =
             flux_dn_ilev * albedo_ilev + # Equation 12
             src_ilev
-        flux_dn[ilev, gcol] =
-            flux_dn_ilev + flux_dn_dir_top * exp(-τ_cum / max(μ₀, eps(FT)))
+        flux_dn[ilev, gcol] = flux_dn_ilev + flux_dn_dir[ilev, gcol]
         flux_dn_ilevplus1 = flux_dn_ilev
         ilev -= 1
     end

--- a/test/all_sky_with_aerosols_utils.jl
+++ b/test/all_sky_with_aerosols_utils.jl
@@ -184,6 +184,18 @@ function all_sky_with_aerosols(
     # h2o/o3 are layer fields (2D); well-mixed gases are global means.
     @test ndims(RRTMGP.volume_mixing_ratio(solver, "h2o")) == 2
 
+    # Layer-2 update_fluxes! must stay allocation-free and type-stable on the
+    # all-sky (spectral + clouds + aerosols) path too; the gray path is asserted
+    # in test/standalone.jl. Single-threaded only: multi-threaded `@threaded`
+    # loops allocate task state.
+    if device isa ClimaComms.CPUSingleThreaded
+        RRTMGP.update_fluxes!(solver) # warm up / compile
+        # `@allocated`'s first measurement includes one-time setup; discard it.
+        @allocated RRTMGP.update_fluxes!(solver)
+        @test (@allocated RRTMGP.update_fluxes!(solver)) == 0
+        JET.@test_opt RRTMGP.update_fluxes!(solver)
+    end
+
     # --- spectrally-resolved (per-band) fluxes (two-stream only) ---
     if op_lw isa Optics.TwoStream && op_sw isa Optics.TwoStream
         solver_spec = RRTMGPSolver(

--- a/test/float32_consistency.jl
+++ b/test/float32_consistency.jl
@@ -39,11 +39,15 @@ using RRTMGP.ArtifactPaths
 @isdefined(setup_cloudy_sky_as) || include("read_cloudy_sky.jl")
 
 # Maximum |Float32 − Float64| flux thresholds [W/m²] (gray heating rate [K/s]).
-# Measured-with-~2× headroom; tighten as numerics fixes land, never loosen.
-# Post-PR-1 measurements (F1 τ_thresh, F3 k-identity, F9/F10/F11): LW noscat
-# 3.8e-4 (was 1.1e-2 clear / 3.3e-2 cloudy); cloudy LW 2-stream 4.2e-3 (was
-# 3.4e-2). Clear LW 2-stream (~3.2e-2) awaits the source restructure; SW
-# (~1e-2 clear, ~5.6e-2 cloudy) awaits the second-wave fixes.
+# Measured-with-headroom; tighten as numerics fixes land, never loosen.
+# Measured after the quick-win fixes (τ_thresh, k-identity, η/index clamps) and
+# the second wave (expm1, resonance shift, delta-scale forms, direct-beam
+# prepass): LW noscat 3.8e-4 (was 1.1e-2 clear / 3.3e-2 cloudy); cloudy LW
+# 2-stream 4.5e-3 (was 3.4e-2); clear LW 2-stream ~3.0e-2 (awaits the LW source
+# restructure). SW: ~1.1e-2/1.6e-2 clear, ~4.9e-2/5.5e-2 cloudy — verified to be
+# per-g-point interpolation/coefficient noise, NOT accumulation: repeating the
+# runs with full Float64 broadband accumulation left the SW differences
+# unchanged, so compensated/f64 accumulators were deliberately not added.
 const F32_THRESHOLDS = (;
     gray_flux = 1.0e-3,
     gray_heating_rate = 1.0e-8,

--- a/test/float32_consistency.jl
+++ b/test/float32_consistency.jl
@@ -1,0 +1,233 @@
+#=
+Float32 ↔ Float64 consistency harness.
+
+Solves the same radiation problems at Float32 and Float64 (states built from the
+same NetCDF inputs, downcast per precision) and compares broadband fluxes. This
+pins the end-to-end Float32 accuracy of the pipeline — input rounding, gas/cloud
+optics, and the RTE solve — directly against the Float64 result, which is a much
+sharper probe than the per-precision reference comparisons.
+
+The thresholds below are a RATCHET: they are set from measured values (with ~2×
+headroom) and must be tightened, never loosened, as numerics fixes land. For
+context, the Fortran reference (rte-rrtmgp) accepts 0.35 W/m² absolute flux error
+in its single-precision CI.
+=#
+
+using Test
+using NCDatasets
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+
+using RRTMGP
+using RRTMGP: RRTMGPGridParams
+using RRTMGP.Vmrs
+using RRTMGP.LookUpTables
+using RRTMGP.AtmosphericStates
+using RRTMGP.Optics
+using RRTMGP.Sources
+using RRTMGP.BCs
+using RRTMGP.Fluxes
+using RRTMGP.AngularDiscretizations
+using RRTMGP.RTE
+using RRTMGP.RTESolver
+import RRTMGP.Parameters.RRTMGPParameters
+import ClimaParams as CP
+using RRTMGP.ArtifactPaths
+
+@isdefined(get_reference_filename) || include("reference_files.jl")
+@isdefined(setup_clear_sky_as) || include("read_clear_sky.jl")
+@isdefined(setup_cloudy_sky_as) || include("read_cloudy_sky.jl")
+
+# Maximum |Float32 − Float64| flux thresholds [W/m²] (gray heating rate [K/s]).
+# Measured-with-~2× headroom; tighten as numerics fixes land, never loosen.
+# Post-PR-1 measurements (F1 τ_thresh, F3 k-identity, F9/F10/F11): LW noscat
+# 3.8e-4 (was 1.1e-2 clear / 3.3e-2 cloudy); cloudy LW 2-stream 4.2e-3 (was
+# 3.4e-2). Clear LW 2-stream (~3.2e-2) awaits the source restructure; SW
+# (~1e-2 clear, ~5.6e-2 cloudy) awaits the second-wave fixes.
+const F32_THRESHOLDS = (;
+    gray_flux = 1.0e-3,
+    gray_heating_rate = 1.0e-8,
+    clear_lw_noscat = 1.0e-3,
+    clear_lw_2stream = 7.0e-2,
+    clear_sw = 3.0e-2,
+    cloudy_lw_noscat = 1.0e-3,
+    cloudy_lw_2stream = 1.0e-2,
+    cloudy_sw = 1.2e-1,
+)
+
+maxabsdiff(a32, a64) = maximum(abs.(Float64.(Array(a32)) .- Array(a64)))
+
+#------------------------------------------------------------------
+# Gray atmosphere (two-stream LW + SW): no lookup tables involved.
+function gray_consistency(; nlay = 60, ncol = 8)
+    out = map((Float32, Float64)) do FT
+        RRTMGP.solve_gray(FT; nlay, ncol)
+    end
+    o32, o64 = out
+    return (;
+        lw_net = maxabsdiff(o32.lw_net, o64.lw_net),
+        sw_net = maxabsdiff(o32.sw_net, o64.sw_net),
+        heating_rate = maxabsdiff(o32.heating_rate, o64.heating_rate),
+    )
+end
+
+#------------------------------------------------------------------
+# Clear-sky (RFMIP state): gas optics + LW (noscat and 2-stream) + SW 2-stream.
+function clear_sky_fluxes(context, ::Type{FT}, ::Type{SLVLW}; ncol) where {FT, SLVLW}
+    overrides =
+        (; grav = 9.80665, molmass_dryair = 0.028964, molmass_water = 0.018016)
+    param_set = RRTMGPParameters(FT, overrides)
+    device = ClimaComms.device(context)
+    DA = ClimaComms.array_type(device)
+
+    lookup_lw, idx_gases = Dataset(get_lookup_filename(:gas, :lw), "r") do ds
+        LookUpLW(ds, FT, DA)
+    end
+    lookup_sw, _ = Dataset(get_lookup_filename(:gas, :sw), "r") do ds
+        LookUpSW(ds, FT, DA)
+    end
+
+    ds_lw_in = Dataset(get_input_filename(:gas, :lw), "r")
+    (as, sfc_emis, sfc_alb_direct, cos_zenith, toa_flux, _) =
+        setup_clear_sky_as(
+            context,
+            ds_lw_in,
+            idx_gases,
+            1,
+            lookup_lw,
+            ncol,
+            FT,
+            VmrGM,
+            param_set,
+        )
+    close(ds_lw_in)
+
+    nlay, _ = AtmosphericStates.get_dims(as)
+    grid_params = RRTMGPGridParams(FT; context, domain_nlay = nlay, ncol)
+
+    slv_lw = SLVLW(grid_params; params = param_set, sfc_emis, inc_flux = nothing)
+    sfc_alb_diffuse = DA{FT, 2}(deepcopy(sfc_alb_direct))
+    slv_sw = TwoStreamSWRTE(
+        grid_params;
+        cos_zenith,
+        toa_flux,
+        sfc_alb_direct,
+        inc_flux_diffuse = nothing,
+        sfc_alb_diffuse,
+    )
+
+    solve_lw!(slv_lw, as, lookup_lw)
+    solve_sw!(slv_sw, as, lookup_sw)
+    return (;
+        lw_up = Array(slv_lw.flux.flux_up),
+        lw_dn = Array(slv_lw.flux.flux_dn),
+        sw_up = Array(slv_sw.flux.flux_up),
+        sw_dn = Array(slv_sw.flux.flux_dn),
+    )
+end
+
+#------------------------------------------------------------------
+# Cloudy sky (cldfrac = 1 → deterministic McICA mask): cloud optics + δ-scaling.
+function cloudy_sky_fluxes(context, ::Type{FT}, ::Type{SLVLW}; ncol) where {FT, SLVLW}
+    overrides =
+        (; grav = 9.80665, molmass_dryair = 0.028964, molmass_water = 0.018016)
+    param_set = RRTMGPParameters(FT, overrides)
+    device = ClimaComms.device(context)
+    DA = ClimaComms.array_type(device)
+
+    lookup_lw, idx_gases = Dataset(get_lookup_filename(:gas, :lw), "r") do ds
+        LookUpLW(ds, FT, DA)
+    end
+    lookup_lw_cld = Dataset(get_lookup_filename(:cloud, :lw), "r") do ds
+        LookUpCld(ds, FT, DA)
+    end
+    lookup_sw, _ = Dataset(get_lookup_filename(:gas, :sw), "r") do ds
+        LookUpSW(ds, FT, DA)
+    end
+    lookup_sw_cld = Dataset(get_lookup_filename(:cloud, :sw), "r") do ds
+        LookUpCld(ds, FT, DA)
+    end
+
+    ds_in = Dataset(get_input_filename(:gas_clouds, :lw), "r")
+    as, sfc_emis, sfc_alb_direct, sfc_alb_diffuse, cos_zenith, toa_flux, _ =
+        setup_cloudy_sky_as(
+            context,
+            ds_in,
+            idx_gases,
+            lookup_lw,
+            lookup_sw,
+            lookup_lw_cld,
+            lookup_sw_cld,
+            FT(1), # cldfrac = 1 everywhere the input has cloud: deterministic mask
+            ncol,
+            FT,
+            param_set,
+        )
+    close(ds_in)
+
+    nlay, ncol = AtmosphericStates.get_dims(as)
+    grid_params = RRTMGPGridParams(FT; context, domain_nlay = nlay, ncol)
+
+    slv_lw = SLVLW(grid_params; params = param_set, sfc_emis, inc_flux = nothing)
+    slv_sw = TwoStreamSWRTE(
+        grid_params;
+        cos_zenith,
+        toa_flux,
+        sfc_alb_direct,
+        inc_flux_diffuse = nothing,
+        sfc_alb_diffuse,
+    )
+
+    solve_lw!(slv_lw, as, lookup_lw, lookup_lw_cld)
+    solve_sw!(slv_sw, as, lookup_sw, lookup_sw_cld)
+    return (;
+        lw_up = Array(slv_lw.flux.flux_up),
+        lw_dn = Array(slv_lw.flux.flux_dn),
+        sw_up = Array(slv_sw.flux.flux_up),
+        sw_dn = Array(slv_sw.flux.flux_dn),
+    )
+end
+
+fluxdiffs(f32, f64) = (;
+    lw_up = maxabsdiff(f32.lw_up, f64.lw_up),
+    lw_dn = maxabsdiff(f32.lw_dn, f64.lw_dn),
+    sw_up = maxabsdiff(f32.sw_up, f64.sw_up),
+    sw_dn = maxabsdiff(f32.sw_dn, f64.sw_dn),
+)
+lwmax(d) = max(d.lw_up, d.lw_dn)
+swmax(d) = max(d.sw_up, d.sw_dn)
+
+@testset "Float32 ↔ Float64 consistency" begin
+    context = ClimaComms.context()
+
+    gray = gray_consistency()
+    @info "f32↔f64 gray (2-stream)" gray.lw_net gray.sw_net gray.heating_rate
+    @test max(gray.lw_net, gray.sw_net) ≤ F32_THRESHOLDS.gray_flux
+    @test gray.heating_rate ≤ F32_THRESHOLDS.gray_heating_rate
+
+    for (SLVLW, tag, thresh) in (
+        (NoScatLWRTE, "noscat", F32_THRESHOLDS.clear_lw_noscat),
+        (TwoStreamLWRTE, "2stream", F32_THRESHOLDS.clear_lw_2stream),
+    )
+        d = fluxdiffs(
+            clear_sky_fluxes(context, Float32, SLVLW; ncol = 100),
+            clear_sky_fluxes(context, Float64, SLVLW; ncol = 100),
+        )
+        @info "f32↔f64 clear-sky (LW $tag)" d.lw_up d.lw_dn d.sw_up d.sw_dn
+        @test lwmax(d) ≤ thresh
+        @test swmax(d) ≤ F32_THRESHOLDS.clear_sw
+    end
+
+    for (SLVLW, tag, thresh) in (
+        (NoScatLWRTE, "noscat", F32_THRESHOLDS.cloudy_lw_noscat),
+        (TwoStreamLWRTE, "2stream", F32_THRESHOLDS.cloudy_lw_2stream),
+    )
+        d = fluxdiffs(
+            cloudy_sky_fluxes(context, Float32, SLVLW; ncol = 128),
+            cloudy_sky_fluxes(context, Float64, SLVLW; ncol = 128),
+        )
+        @info "f32↔f64 cloudy-sky (LW $tag)" d.lw_up d.lw_dn d.sw_up d.sw_dn
+        @test lwmax(d) ≤ thresh
+        @test swmax(d) ≤ F32_THRESHOLDS.cloudy_sw
+    end
+end

--- a/test/float32_consistency.jl
+++ b/test/float32_consistency.jl
@@ -40,22 +40,24 @@ using RRTMGP.ArtifactPaths
 
 # Maximum |Float32 − Float64| flux thresholds [W/m²] (gray heating rate [K/s]).
 # Measured-with-headroom; tighten as numerics fixes land, never loosen.
-# Measured after the quick-win fixes (τ_thresh, k-identity, η/index clamps) and
-# the second wave (expm1, resonance shift, delta-scale forms, direct-beam
-# prepass): LW noscat 3.8e-4 (was 1.1e-2 clear / 3.3e-2 cloudy); cloudy LW
-# 2-stream 4.5e-3 (was 3.4e-2); clear LW 2-stream ~3.0e-2 (awaits the LW source
-# restructure). SW: ~1.1e-2/1.6e-2 clear, ~4.9e-2/5.5e-2 cloudy — verified to be
-# per-g-point interpolation/coefficient noise, NOT accumulation: repeating the
-# runs with full Float64 broadband accumulation left the SW differences
-# unchanged, so compensated/f64 accumulators were deliberately not added.
+# Measured after the f32 numerics program (τ_thresh at eps^(1/4), the γ1−γ2
+# identities, expm1 thin-layer factors, the SW resonance nudge, exact
+# delta-scale forms, the addition-built direct-beam prepass, and the
+# restructured LW two-stream source): every LW path sits at its ~2–5e-4
+# interpolation-noise floor, 25–90× below the pre-program values (LW noscat was
+# 1.1e-2 clear / 3.3e-2 cloudy; LW 2-stream 3.2e-2 clear / 3.4e-2 cloudy).
+# SW: ~1.1e-2/1.6e-2 clear, ~4.9e-2/5.5e-2 cloudy — verified to be per-g-point
+# interpolation/coefficient noise, NOT accumulation: repeating the runs with
+# full Float64 broadband accumulation left the SW differences unchanged, so
+# compensated/f64 accumulators were deliberately not added.
 const F32_THRESHOLDS = (;
     gray_flux = 1.0e-3,
     gray_heating_rate = 1.0e-8,
     clear_lw_noscat = 1.0e-3,
-    clear_lw_2stream = 7.0e-2,
+    clear_lw_2stream = 1.0e-3,
     clear_sw = 3.0e-2,
     cloudy_lw_noscat = 1.0e-3,
-    cloudy_lw_2stream = 1.0e-2,
+    cloudy_lw_2stream = 1.0e-3,
     cloudy_sw = 1.2e-1,
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,10 @@ printstyled("=================================\n\n", color = color1)
     include("cos_zenith_edge_cases.jl")
 end
 
+printstyled("\n\nFloat32 consistency tests\n", color = color1)
+printstyled("=================================\n\n", color = color1)
+include("float32_consistency.jl")
+
 printstyled("\n\nOptics utilities tests\n", color = color1)
 printstyled("==============\n\n", color = color1)
 include("optics_utils.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,8 @@ printstyled("==========================\n\n", color = color1)
 @testset "RRTMGP clear-sky tests" begin
     context = ClimaComms.context()
 
-    toler_lw_noscat = Dict(Float64 => Float64(1e-4), Float32 => Float32(0.05))
+    toler_lw_noscat =
+        Dict(Float64 => Float64(1e-4), Float32 => Float32(5e-3))
     toler_lw_2stream = Dict(Float64 => Float64(4.5), Float32 => Float32(4.5))
     toler_sw = Dict(Float64 => Float64(1e-3), Float32 => Float32(0.04))
 
@@ -60,7 +61,8 @@ printstyled("=================================\n\n", color = color1)
 @testset "RRTMGP cloudy-sky (gas + clouds) tests" begin
     context = ClimaComms.context()
 
-    toler_lw_noscat = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.05))
+    toler_lw_noscat =
+        Dict(Float64 => Float64(1e-5), Float32 => Float32(5e-3))
     toler_lw_2stream = Dict(Float64 => Float64(5), Float32 => Float32(5))
     toler_sw = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.06))
 
@@ -108,7 +110,8 @@ printstyled("=================================\n\n", color = color1)
 @testset "RRTMGP all-sky (gas + clouds + aerosols) tests" begin
     context = ClimaComms.context()
 
-    toler_lw_noscat = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.05))
+    toler_lw_noscat =
+        Dict(Float64 => Float64(1e-5), Float32 => Float32(5e-3))
     toler_lw_2stream = Dict(Float64 => Float64(5), Float32 => Float32(5))
     toler_sw = Dict(Float64 => Float64(1e-5), Float32 => Float32(0.06))
 

--- a/test/standalone.jl
+++ b/test/standalone.jl
@@ -217,6 +217,25 @@ end
     @test parent(op1.τ) === op1.layerdata
 end
 
+# Opt-in input validation: `RRTMGP.check_values[] = true` makes `update_fluxes!`
+# validate solver inputs; off (the default) it costs a single branch — the
+# zero-alloc/JET testset below runs with the toggle off and still asserts 0.
+@testset "input validation toggle" begin
+    solver = RRTMGP.solve_gray(Float64; nlay = 12, ncol = 3).solver
+    RRTMGP.validate_inputs(solver) # valid inputs pass
+    RRTMGP.cos_zenith(solver) .= 2 # corrupt an input (broadcast: device-safe)
+    @test_throws ErrorException RRTMGP.validate_inputs(solver)
+    try
+        RRTMGP.check_values[] = true
+        @test_throws ErrorException RRTMGP.update_fluxes!(solver)
+    finally
+        RRTMGP.check_values[] = false
+    end
+    RRTMGP.cos_zenith(solver) .= 1 / 2
+    RRTMGP.update_fluxes!(solver) # runs again once repaired, toggle off
+    @test all(isfinite, Array(RRTMGP.net_flux(solver)))
+end
+
 # Layer-2 `update_fluxes!` runs every radiation step, so it must be allocation-free
 # and type-stable. The getters are type-stable because `_domain_view` always returns
 # one concrete view type (no `Union{Array, SubArray}` from a runtime boundary-layer


### PR DESCRIPTION
Improves the numerically sensitive parts of the longwave/shortwave solvers so Float32 results track Float64 better. Broadband f32↔f64 agreement improves 25–90×: every longwave path now sits at its ~2–5e-4 W/m² interpolation-noise floor (from 1e-2–3e-2).

## Accuracy fixes

* LW no-scattering source: series switch at `eps^(1/4)` (was `100·eps`), avoiding O(1) cancellation error just above threshold.
* Two-stream `k`: exact `γ1 − γ2` identities (`PIFM ≡ 2(1−ssa)`, `Fu ≡ 1.66(1−ssa)`), removing near-1 cancellation at `ssa → 1`.
* Thin-layer factors via `expm1` and the exact `(1−e)(1+e)` factorization.
* Consistent off-resonance evaluation of the SW direct beam near `k·μ₀ = 1`.
* Addition-built cumulative optical depth for the direct-beam profile (no repeated subtraction).
* LW two-stream source restructured so no term divides by `τ`; thin layers keep their real `O(τ)` emission instead of being zeroed.

## Supporting

* New `RRTMGP.Numerics module`: collects every guard constant (`k_min`, `τ_thresh`, `resonance_window`, `μ₀_min`) in one place.
* Opt-in input validation (`RRTMGP.check_values[] = true`), allocation-free when off.
* Lookup-loader hardening (asserts the hard-coded h2o/o3 slots and temperatures).
* Testing: new ratcheting `test/float32_consistency.jl` harness to avoid regressions: the f32 LW no-scattering reference tolerances tighten from `0.05` to `5e-3 W/m²`. 