### PR TITLE
Standalone single-column RRTMGP path (prepare/solve split, standard_atmosphere, RadiationOutput)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ RRTMGP.jl Release Notes
 
 main
 ------
+- New docs page "Fortran and paper concordance": tables mapping RRTMGP.jl
+  names (containers, RTE/gas-optics/cloud/aerosol kernels) to the Fortran
+  rte-rrtmgp `mo_*`/`ty_*` names and to the papers whose equations they
+  implement, so Fortran-literate readers can navigate instantly.
 - The standalone (Layer-3) path is complete: `standard_atmosphere(FT; kind)`
   builds an idealized clear-sky `AtmosphereProfile` (`:tropical`,
   `:midlatitude_summer`, `:subarctic_winter` — analytic two-segment

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@ RRTMGP.jl Release Notes
 
 main
 ------
+- New `prepare_atmosphere!(solver)`: runs the atmospheric-state preparation
+  cascade (level interpolation, isothermal boundary layer, clipping, dry-air
+  column amounts) without solving, so hosts can inspect the prepared state —
+  the prepare/solve split. `update_fluxes!` is now literally
+  `prepare_atmosphere!` followed by the three solve/combine steps.
 - **Breaking:** `lookup_tables` now returns a typed [`LookupBundle`] instead of
   a nested `(; lookups, lu_kwargs)` `NamedTuple`: stable fields
   (`lookup_lw`, `lookup_sw`, cloud/aerosol tables, the name→index maps, and the

--- a/NEWS.md
+++ b/NEWS.md
@@ -92,12 +92,12 @@ main
   functions over plain `(nlay, ncol)` array views: `interpolate_levels!`,
   `add_isothermal_boundary_layer!`, `clip!`, and `update_concentrations!`.
 - `clip!` now also clamps the spectral solvers' layer/level temperatures into the
-  valid range of the optics lookup tables (new `RRTMGPParameters` fields
-  `optics_lookup_temperature_min`/`max`, read from ClimaParams; 160–355 K), moving
-  the clamp that ClimaAtmos applied before every radiation call into RRTMGP's own
-  input preparation. The gray path is deliberately not clamped: it uses no lookup
-  tables, and idealized gray atmospheres can legitimately reach temperatures
-  outside the lookup range.
+  valid range of the optics lookup tables — the tables' first and last reference
+  temperatures (`lookup.t_ref_min`/`t_ref_max`, 160–355 K for the standard tables),
+  read straight from the lookup table — moving the clamp that ClimaAtmos applied
+  before every radiation call into RRTMGP's own input preparation. The gray path is
+  deliberately not clamped: it uses no lookup tables, and idealized gray atmospheres
+  can legitimately reach temperatures outside the lookup range.
 - Added standalone entry points that need no NetCDF lookup tables — `solve_gray`,
   `default_parameters`, and `heating_rate` (in K/s) — for single-column/classroom use.
 - Added optional spectrally-resolved (per-band) fluxes: construct with `spectral_fluxes = true`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,16 @@ RRTMGP.jl Release Notes
 
 main
 ------
+- The standalone (Layer-3) path is complete: `standard_atmosphere(FT; kind)`
+  builds an idealized clear-sky `AtmosphereProfile` (`:tropical`,
+  `:midlatitude_summer`, `:subarctic_winter` — analytic two-segment
+  temperature, exact hydrostatic pressure, idealized water vapor/ozone,
+  present-day well-mixed gases), and `solve(profile; method)` solves it in one
+  call — `ClearSkyRadiation` (default) or `GrayRadiation`. Both `solve` and
+  `solve_gray` now return a documented `RadiationOutput` struct with stable
+  field names (`lw_up` … `sw_direct_dn`, `net`, `heating_rate`, `solver`);
+  `solve_gray` previously returned a `NamedTuple` with the same names, so
+  field access is unchanged.
 - New `prepare_atmosphere!(solver)`: runs the atmospheric-state preparation
   cascade (level interpolation, isothermal boundary layer, clipping, dry-air
   column amounts) without solving, so hosts can inspect the prepared state —

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -104,3 +104,44 @@
   year={2013},
   doi={10.1175/JAS-D-12-039.1}
 }
+@article{clough1992,
+  title={Line-by-line calculations of atmospheric fluxes and cooling rates: Application to water vapor},
+  author={Clough, Shepard A and Iacono, Michael J and Moncet, Jean-Luc},
+  journal={Journal of Geophysical Research: Atmospheres},
+  volume={97},
+  number={D14},
+  pages={15761--15785},
+  year={1992},
+  doi={10.1029/92JD01419}
+}
+
+@article{fu1997,
+  title={Multiple scattering parameterization in thermal infrared radiative transfer},
+  author={Fu, Qiang and Liou, KN and Cribb, MC and Charlock, TP and Grossman, A},
+  journal={Journal of the Atmospheric Sciences},
+  volume={54},
+  number={24},
+  pages={2799--2812},
+  year={1997},
+  doi={10.1175/1520-0469(1997)054<2799:MSPITI>2.0.CO;2}
+}
+
+@article{hogan2023,
+  title={What are the optimum discrete angles to use in thermal-infrared radiative transfer calculations?},
+  author={Hogan, Robin J},
+  journal={Quarterly Journal of the Royal Meteorological Society},
+  volume={150},
+  number={758},
+  pages={318--333},
+  year={2023},
+  doi={10.1002/qj.4598}
+}
+
+@article{zdunkowski1980,
+  title={An investigation of the structure of typical two-stream methods for the calculation of solar fluxes and heating rates in clouds},
+  author={Zdunkowski, Wilford G and Welch, Ronald M and Korb, G},
+  journal={Contributions to Atmospheric Physics},
+  volume={53},
+  pages={147--166},
+  year={1980}
+}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(;
         "RTE" => "RTE.md",
         "Optics" => "Optics.md",
         "Example" => "Example.md",
+        "Fortran and paper concordance" => "concordance.md",
         "API" => Any[
             "API" => "api.md"
             "Getter contract" => "getters.md"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -117,6 +117,10 @@ VolumeMixingRatios.VolumeMixingRatioGlobalMean
 
 ```@docs
 RRTMGP.default_parameters
+RRTMGP.AtmosphereProfile
+RRTMGP.standard_atmosphere
+RRTMGP.solve
+RRTMGP.RadiationOutput
 RRTMGP.solve_gray
 RRTMGP.heating_rate
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -94,6 +94,7 @@ RRTMGP.add_isothermal_boundary_layer!
 RRTMGP.clip!
 RRTMGP.update_concentrations!
 RRTMGP.get_p_min
+RRTMGP.get_t_min
 ```
 
 ## Aerosol properties

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,6 +46,7 @@ RRTMGP.load_lookup_tables
 
 ```@docs
 RRTMGP.update_fluxes!
+RRTMGP.prepare_atmosphere!
 RRTMGP.update_sw_fluxes!
 RRTMGP.update_lw_fluxes!
 RRTMGP.update_net_fluxes!

--- a/docs/src/concordance.md
+++ b/docs/src/concordance.md
@@ -24,7 +24,7 @@ and ``μ₀`` (cosine of the solar zenith angle).
 | `VolumeMixingRatios.Vmr` / `VmrGM` | `mo_gas_concentrations`: `ty_gas_concs` (`set_vmr!`) | — |
 | `Optics.OneScalar` (``τ`` only) | `mo_optical_props`: `ty_optical_props_1scl` | — |
 | `Optics.TwoStream` (``τ``, ``ω₀``, ``g``) | `mo_optical_props`: `ty_optical_props_2str` | — |
-| `SourceLWNoScat`, `SourceLW2Str` (`lay_source`, `lev_source`, `sfc_source` — same field names) | `mo_source_functions`: `ty_source_func_lw` (older Fortran versions split `lev_source` into `lev_source_inc`/`dec`) | Planck source ``B`` |
+| `SourceLWNoScat` (`lay_source`, `lev_source`, `sfc_source`), `SourceLW2Str` (`lev_source`, `sfc_source`) | `mo_source_functions`: `ty_source_func_lw` (older Fortran versions split `lev_source` into `lev_source_inc`/`dec`) | Planck source ``B`` |
 | `SourceSW2Str` | internal arrays of `sw_solver_2stream` | — |
 | `FluxLW`, `FluxSW` (`flux_up`, `flux_dn`, `flux_net`, `flux_dn_dir` — same field names) | `mo_fluxes`: `ty_fluxes_broadband` | ``F^↑``, ``F^↓`` |
 | `Fluxes.FluxBand` (`spectral_fluxes = true`) | `extensions/mo_fluxes_byband`: `ty_fluxes_byband` | — |

--- a/docs/src/concordance.md
+++ b/docs/src/concordance.md
@@ -1,0 +1,103 @@
+# Fortran and paper concordance
+
+RRTMGP.jl is a Julia implementation of the algorithms in the reference Fortran
+package [rte-rrtmgp](https://github.com/earth-system-radiation/rte-rrtmgp)
+[pincus2019](@cite). If you know the Fortran code — or the papers it
+implements — the tables below map its `mo_*` modules, `ty_*` derived types, and
+kernel subroutines to their RRTMGP.jl counterparts, with the papers whose
+equations each kernel implements.
+
+Fortran names follow rte-rrtmgp v1.7; where a kernel was merged or renamed
+across Fortran versions, both names are given. The shared vocabulary is the
+same in both codes: `lay` for layer centers (`nlay`), `lev` for level faces
+(`nlev = nlay + 1`), `gpt` for correlated-``k`` g-points, `bnd` for spectral
+bands, `sfc` for surface, and the radiative-transfer symbols ``τ`` (optical
+depth), ``ω₀``/`ssa` (single-scattering albedo), ``g`` (asymmetry parameter),
+and ``μ₀`` (cosine of the solar zenith angle).
+
+## Containers
+
+| RRTMGP.jl | Fortran rte-rrtmgp | Papers / symbols |
+|:----------|:-------------------|:-----------------|
+| `AtmosphericState` (layer/level ``p``, ``T``; `vmr`; `col_dry`) | the `gas_optics()` arguments `play`, `plev`, `tlay`, `tlev`, `col_dry` | — |
+| `GrayAtmosphericState` | — (no gray path in the Fortran code) | [schneider2004](@cite), [ogorman2008](@cite) |
+| `VolumeMixingRatios.Vmr` / `VmrGM` | `mo_gas_concentrations`: `ty_gas_concs` (`set_vmr!`) | — |
+| `Optics.OneScalar` (``τ`` only) | `mo_optical_props`: `ty_optical_props_1scl` | — |
+| `Optics.TwoStream` (``τ``, ``ω₀``, ``g``) | `mo_optical_props`: `ty_optical_props_2str` | — |
+| `SourceLWNoScat`, `SourceLW2Str` (`lay_source`, `lev_source`, `sfc_source` — same field names) | `mo_source_functions`: `ty_source_func_lw` (older Fortran versions split `lev_source` into `lev_source_inc`/`dec`) | Planck source ``B`` |
+| `SourceSW2Str` | internal arrays of `sw_solver_2stream` | — |
+| `FluxLW`, `FluxSW` (`flux_up`, `flux_dn`, `flux_net`, `flux_dn_dir` — same field names) | `mo_fluxes`: `ty_fluxes_broadband` | ``F^↑``, ``F^↓`` |
+| `Fluxes.FluxBand` (`spectral_fluxes = true`) | `extensions/mo_fluxes_byband`: `ty_fluxes_byband` | — |
+| `LwBCs` (`sfc_emis`, `inc_flux`) | the `rte_lw` arguments `sfc_emis`, `inc_flux` | ``ε_{\mathrm{sfc}}`` |
+| `SwBCs` (`cos_zenith`, `toa_flux`, `sfc_alb_direct`, `inc_flux_diffuse`, `sfc_alb_diffuse`) | the `rte_sw` arguments `mu0`, `inc_flux`, `sfc_alb_dir`, `sfc_alb_dif`, `inc_flux_dif` | ``μ₀``, ``α`` |
+| `AngularDiscretization` (`gauss_Ds`, `gauss_wts`) | the `gauss_Ds`/`gauss_wts` tables in `mo_rte_solver_kernels` (`n_gauss_angles`) | Gauss–Jacobi-5 quadrature, [hogan2023](@cite) Table 1 |
+| `LookupBundle`, `lookup_tables`, `LookUpLW`/`LookUpSW` | `mo_load_coefficients` loading a k-distribution into `mo_gas_optics_rrtmgp`: `ty_gas_optics_rrtmgp` | correlated-``k`` distribution, [pincus2019](@cite) |
+| `LookUpCld` | `mo_load_cloud_coefficients` → `mo_cloud_optics_rrtmgp`: `ty_cloud_optics_rrtmgp` (LUT path) | — |
+| `LookUpAerosolMerra` | `extensions/mo_aerosol_optics_rrtmgp_merra`: `ty_aerosol_optics_rrtmgp_merra` | MERRA-2 aerosol types |
+| `CloudState`, `AerosolState` | the `cloud_optics()` / `aerosol_optics()` arguments (water paths, effective radii, relative humidity) | — |
+
+## RTE solvers and kernels
+
+The Fortran RTE kernels live in `rte-kernels/mo_rte_solver_kernels.F90`; the
+RRTMGP.jl equivalents live in `src/rte/`, split by band and solver
+(`longwave_noscat.jl`, `longwave_2stream.jl`, `shortwave_noscat.jl`,
+`shortwave_2stream.jl`). In RRTMGP.jl the same per-(g-point, column) bodies
+(`*_gpt_col!`) are driven by both the CPU and CUDA drivers.
+
+| RRTMGP.jl | Fortran rte-rrtmgp | Papers / symbols |
+|:----------|:-------------------|:-----------------|
+| `RTESolver.solve_lw!` on a `NoScatLWRTE`/`TwoStreamLWRTE` workspace | `mo_rte_lw`: `rte_lw` | — |
+| `RTESolver.solve_sw!` on a `NoScatSWRTE`/`TwoStreamSWRTE` workspace | `mo_rte_sw`: `rte_sw` | — |
+| `rte_lw_noscat_solve!` → `lw_noscat_gpt_col!` | `lw_solver_noscat` (`lw_solver_noscat_oneangle`) | — |
+| `lw_noscat_source_up` / `lw_noscat_source_dn` | `lw_source_noscat` | linear-in-``τ`` Planck source, [clough1992](@cite) Eq. 13 |
+| `rte_lw_noscat_one_angle!` (transport sweep) | `lw_transport_noscat` | ``T = e^{-Dτ}`` at secant ``D`` |
+| `rte_lw_2stream_solve!` → `lw_2stream_gpt_col!` | `lw_solver_2stream` | — |
+| `lw_2stream_coeffs` | `lw_two_stream` | ``γ₁``, ``γ₂``, ``k = \sqrt{(γ₁-γ₂)(γ₁+γ₂)}``, ``R_{\mathrm{dif}}``/``T_{\mathrm{dif}}`` — [meador1980](@cite) with the diffusivity ``D = 1.66`` of [fu1997](@cite) |
+| longwave source part of `rte_lw_2stream!` | `lw_source_2str` | linear-in-``τ`` source for scattering atmospheres, [toon1989](@cite) |
+| `rte_sw_noscat_solve!` → `sw_noscat_gpt_col!` (`rte_sw_noscat!`) | `sw_solver_noscat` | Beer–Lambert direct beam, ``e^{-τ/μ₀}`` |
+| `rte_sw_2stream_solve!` → `sw_2stream_gpt_col!` | `sw_solver_2stream` | — |
+| `sw_2stream_coeffs` | `sw_two_stream` + `sw_source_2str` (merged as `sw_dif_and_source` in later versions) | ``γ₁``–``γ₄`` of the Zdunkowski PIFM scheme [zdunkowski1980](@cite); ``R_{\mathrm{dir}}``/``T_{\mathrm{dir}}`` from [meador1980](@cite) Eqs. 14–18 |
+| direct-beam prepass inside `rte_sw_2stream!` | the direct-beam accumulation inside `sw_solver_2stream` | ``F^↓_{\mathrm{dir}} = μ₀ F_0 e^{-τ_{\mathrm{cum}}/μ₀}`` |
+| adding pass inside `rte_lw_2stream!` / `rte_sw_2stream!` | `adding` | interface albedo recursion, [shonk2008](@cite) |
+| `Optics.delta_scale` | `mo_optical_props_kernels`: `delta_scale_2str_kernel` | δ-scaling, [joseph1976](@cite) (RRTMGP.jl uses the algebraically exact forms, e.g. ``g' = g/(1+g)``) |
+| `Optics.increment_2stream` | `mo_optical_props_kernels`: `increment_2stream_by_2stream` | — |
+| `Fluxes.compute_net_flux!` | `mo_fluxes_broadband_kernels`: `net_broadband` | ``F_{\mathrm{net}} = F^↑ - F^↓`` |
+
+## Gas optics
+
+The Fortran gas-optics kernels live in
+`rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90`; the RRTMGP.jl equivalents in
+`src/optics/gas_optics.jl` and `src/optics/compute_optical_props.jl`.
+
+| RRTMGP.jl | Fortran rte-rrtmgp | Papers / symbols |
+|:----------|:-------------------|:-----------------|
+| `Optics.compute_optical_props!` | `ty_gas_optics_rrtmgp`: `gas_optics()` | [pincus2019](@cite) |
+| `compute_gas_optics` (per g-point and column) | `compute_tau_absorption` + `compute_Planck_source` | ``τ``, Planck fraction |
+| `compute_interp_frac_temp` / `_press` / `_η` | `interpolation` | temperature/pressure/mixing-fraction interpolation weights (`jtemp`, `jpress`, `jeta`, `fmajor`, `fminor`); ``η`` is the binary-species mixing fraction |
+| `compute_τ_minor` | `gas_optical_depths_minor` | minor-gas absorption |
+| `compute_τ_rayleigh` | `compute_tau_rayleigh` | Rayleigh scattering ``τ`` |
+| `interp1d_equispaced`, `interp2d`, `interp3d` | `interpolate1D`, `interpolate2D`, `interpolate3D` | — |
+| `Optics.compute_col_gas!` | `ty_gas_optics_rrtmgp`: `get_col_dry` | dry-air column amount [molecules cm⁻²] |
+| `Optics.compute_relative_humidity!` | — (host responsibility in Fortran) | feeds the MERRA aerosol lookup |
+
+## Cloud and aerosol optics
+
+| RRTMGP.jl | Fortran rte-rrtmgp | Papers / symbols |
+|:----------|:-------------------|:-----------------|
+| `add_cloud_optics_1scalar!` / `add_cloud_optics_2stream!` with `compute_lookup_cld_liq_props` / `compute_lookup_cld_ice_props` | `ty_cloud_optics_rrtmgp`: `cloud_optics()` (lookup-table path) | liquid/ice ``τ``, ``ω₀``, ``g`` from water path and effective radius |
+| `build_cloud_mask!` with `MaxRandomOverlap` | `extensions/mo_cloud_sampling`: `sampled_mask` (maximum-random overlap) | cloud-overlap sampling |
+| `add_aerosol_optics_1scalar!` / `add_aerosol_optics_2stream!` with `compute_lookup_aerosol` | `ty_aerosol_optics_rrtmgp_merra`: `aerosol_optics()` | MERRA-2 aerosol optics by type, radius bin, and relative humidity |
+
+## RRTMGP.jl-only layers
+
+These have no Fortran counterpart; the closest analog is the example driver
+programs (`examples/rfmip-clear-sky`, `examples/all-sky`), which each user of
+the Fortran code re-writes.
+
+| RRTMGP.jl | Role |
+|:----------|:-----|
+| `RRTMGPSolver`, `update_fluxes!`, `prepare_atmosphere!`, the named getters | Layer-2 host convenience: construct once, drive the functional core each radiation step (see [The getter contract](@ref)) |
+| `standard_atmosphere`, `solve(profile)`, `RadiationOutput`, `solve_gray` | Layer-3 standalone front door (teaching, single-column experiments) |
+| `GrayAtmosphere` module and the gray optics kernels | analytic gray-atmosphere radiation [schneider2004](@cite), [ogorman2008](@cite) |
+| `Numerics` module (`k_min`, `τ_thresh`, `resonance_window`, `μ₀_min`) | documented numerical guard constants (hard-coded literals in the Fortran kernels) |
+| `LookupBundle` caching via `save_lookup_tables` / `load_lookup_tables` | NetCDF-free lookup reuse |

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -21,8 +21,6 @@ function RRTMGPParameters(
         :adiabatic_exponent_dry_air => :kappa_d,
         :stefan_boltzmann_constant => :Stefan,
         :avogadro_constant => :avogad,
-        :optics_lookup_temperature_min => :optics_lookup_temperature_min,
-        :optics_lookup_temperature_max => :optics_lookup_temperature_max,
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "RRTMGP")
     parameters = merge(parameters, overrides)

--- a/ext/RRTMGPNCDatasetsExt.jl
+++ b/ext/RRTMGPNCDatasetsExt.jl
@@ -70,6 +70,8 @@ function lookup_tables(
     @assert RRTMGP.LookUpTables.get_n_gases(lookup_lw) ==
             RRTMGP.LookUpTables.get_n_gases(lookup_sw)
     @assert lookup_lw.p_ref_min == lookup_sw.p_ref_min
+    @assert lookup_lw.t_ref_min == lookup_sw.t_ref_min
+    @assert lookup_lw.t_ref_max == lookup_sw.t_ref_max
     return LookupBundle(;
         lookup_lw,
         lookup_sw,

--- a/ext/lookup_constructors.jl
+++ b/ext/lookup_constructors.jl
@@ -335,6 +335,10 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     t_ref = Array{FT, 1}(Array(ds["temp_ref"]))
 
     p_ref_min = minimum(p_ref)
+    # First/last reference temperatures bound the table's valid interpolation
+    # range. Capture them here as CPU scalars (like `p_ref_min`) so callers can
+    # read the temperature bounds without indexing the device-resident `t_ref`.
+    t_ref_min, t_ref_max = extrema(t_ref)
 
     Δ_t_ref = t_ref[2] - t_ref[1]
     Δ_ln_p_ref = log(p_ref[1]) - log(p_ref[2])
@@ -385,6 +389,8 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
             idx_h2o,
             p_ref_tropo,
             p_ref_min,
+            t_ref_min,
+            t_ref_max,
             key_species,
             kmajor,
             planck,
@@ -630,6 +636,10 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     t_ref = Array{FT, 1}(Array(ds["temp_ref"]))
 
     p_ref_min = minimum(p_ref)
+    # First/last reference temperatures bound the table's valid interpolation
+    # range. Capture them here as CPU scalars (like `p_ref_min`) so callers can
+    # read the temperature bounds without indexing the device-resident `t_ref`.
+    t_ref_min, t_ref_max = extrema(t_ref)
 
     Δ_t_ref = t_ref[2] - t_ref[1]
     Δ_ln_p_ref = log(p_ref[1]) - log(p_ref[2])
@@ -697,6 +707,8 @@ function LookUpSW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
             idx_h2o,
             p_ref_tropo,
             p_ref_min,
+            t_ref_min,
+            t_ref_max,
             solar_src_tot,
             key_species,
             kmajor,

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -11,10 +11,6 @@ Base.@kwdef struct RRTMGPParameters{FT} <: ARP
     kappa_d::FT
     Stefan::FT
     avogad::FT
-    # valid temperature range of the optics lookup tables [K]; `clip!` clamps
-    # the spectral solvers' temperature inputs to it
-    optics_lookup_temperature_min::FT = 160
-    optics_lookup_temperature_max::FT = 355
 end
 
 # Method wrappers

--- a/src/RRTMGP.jl
+++ b/src/RRTMGP.jl
@@ -52,6 +52,7 @@ include(joinpath("api", "getters.jl"))
 include(joinpath("api", "validation.jl"))
 
 # ── Layer 3: standalone front door
+include(joinpath("api", "atmosphere_profile.jl"))
 include(joinpath("api", "standalone.jl"))
 
 end # module

--- a/src/api/atmosphere_profile.jl
+++ b/src/api/atmosphere_profile.jl
@@ -36,7 +36,7 @@ end
 
 # Idealized per-kind parameters: surface temperature [K], tropopause height
 # [m], tropospheric lapse rate [K/m], stratospheric inverse lapse rate [K/m],
-# surface and stratospheric-floor water-vapor vmr, default latitude [degrees].
+# surface water-vapor vmr, default latitude [degrees].
 # The values are idealized climatological choices (inspired by the AFGL
 # reference-atmosphere climatology, but analytic rather than tabulated).
 const _STANDARD_ATMOSPHERES = Dict(
@@ -73,9 +73,10 @@ function _standard_T(z, prm)
     return (prm.t_sfc - prm.Γ_trop * prm.z_trop) + prm.Γ_strat * (z - prm.z_trop)
 end
 
-# Hydrostatic pressure for the two-segment profile (exact closed forms for a
-# constant-lapse-rate ideal-gas atmosphere: p ∝ T^(g/(R_d·Γ)), decreasing
-# along −Γ and increasing along +Γ).
+# Hydrostatic pressure for the two-segment profile (exact closed form for a
+# constant-lapse-rate ideal-gas atmosphere, p ∝ T^(±g/(R_d·Γ)); the exponent is
+# positive in the cooling troposphere and negative in the warming stratosphere,
+# so pressure decreases monotonically with height in both segments).
 function _standard_p(z, prm, p_sfc, grav, R_d)
     T_trop = prm.t_sfc - prm.Γ_trop * prm.z_trop
     if z ≤ prm.z_trop

--- a/src/api/atmosphere_profile.jl
+++ b/src/api/atmosphere_profile.jl
@@ -1,0 +1,161 @@
+#####
+##### Idealized standard-atmosphere profiles for the Layer-3 standalone path
+#####
+
+"""
+    AtmosphereProfile
+
+A self-contained, host-side description of a clear-sky atmospheric column (or
+`ncol` identical columns), as produced by [`standard_atmosphere`](@ref) and
+consumed by [`solve`](@ref). All arrays are plain `Array{FT}` on the host;
+[`solve`](@ref) moves them to the compute device.
+
+# Fields
+- `p_lay`, `t_lay`: layer-center pressures [Pa] and temperatures [K], `(nlay, ncol)`.
+- `p_lev`, `t_lev`: level pressures [Pa] and temperatures [K], `(nlay + 1, ncol)`.
+- `z_lev`: level altitudes [m], `(nlay + 1, ncol)`.
+- `t_sfc`: surface temperature [K], `(ncol,)`.
+- `lat`: latitude [degrees], `(ncol,)`.
+- `vmr_h2o`, `vmr_o3`: water-vapor and ozone volume mixing ratios, `(nlay, ncol)`.
+- `well_mixed_vmr`: `Dict` of global-mean volume mixing ratios for the
+  well-mixed gases, keyed by the RRTMGP gas names (see `gas_names_sw`); gases
+  not listed are taken as zero.
+"""
+struct AtmosphereProfile{A1, A2, WM}
+    p_lay::A2
+    p_lev::A2
+    t_lay::A2
+    t_lev::A2
+    z_lev::A2
+    t_sfc::A1
+    lat::A1
+    vmr_h2o::A2
+    vmr_o3::A2
+    well_mixed_vmr::WM
+end
+
+# Idealized per-kind parameters: surface temperature [K], tropopause height
+# [m], tropospheric lapse rate [K/m], stratospheric inverse lapse rate [K/m],
+# surface and stratospheric-floor water-vapor vmr, default latitude [degrees].
+# The values are idealized climatological choices (inspired by the AFGL
+# reference-atmosphere climatology, but analytic rather than tabulated).
+const _STANDARD_ATMOSPHERES = Dict(
+    :tropical => (;
+        t_sfc = 300.0,
+        z_trop = 17.0e3,
+        Γ_trop = 6.5e-3,
+        Γ_strat = 2.2e-3,
+        vmr_h2o_sfc = 2.3e-2,
+        lat = 0.0,
+    ),
+    :midlatitude_summer => (;
+        t_sfc = 294.0,
+        z_trop = 13.0e3,
+        Γ_trop = 6.5e-3,
+        Γ_strat = 2.0e-3,
+        vmr_h2o_sfc = 1.4e-2,
+        lat = 45.0,
+    ),
+    :subarctic_winter => (;
+        t_sfc = 257.0,
+        z_trop = 9.0e3,
+        Γ_trop = 5.0e-3,
+        Γ_strat = 1.5e-3,
+        vmr_h2o_sfc = 1.6e-3,
+        lat = 65.0,
+    ),
+)
+
+# Two-segment temperature profile: constant tropospheric lapse Γ_trop up to
+# z_trop, then linear warming Γ_strat above (an idealized stratosphere).
+function _standard_T(z, prm)
+    z ≤ prm.z_trop && return prm.t_sfc - prm.Γ_trop * z
+    return (prm.t_sfc - prm.Γ_trop * prm.z_trop) + prm.Γ_strat * (z - prm.z_trop)
+end
+
+# Hydrostatic pressure for the two-segment profile (exact closed forms for a
+# constant-lapse-rate ideal-gas atmosphere: p ∝ T^(g/(R_d·Γ)), decreasing
+# along −Γ and increasing along +Γ).
+function _standard_p(z, prm, p_sfc, grav, R_d)
+    T_trop = prm.t_sfc - prm.Γ_trop * prm.z_trop
+    if z ≤ prm.z_trop
+        return p_sfc * (_standard_T(z, prm) / prm.t_sfc)^(grav / (R_d * prm.Γ_trop))
+    end
+    p_trop = p_sfc * (T_trop / prm.t_sfc)^(grav / (R_d * prm.Γ_trop))
+    return p_trop * (_standard_T(z, prm) / T_trop)^(-grav / (R_d * prm.Γ_strat))
+end
+
+# Idealized water vapor: exponential decay with a 2 km scale height above the
+# surface value, floored at a stratospheric background of 4 ppmv.
+_standard_vmr_h2o(z, prm) = max(prm.vmr_h2o_sfc * exp(-z / 2.0e3), 4.0e-6)
+
+# Idealized ozone layer: log-pressure Gaussian peaking at ~7.5 ppmv near
+# p = 1200 Pa (≈30 km), over a 30 ppbv tropospheric background.
+_standard_vmr_o3(p) = 3.0e-8 + 7.5e-6 * exp(-(log(p / 1.2e3))^2 / (2 * 1.2^2))
+
+"""
+    standard_atmosphere(FT; kind = :midlatitude_summer, nlay = 60, ncol = 1,
+                        z_top = 45.0e3, p_sfc = 101325.0,
+                        params = default_parameters(FT))
+
+Build an idealized clear-sky [`AtmosphereProfile`](@ref) on `nlay` layers with
+levels uniformly spaced in altitude from the surface to `z_top` [m]:
+
+- temperature: a constant tropospheric lapse rate up to an idealized
+  tropopause, linear warming above (per-`kind` parameters);
+- pressure: the exact hydrostatic profile for that temperature structure;
+- water vapor: exponential decay (2 km scale height) to a 4 ppmv
+  stratospheric floor; ozone: a log-pressure Gaussian layer peaking near
+  30 km; well-mixed gases at present-day global means (CO₂ 420 ppmv,
+  CH₄ 1.9 ppmv, N₂O 0.34 ppmv, CO 0.1 ppmv, O₂ 0.209, N₂ 0.781).
+
+`kind` selects the idealized climatology: `:tropical`,
+`:midlatitude_summer` (default), or `:subarctic_winter`. The profiles are
+analytic and idealized — made for teaching and testing, not for reproducing
+tabulated reference atmospheres. All `ncol` columns are identical.
+"""
+function standard_atmosphere(
+    ::Type{FT};
+    kind::Symbol = :midlatitude_summer,
+    nlay::Int = 60,
+    ncol::Int = 1,
+    z_top = 45.0e3,
+    p_sfc = 101325.0,
+    params = default_parameters(FT),
+) where {FT <: AbstractFloat}
+    haskey(_STANDARD_ATMOSPHERES, kind) || error(
+        "unknown standard-atmosphere kind `$(repr(kind))`; available kinds: " *
+        "$(sort(collect(keys(_STANDARD_ATMOSPHERES))))",
+    )
+    prm = _STANDARD_ATMOSPHERES[kind]
+    grav = Float64(RP.grav(params))
+    R_d = Float64(RP.R_d(params))
+
+    nlev = nlay + 1
+    z_lev1 = range(0.0, Float64(z_top); length = nlev)
+    z_lay1 = (z_lev1[1:(end - 1)] .+ z_lev1[2:end]) ./ 2
+
+    p_lay1 = _standard_p.(z_lay1, Ref(prm), Float64(p_sfc), grav, R_d)
+    p_lev1 = _standard_p.(z_lev1, Ref(prm), Float64(p_sfc), grav, R_d)
+
+    tocols(v) = FT.(repeat(reshape(collect(v), :, 1), 1, ncol))
+    return AtmosphereProfile(
+        tocols(p_lay1),
+        tocols(p_lev1),
+        tocols(_standard_T.(z_lay1, Ref(prm))),
+        tocols(_standard_T.(z_lev1, Ref(prm))),
+        tocols(z_lev1),
+        fill(FT(prm.t_sfc), ncol),
+        fill(FT(prm.lat), ncol),
+        tocols(_standard_vmr_h2o.(z_lay1, Ref(prm))),
+        tocols(_standard_vmr_o3.(p_lay1)),
+        Dict(
+            "co2" => FT(420.0e-6),
+            "ch4" => FT(1.9e-6),
+            "n2o" => FT(0.34e-6),
+            "co" => FT(1.0e-7),
+            "o2" => FT(0.209),
+            "n2" => FT(0.781),
+        ),
+    )
+end

--- a/src/api/getters.jl
+++ b/src/api/getters.jl
@@ -136,7 +136,6 @@ _require_band_flux(band::Fluxes.FluxBand) = band
 _solver_band_flux(ws) =
     hasproperty(ws, :band_flux) ? _require_band_flux(ws.band_flux) :
     error("spectral fluxes require a two-stream, non-gray solver.")
-_band_net(band::Fluxes.FluxBand) = band.flux_up .- band.flux_dn
 
 """
     spectral_lw_flux_up(s::RRTMGPSolver)
@@ -153,22 +152,20 @@ for two-stream, non-gray radiation. Band `b`'s slice `[:, :, b]` has the same la
 broadband fluxes, and summing over the band dimension recovers them. Use
 [`lw_band_bounds`](@ref) / [`sw_band_bounds`](@ref) to identify each band's wavenumber range.
 
-The `up`/`dn` getters are views into the retained per-band buffers. The `net` getters instead
-allocate a fresh array each call (`up − dn` is not stored separately), so — unlike the other
-vertical getters — they are outside the zero-allocation/view contract.
+The `up`/`dn`/`net` getters are views into the retained per-band buffers.
 """
 spectral_lw_flux_up(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.lws).flux_up)
 spectral_lw_flux_dn(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.lws).flux_dn)
 spectral_lw_flux_net(s::RRTMGPSolver) =
-    _domain_view(s, _band_net(_solver_band_flux(s.lws)))
+    _domain_view(s, _solver_band_flux(s.lws).flux_net)
 spectral_sw_flux_up(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.sws).flux_up)
 spectral_sw_flux_dn(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.sws).flux_dn)
 spectral_sw_flux_net(s::RRTMGPSolver) =
-    _domain_view(s, _band_net(_solver_band_flux(s.sws)))
+    _domain_view(s, _solver_band_flux(s.sws).flux_net)
 
 """
     lw_band_bounds(s::RRTMGPSolver)

--- a/src/api/grid_adaptation.jl
+++ b/src/api/grid_adaptation.jl
@@ -29,6 +29,21 @@ radiation, and the longwave lookup table's reference minimum pressure otherwise.
 get_p_min(as::GrayAtmosphericState, lookup_lw) = zero(eltype(as.p_lay))
 get_p_min(as::AtmosphericState, lookup_lw) = lookup_lw.p_ref_min
 
+"""
+    get_t_min(as, lookup_lw)
+    get_t_max(as, lookup_lw)
+
+Return the temperature bounds of the radiation scheme's valid interpolation
+range: the longwave lookup table's first/last reference temperatures for
+non-gray radiation, and `nothing` for gray radiation (which has no temperature
+lookup and whose temperatures are left unclipped). Passing `nothing` to
+[`clip!`](@ref) makes temperature clipping a no-op.
+"""
+get_t_min(as::GrayAtmosphericState, lookup_lw) = nothing
+get_t_min(as::AtmosphericState, lookup_lw) = lookup_lw.t_ref_min
+get_t_max(as::GrayAtmosphericState, lookup_lw) = nothing
+get_t_max(as::AtmosphericState, lookup_lw) = lookup_lw.t_ref_max
+
 #####
 ##### Level <-> layer interpolation
 #####

--- a/src/api/standalone.jl
+++ b/src/api/standalone.jl
@@ -86,7 +86,7 @@ function heating_rate(s::RRTMGPSolver)
     device = ClimaComms.device(s.grid_params)
     (; ncol) = s.grid_params
     FT = eltype(s.grid_params)
-    # `net_flux`/`face_pressure` are domain views, so use the domain layer count.
+    # `net_flux`/`level_pressure` are domain views, so use the domain layer count.
     nlay = s.grid_params.nlay - Int(s.grid_params.isothermal_boundary_layer)
     hr = similar(net_flux(s), nlay, ncol)
     GrayAtmosphere.compute_gray_heating_rate!(

--- a/src/api/standalone.jl
+++ b/src/api/standalone.jl
@@ -8,8 +8,53 @@
 
 import ..GrayAtmosphere
 import ..AtmosphericStates
+import ..VolumeMixingRatios
 import ..BCs
 using ClimaComms
+
+"""
+    RadiationOutput
+
+The result of a standalone radiation solve ([`solve`](@ref) or
+[`solve_gray`](@ref)): the broadband fluxes, the heating rate, and the
+underlying solver. The field names are stable — teaching material written
+against them does not depend on the getter API. The flux fields are views into
+the solver's buffers (they change if the solver is re-solved); `heating_rate`
+is a freshly allocated array.
+
+# Fields
+- `lw_up`, `lw_dn`, `lw_net`: longwave up/down/net flux [W/m²], `(nlev, ncol)`.
+- `sw_up`, `sw_dn`, `sw_direct_dn`, `sw_net`: shortwave up/down/direct-beam/net
+  flux [W/m²], `(nlev, ncol)`.
+- `net`: combined longwave + shortwave net flux [W/m²], `(nlev, ncol)`.
+- `heating_rate`: radiative heating rate [K/s], `(nlay, ncol)`.
+- `solver`: the `RRTMGPSolver`, for getter access and re-solves.
+"""
+struct RadiationOutput{A, H, S}
+    lw_up::A
+    lw_dn::A
+    lw_net::A
+    sw_up::A
+    sw_dn::A
+    sw_direct_dn::A
+    sw_net::A
+    net::A
+    heating_rate::H
+    solver::S
+end
+
+_radiation_output(solver::RRTMGPSolver) = RadiationOutput(
+    lw_flux_up(solver),
+    lw_flux_dn(solver),
+    lw_flux_net(solver),
+    sw_flux_up(solver),
+    sw_flux_dn(solver),
+    sw_direct_flux_dn(solver),
+    sw_flux_net(solver),
+    net_flux(solver),
+    heating_rate(solver),
+    solver,
+)
 
 """
     default_parameters(FT)
@@ -83,9 +128,8 @@ conditions, and an `RRTMGPSolver`, then runs `update_fluxes!`.
 - `surface_albedo = 0.2`: shortwave surface albedo [-].
 
 # Returns
-A `NamedTuple` with the level fluxes `lw_up`, `lw_dn`, `lw_net`, `sw_up`, `sw_dn`,
-`sw_net`, and `net` (each `(nlev, ncol)` [W/m²]), the layer `heating_rate`
-`(nlay, ncol)` [K/s], and the underlying `solver`.
+A [`RadiationOutput`](@ref) with the level fluxes, the layer heating rate, and
+the underlying solver.
 
 # Examples
 ```julia
@@ -141,15 +185,144 @@ function solve_gray(
     solver =
         RRTMGPSolver(grid_params, GrayRadiation(), params, bcs_lw, bcs_sw, as)
     update_fluxes!(solver)
-    return (;
-        solver,
-        lw_up = lw_flux_up(solver),
-        lw_dn = lw_flux_dn(solver),
-        lw_net = lw_flux_net(solver),
-        sw_up = sw_flux_up(solver),
-        sw_dn = sw_flux_dn(solver),
-        sw_net = sw_flux_net(solver),
-        net = net_flux(solver),
-        heating_rate = heating_rate(solver),
+    return _radiation_output(solver)
+end
+
+"""
+    solve(profile::AtmosphereProfile; method = ClearSkyRadiation(false), kwargs...)
+
+Solve the radiative-transfer problem for an [`AtmosphereProfile`](@ref) in a
+single call and return a [`RadiationOutput`](@ref). Builds the atmospheric
+state, boundary conditions, and an `RRTMGPSolver` internally, then runs
+[`update_fluxes!`](@ref) — the one-line standalone path:
+
+```julia
+using RRTMGP, NCDatasets
+profile = RRTMGP.standard_atmosphere(Float64; kind = :tropical)
+out = RRTMGP.solve(profile)
+out.net          # net flux at each level [W/m²]
+out.heating_rate # heating rate at each layer [K/s]
+```
+
+`method` selects the radiation model: `ClearSkyRadiation(false)` (the default;
+requires lookup tables, so load NCDatasets first or pass cached `lookups`) or
+`GrayRadiation()` (no lookup tables — runs after a bare `using RRTMGP`; the
+profile's mixing ratios are ignored). Cloud and aerosol methods are not
+supported here — construct an [`RRTMGPSolver`](@ref) directly for those.
+
+# Keyword Arguments
+- `method = ClearSkyRadiation(false)`: the radiation method (see above).
+- `context = ClimaComms.context()`: the `ClimaComms` context (CPU or GPU); the
+  profile's host arrays are copied to the device.
+- `params = default_parameters(FT)`: RRTMGP physical parameters.
+- `lookups = nothing`: prebuilt [`LookupBundle`](@ref) to reuse (avoids the
+  NetCDF read when solving many profiles); `nothing` builds them internally.
+- `surface_emissivity = 1`: longwave surface emissivity [-].
+- `cos_zenith = 0.5`: cosine of the solar zenith angle [-].
+- `toa_flux = 1361`: top-of-atmosphere solar flux [W/m²].
+- `surface_albedo = 0.2`: shortwave surface albedo [-].
+- `optical_thickness = GrayOpticalThicknessOGorman2008(FT)`: gray
+  optical-thickness parameters (`GrayRadiation` only).
+"""
+function solve(
+    profile::AtmosphereProfile;
+    method::AbstractRRTMGPMethod = ClearSkyRadiation(false),
+    context = ClimaComms.context(),
+    params = default_parameters(eltype(profile.p_lay)),
+    lookups = nothing,
+    surface_emissivity = 1,
+    cos_zenith = 0.5,
+    toa_flux = 1361,
+    surface_albedo = 0.2,
+    optical_thickness = AtmosphericStates.GrayOpticalThicknessOGorman2008(
+        eltype(profile.p_lay),
+    ),
+)
+    FT = eltype(profile.p_lay)
+    (nlay, ncol) = size(profile.p_lay)
+    device = ClimaComms.device(context)
+    DA = ClimaComms.array_type(device)
+    # Copy (never alias) the profile's host arrays: the solve mutates its state
+    # in place (clipping, column amounts), and the profile should stay reusable.
+    dev(x) = DA{FT}(copy(x))
+
+    method isa Union{GrayRadiation, ClearSkyRadiation} || error(
+        "`solve(profile)` supports `GrayRadiation` and `ClearSkyRadiation`; \
+         for cloud or aerosol radiation, construct an `RRTMGPSolver` directly.",
     )
+    method isa ClearSkyRadiation && method.aerosol_radiation && error(
+        "`solve(profile)` does not support aerosol radiation (an \
+         `AtmosphereProfile` carries no aerosol state); use \
+         `ClearSkyRadiation(false)` or construct an `RRTMGPSolver` directly.",
+    )
+
+    grid_params = RRTMGPGridParams(FT; context, domain_nlay = nlay, ncol)
+    if isnothing(lookups)
+        _check_lookup_support(method)
+        lookups = lookup_tables(grid_params, method)
+    end
+
+    as = if method isa GrayRadiation
+        AtmosphericStates.GrayAtmosphericState(
+            dev(profile.lat),
+            dev(profile.p_lay),
+            dev(profile.p_lev),
+            dev(profile.t_lay),
+            dev(profile.t_lev),
+            dev(profile.z_lev),
+            dev(profile.t_sfc),
+            optical_thickness,
+        )
+    else
+        idx_gases = lookups.idx_gases_lw
+        vmr_wm = zeros(FT, lookups.ngas_lw)
+        for (gas, val) in profile.well_mixed_vmr
+            gas in ("h2o", "o3") && error(
+                "`well_mixed_vmr` lists \"$gas\", which is not well-mixed; it \
+                 belongs in the profile's `vmr_$gas` field.",
+            )
+            haskey(idx_gases, gas) || error(
+                "unknown gas \"$gas\" in `well_mixed_vmr`; RRTMGP's gas names \
+                 are $(sort(collect(keys(idx_gases)))).",
+            )
+            vmr_wm[idx_gases[gas]] = FT(val)
+        end
+        vmr = VolumeMixingRatios.VmrGM(
+            dev(profile.vmr_h2o),
+            dev(profile.vmr_o3),
+            DA{FT}(vmr_wm),
+        )
+        # Row 1 (col_dry) is computed by `prepare_atmosphere!` inside
+        # `update_fluxes!`; row 4 (rel_hum) feeds only aerosol optics, which
+        # this path rejects above.
+        layerdata = zeros(FT, 4, nlay, ncol)
+        layerdata[2, :, :] .= profile.p_lay
+        layerdata[3, :, :] .= profile.t_lay
+        # `lon` is unused by RRTMGP but must match `lat`'s type; `lat` enables
+        # latitude-dependent gravity in the column-amount computation.
+        AtmosphericStates.AtmosphericState(
+            dev(zeros(FT, ncol)),
+            dev(profile.lat),
+            DA{FT}(layerdata),
+            dev(profile.p_lev),
+            dev(profile.t_lev),
+            dev(profile.t_sfc),
+            vmr,
+            nothing,
+            nothing,
+        )
+    end
+
+    sfc_emis = fill!(DA{FT}(undef, lookups.nbnd_lw, ncol), FT(surface_emissivity))
+    bcs_lw = BCs.LwBCs(sfc_emis, nothing)
+    cos_zen = fill!(DA{FT}(undef, ncol), FT(cos_zenith))
+    toa = fill!(DA{FT}(undef, ncol), FT(toa_flux))
+    alb_dir = fill!(DA{FT}(undef, lookups.nbnd_sw, ncol), FT(surface_albedo))
+    alb_dif = fill!(DA{FT}(undef, lookups.nbnd_sw, ncol), FT(surface_albedo))
+    bcs_sw = BCs.SwBCs(cos_zen, toa, alb_dir, nothing, alb_dif)
+
+    solver =
+        RRTMGPSolver(grid_params, method, params, bcs_lw, bcs_sw, as; lookups)
+    update_fluxes!(solver)
+    return _radiation_output(solver)
 end

--- a/src/api/update_fluxes.jl
+++ b/src/api/update_fluxes.jl
@@ -159,6 +159,8 @@ function update_net_fluxes!(s::RRTMGPSolver, ::AbstractRRTMGPMethod)
     # Operate on the raw (boundary-extended) buffers, not `parent(getter(s))`: the
     # getters allocate a `view` per call that would then just be stripped by `parent`.
     s.net_flux_buffer .= s.lws.flux.flux_net .+ s.sws.flux.flux_net
+    _update_band_net_fluxes!(s.lws)
+    _update_band_net_fluxes!(s.sws)
     return nothing
 end
 function update_net_fluxes!(
@@ -168,6 +170,15 @@ function update_net_fluxes!(
     s.net_flux_buffer .= s.lws.flux.flux_net .+ s.sws.flux.flux_net
     s.clear_net_flux_buffer .=
         s.clear_flux_lw.flux_net .+ s.clear_flux_sw.flux_net
+    _update_band_net_fluxes!(s.lws)
+    _update_band_net_fluxes!(s.sws)
+    return nothing
+end
+
+_update_band_net_fluxes!(ws) = _update_band_net_fluxes!(hasproperty(ws, :band_flux) ? ws.band_flux : nothing)
+_update_band_net_fluxes!(::Nothing) = nothing
+function _update_band_net_fluxes!(band::Fluxes.FluxBand)
+    band.flux_net .= band.flux_up .- band.flux_dn
     return nothing
 end
 

--- a/src/api/update_fluxes.jl
+++ b/src/api/update_fluxes.jl
@@ -188,13 +188,39 @@ host calls it every radiation step. CI asserts `@allocated == 0` and
 `JET.@test_opt` for the gray Layer-2 aggregate and for the Layer-1
 `solve_lw!`/`solve_sw!` kernels of the spectral modes (single-threaded CPU).
 
-See also `update_lw_fluxes!`, `update_sw_fluxes!`, and `update_net_fluxes!`.
+See also `prepare_atmosphere!`, `update_lw_fluxes!`, `update_sw_fluxes!`, and
+`update_net_fluxes!`.
 """
 function update_fluxes!(s::RRTMGPSolver, seedval = nothing)
     # opt-in input validation (see `check_values`/`validate_inputs`); a single
     # branch when off, so the zero-allocation contract is unaffected
     check_values[] && validate_inputs(s)
     _maybe_reset_rng_seed!(_radiation_method(s), seedval)
+    prepare_atmosphere!(s)
+    update_lw_fluxes!(s)
+    update_sw_fluxes!(s)
+    update_net_fluxes!(s)
+    return nothing
+end
+
+"""
+    prepare_atmosphere!(s::RRTMGPSolver)
+
+Run the atmospheric-state preparation cascade without solving: interpolate
+level pressures/temperatures from layer values (per the solver's
+`interpolation`/`bottom_extrapolation` configuration; a no-op for
+`NoInterpolation`), fill the isothermal boundary layer (when configured), clip
+unphysical inputs (pressures below the lookup tables' minimum, negative water
+vapor), and compute the dry-air column amounts. Mutates the solver's
+atmospheric state in place and returns `nothing`.
+
+[`update_fluxes!`](@ref) calls this before solving; call it directly to inspect
+the prepared state (interpolated level values, column amounts) without running
+the radiative transfer — the prepare/solve split familiar from other radiation
+drivers. Relative humidity is *not* recomputed here (a host responsibility; see
+[`update_concentrations!`](@ref)).
+"""
+function prepare_atmosphere!(s::RRTMGPSolver)
     as = _atmospheric_state(s)
     p_min = get_p_min(as, _lw_lookup(s))
     interpolate_levels!(
@@ -209,20 +235,17 @@ function update_fluxes!(s::RRTMGPSolver, seedval = nothing)
     s.grid_params.isothermal_boundary_layer &&
         add_isothermal_boundary_layer!(as, p_min)
     clip!(
-    as,
-    p_min,
-    _idx_h2o(s);
-    t_min = RP.optics_lookup_temperature_min(s.params),
-    t_max = RP.optics_lookup_temperature_max(s.params),
-)
+        as,
+        p_min,
+        _idx_h2o(s);
+        t_min = RP.optics_lookup_temperature_min(s.params),
+        t_max = RP.optics_lookup_temperature_max(s.params),
+    )
     update_concentrations!(
         as,
         s.params,
         ClimaComms.device(s.grid_params),
         _idx_h2o(s),
     )
-    update_lw_fluxes!(s)
-    update_sw_fluxes!(s)
-    update_net_fluxes!(s)
     return nothing
 end

--- a/src/api/update_fluxes.jl
+++ b/src/api/update_fluxes.jl
@@ -222,7 +222,8 @@ level pressures/temperatures from layer values (per the solver's
 `interpolation`/`bottom_extrapolation` configuration; a no-op for
 `NoInterpolation`), fill the isothermal boundary layer (when configured), clip
 unphysical inputs (pressures below the lookup tables' minimum, negative water
-vapor), and compute the dry-air column amounts. Mutates the solver's
+vapor, and — for non-gray optics — temperatures outside the lookup tables'
+range), and compute the dry-air column amounts. Mutates the solver's
 atmospheric state in place and returns `nothing`.
 
 [`update_fluxes!`](@ref) calls this before solving; call it directly to inspect
@@ -233,7 +234,8 @@ drivers. Relative humidity is *not* recomputed here (a host responsibility; see
 """
 function prepare_atmosphere!(s::RRTMGPSolver)
     as = _atmospheric_state(s)
-    p_min = get_p_min(as, _lw_lookup(s))
+    lookup_lw = _lw_lookup(s)
+    p_min = get_p_min(as, lookup_lw)
     interpolate_levels!(
         as,
         s.interpolation,
@@ -249,8 +251,8 @@ function prepare_atmosphere!(s::RRTMGPSolver)
         as,
         p_min,
         _idx_h2o(s);
-        t_min = RP.optics_lookup_temperature_min(s.params),
-        t_max = RP.optics_lookup_temperature_max(s.params),
+        t_min = get_t_min(as, lookup_lw),
+        t_max = get_t_max(as, lookup_lw),
     )
     update_concentrations!(
         as,

--- a/src/optics/Fluxes.jl
+++ b/src/optics/Fluxes.jl
@@ -91,14 +91,15 @@ end
 """
     FluxBand{FT, FTA3D}
 
-Optional per-band upward and downward radiative fluxes at each level,
+Optional per-band upward, downward, and net radiative fluxes at each level,
 `(nlev, ncol, n_bnd)`. Only allocated when spectrally-resolved fluxes are requested.
 Band `b`'s slice `[:, :, b]` has the same `(nlev, ncol)` layout as the broadband
-fluxes, and summing over the band dimension recovers the broadband up/down fluxes.
+fluxes, and summing over the band dimension recovers the broadband fluxes.
 
 # Fields
 - `flux_up`: upward flux per band [W/m²], `(nlev, ncol, n_bnd)`.
 - `flux_dn`: downward flux per band [W/m²], `(nlev, ncol, n_bnd)`.
+- `flux_net`: net flux per band (`flux_up - flux_dn`) [W/m²], `(nlev, ncol, n_bnd)`.
 """
 struct FluxBand{FT <: AbstractFloat, FTA3D <: AbstractArray{FT, 3}}
     flux_up::FTA3D

--- a/src/optics/Fluxes.jl
+++ b/src/optics/Fluxes.jl
@@ -103,6 +103,7 @@ fluxes, and summing over the band dimension recovers the broadband up/down fluxe
 struct FluxBand{FT <: AbstractFloat, FTA3D <: AbstractArray{FT, 3}}
     flux_up::FTA3D
     flux_dn::FTA3D
+    flux_net::FTA3D
 end
 Adapt.@adapt_structure FluxBand
 
@@ -112,7 +113,8 @@ function FluxBand(grid_params::RRTMGPGridParams, n_bnd::Int)
     DA = ClimaComms.array_type(grid_params)
     flux_up = DA{FT}(undef, nlay + 1, ncol, n_bnd)
     flux_dn = DA{FT}(undef, nlay + 1, ncol, n_bnd)
-    return FluxBand{FT, typeof(flux_up)}(flux_up, flux_dn)
+    flux_net = DA{FT}(undef, nlay + 1, ncol, n_bnd)
+    return FluxBand{FT, typeof(flux_up)}(flux_up, flux_dn, flux_net)
 end
 
 # Zero a per-band flux buffer before a solve (no-op when spectral fluxes are off).
@@ -120,6 +122,7 @@ set_band_flux_to_zero!(::Nothing) = nothing
 function set_band_flux_to_zero!(band::FluxBand{FT}) where {FT}
     band.flux_up .= FT(0)
     band.flux_dn .= FT(0)
+    band.flux_net .= FT(0)
     return nothing
 end
 

--- a/src/optics/LookUpTables.jl
+++ b/src/optics/LookUpTables.jl
@@ -114,6 +114,10 @@ struct LookUpLW{FT, IA3D, FTA4D, BND, P, R, LMNR} <: AbstractLookUp
     p_ref_tropo::FT
     "minimum pressure supported by RRTMGP lookup tables"
     p_ref_min::FT
+    "minimum temperature supported by RRTMGP lookup tables (first reference temperature)"
+    t_ref_min::FT
+    "maximum temperature supported by RRTMGP lookup tables (last reference temperature)"
+    t_ref_max::FT
     "major absorbing species in each band `(2, n_atmos_layers, n_bnd)`"
     key_species::IA3D
     "major absorption coefficient `(n_η, n_p_ref + 1, n_t_ref, n_gpt)`"
@@ -161,6 +165,10 @@ struct LookUpSW{FT, IA3D, FTA1D, FTA3D, FTA4D, BND, R, LMNR} <: AbstractLookUp
     p_ref_tropo::FT
     "minimum pressure supported by RRTMGP lookup tables"
     p_ref_min::FT
+    "minimum temperature supported by RRTMGP lookup tables (first reference temperature)"
+    t_ref_min::FT
+    "maximum temperature supported by RRTMGP lookup tables (last reference temperature)"
+    t_ref_max::FT
     "total solar irradiation"
     solar_src_tot::FT
     "major absorbing species in each band `(2, n_atmos_layers, n_bnd)`"

--- a/src/optics/gas_optics.jl
+++ b/src/optics/gas_optics.jl
@@ -190,8 +190,8 @@ end
 
 Compute optical thickness, single scattering albedo, and asymmetry parameter.
 """
-@inline function compute_gas_optics(
-    lkp::LookUpLW,
+@inline function compute_gas_optics_core(
+    lkp,
     vmr,
     col_dry,
     igpt,
@@ -224,9 +224,6 @@ Compute optical thickness, single scattering albedo, and asymmetry parameter.
         tropo,
         jftemp[1],
     )
-    # compute Planck fraction
-    @inbounds planck_fraction = view(lkp.planck.planck_fraction, :, :, :, igpt)
-    pfrac = interp3d(jfη..., jftemp..., jfpress..., planck_fraction)
 
     # computing τ_major
     τ_major =
@@ -247,6 +244,35 @@ Compute optical thickness, single scattering albedo, and asymmetry parameter.
         glay,
         gcol,
     )
+    return (τ_major, τ_minor, tropo, vmr_h2o, jftemp, jfη, jfpress)
+end
+
+@inline function compute_gas_optics(
+    lkp::LookUpLW,
+    vmr,
+    col_dry,
+    igpt,
+    ibnd,
+    p_lay,
+    t_lay,
+    glay,
+    gcol,
+)
+    τ_major, τ_minor, tropo, vmr_h2o, jftemp, jfη, jfpress = compute_gas_optics_core(
+        lkp,
+        vmr,
+        col_dry,
+        igpt,
+        ibnd,
+        p_lay,
+        t_lay,
+        glay,
+        gcol,
+    )
+    # compute Planck fraction
+    @inbounds planck_fraction = view(lkp.planck.planck_fraction, :, :, :, igpt)
+    pfrac = interp3d(jfη..., jftemp..., jfpress..., planck_fraction)
+
     # τ_Rayleigh is zero for longwave
     τ = max(τ_major + τ_minor, zero(τ_major))
     return (τ, zero(τ_major), zero(τ_major), pfrac) # initializing asymmetry parameter
@@ -263,46 +289,14 @@ end
     glay,
     gcol,
 )
-    # upper/lower troposphere
-    tropo = p_lay > lkp.p_ref_tropo ? 1 : 2
-    # volume mixing ratio of h2o
-    vmr_h2o = get_vmr(vmr, lkp.idx_h2o, glay, gcol)
-
-    jftemp = compute_interp_frac_temp(lkp.ref_points.t_ref, t_lay)
-    jfpress = compute_interp_frac_press(lkp.ref_points.ln_p_ref, p_lay, tropo)
-
-    @inbounds kmajor = view(lkp.kmajor, :, :, :, igpt)
-    n_η = size(kmajor, 1)
-
-    ig = view(lkp.key_species, 1:2, tropo, ibnd)
-    @inbounds vmr1 = get_vmr(vmr, ig[1], glay, gcol)
-    @inbounds vmr2 = get_vmr(vmr, ig[2], glay, gcol)
-
-    jfη, col_mix = compute_interp_frac_η(
-        n_η,
-        ig,
-        lkp.ref_points.vmr_ref,
-        (vmr1, vmr2),
-        tropo,
-        jftemp[1],
-    )
-
-    # computing τ_major
-    τ_major =
-        interp3d(jfη..., jftemp..., jfpress..., kmajor, col_mix...) * col_dry
-    # computing τ_minor
-    lkp_minor = tropo == 1 ? lkp.minor_lower : lkp.minor_upper
-    τ_minor = compute_τ_minor(
-        lkp_minor,
+    τ_major, τ_minor, tropo, vmr_h2o, jftemp, jfη, jfpress = compute_gas_optics_core(
+        lkp,
         vmr,
-        vmr_h2o,
         col_dry,
-        p_lay,
-        t_lay,
-        jftemp...,
-        jfη...,
         igpt,
         ibnd,
+        p_lay,
+        t_lay,
         glay,
         gcol,
     )

--- a/src/optics/gas_optics.jl
+++ b/src/optics/gas_optics.jl
@@ -176,20 +176,10 @@ Compute interpolation fraction for binary species parameter.
     return ((jη1, jη2, fη1, fη2), (col_mix1, col_mix2))
 end
 
-"""
-    compute_gas_optics(
-        lkp::Union{LookUpLW, LookUpSW},
-        vmr,
-        col_dry,
-        igpt,
-        ibnd,
-        p_lay,
-        t_lay,
-        glay, gcol,
-    ) where {FT<:AbstractFloat}
-
-Compute optical thickness, single scattering albedo, and asymmetry parameter.
-"""
+# Internal helper shared by the longwave and shortwave `compute_gas_optics`
+# methods: computes the major/minor optical thickness contributions and the
+# interpolation fractions, returning the intermediate quantities the callers
+# need to finish the band-specific (Planck / Rayleigh) work.
 @inline function compute_gas_optics_core(
     lkp,
     vmr,
@@ -247,6 +237,20 @@ Compute optical thickness, single scattering albedo, and asymmetry parameter.
     return (τ_major, τ_minor, tropo, vmr_h2o, jftemp, jfη, jfpress)
 end
 
+"""
+    compute_gas_optics(
+        lkp::Union{LookUpLW, LookUpSW},
+        vmr,
+        col_dry,
+        igpt,
+        ibnd,
+        p_lay,
+        t_lay,
+        glay, gcol,
+    ) where {FT<:AbstractFloat}
+
+Compute optical thickness, single scattering albedo, and asymmetry parameter.
+"""
 @inline function compute_gas_optics(
     lkp::LookUpLW,
     vmr,

--- a/src/rte/shortwave_2stream.jl
+++ b/src/rte/shortwave_2stream.jl
@@ -220,8 +220,9 @@ doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     # Equations 14-15 have a removable singularity at k·μ₀ = 1. Nudge k·μ₀
     # off resonance so numerator and denominator stay mutually consistent.
     # See Numerics.resonance_window for the sqrt(eps) choice.
-    if abs(FT(1) - k_μ2) < Numerics.resonance_window(FT)
-        k_μ2 = FT(1) - Numerics.resonance_window(FT)
+    diff = FT(1) - k_μ2
+    if abs(diff) < Numerics.resonance_window(FT)
+        k_μ2 = diff ≥ 0 ? FT(1) - Numerics.resonance_window(FT) : FT(1) + Numerics.resonance_window(FT)
         k_μ = sqrt(k_μ2)
     end
     k_γ3 = k * γ3
@@ -261,8 +262,15 @@ doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
     # factor), whereas in ecRad (the model in the paper), they are normalized relative 
     # to the perpendicular incident intensity. Thus, the maximum fractional reflectance 
     # Rdir is bounded by 1 - T₀, and must not be scaled by μ₀.
-    Rdir = max(FT(0), min(Rdir_unconstrained, (FT(1) - T₀)))
-    Tdir = max(FT(0), min(Tdir_unconstrained, (FT(1) - T₀ - Rdir)))
+    Rdir = max(FT(0), Rdir_unconstrained)
+    Tdir = max(FT(0), Tdir_unconstrained)
+    av_energy = max(FT(0), FT(1) - T₀)
+    tot_dir = Rdir + Tdir
+    if tot_dir > av_energy
+        scale = av_energy / max(eps(FT), tot_dir)
+        Rdir *= scale
+        Tdir *= scale
+    end
     return (Rdir, Tdir, Tnoscat, Rdif, Tdif)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,6 +154,10 @@ printstyled("\n\nLookup-table serialization tests\n", color = color1)
 printstyled("=================================\n\n", color = color1)
 include("lookup_serialization.jl")
 
+printstyled("\n\nStandalone spectral solve(profile) tests\n", color = color1)
+printstyled("=================================\n\n", color = color1)
+include("standalone_spectral.jl")
+
 printstyled("\n\nOptics utilities tests\n", color = color1)
 printstyled("==============\n\n", color = color1)
 include("optics_utils.jl")

--- a/test/standalone.jl
+++ b/test/standalone.jl
@@ -32,6 +32,19 @@ Adapt.adapt_storage(::CopyToArray, x::AbstractArray) = copy(x)
     end
 end
 
+# prepare_atmosphere! is the preparation half of update_fluxes!: running it
+# separately and then the full update must give the same fluxes as the full
+# update alone (the cascade is idempotent for an already-consistent state).
+@testset "prepare_atmosphere! (prepare/solve split)" begin
+    solver = RRTMGP.solve_gray(Float64; nlay = 20, ncol = 4).solver
+    RRTMGP.prepare_atmosphere!(solver) # callable on its own
+    RRTMGP.update_fluxes!(solver)
+    F1 = copy(Array(RRTMGP.net_flux(solver)))
+    RRTMGP.prepare_atmosphere!(solver) # prepare again, then full update
+    RRTMGP.update_fluxes!(solver)
+    @test Array(RRTMGP.net_flux(solver)) == F1
+end
+
 # Renamed-module compat aliases (deprecated names, kept for one release).
 @testset "renamed-module aliases" begin
     @test RRTMGP.Vmrs === RRTMGP.VolumeMixingRatios

--- a/test/standalone.jl
+++ b/test/standalone.jl
@@ -18,6 +18,7 @@ Adapt.adapt_storage(::CopyToArray, x::AbstractArray) = copy(x)
     for FT in (Float32, Float64)
         nlay, ncol = 60, 9
         out = RRTMGP.solve_gray(FT; nlay, ncol)
+        @test out isa RRTMGP.RadiationOutput
         @test out.solver isa RRTMGP.RRTMGPSolver
         @test eltype(Array(out.net)) == FT
         @test size(Array(out.net)) == (nlay + 1, ncol)
@@ -66,6 +67,70 @@ end
             RRTMGP.ClearSkyRadiation(false),
         )
     end
+end
+
+@testset "standard_atmosphere profiles" begin
+    for FT in (Float32, Float64)
+        nlay, ncol = 40, 3
+        prof = RRTMGP.standard_atmosphere(FT; kind = :tropical, nlay, ncol)
+        @test prof isa RRTMGP.AtmosphereProfile
+        @test eltype(prof.p_lay) == FT
+        @test size(prof.p_lay) == (nlay, ncol)
+        @test size(prof.p_lev) == (nlay + 1, ncol)
+        @test size(prof.t_sfc) == (ncol,)
+        # all columns are identical
+        @test prof.t_lay[:, 1] == prof.t_lay[:, end]
+        # pressure decreases monotonically upward, from the surface value
+        @test prof.p_lev[1, 1] ≈ 101325.0
+        @test all(diff(prof.p_lev[:, 1]) .< 0)
+        @test all(diff(prof.p_lay[:, 1]) .< 0)
+        # layers sit between their bounding levels
+        @test all(prof.p_lev[2:end, 1] .< prof.p_lay[:, 1] .<= prof.p_lev[1:(end - 1), 1])
+        # surface temperature and the tropical tropopause
+        @test prof.t_lev[1, 1] == 300
+        @test 180 < minimum(prof.t_lev) < 210
+        # water vapor decays to the stratospheric floor; ozone peaks aloft
+        @test prof.vmr_h2o[1, 1] > 1e-2
+        @test minimum(prof.vmr_h2o) ≈ 4.0e-6
+        @test 20e3 <
+              prof.z_lev[argmax(prof.vmr_o3[:, 1]), 1] <
+              40e3
+        @test prof.well_mixed_vmr["co2"] ≈ 420e-6
+    end
+    # the three kinds are ordered warm → cold at the surface
+    t_sfc(kind) = RRTMGP.standard_atmosphere(Float64; kind).t_sfc[1]
+    @test t_sfc(:tropical) > t_sfc(:midlatitude_summer) > t_sfc(:subarctic_winter)
+    @test_throws ErrorException RRTMGP.standard_atmosphere(Float64; kind = :venus)
+end
+
+@testset "gray solve(profile)" begin
+    for FT in (Float32, Float64)
+        nlay, ncol = 30, 2
+        prof = RRTMGP.standard_atmosphere(FT; nlay, ncol)
+        out = RRTMGP.solve(prof; method = RRTMGP.GrayRadiation())
+        @test out isa RRTMGP.RadiationOutput
+        @test eltype(Array(out.net)) == FT
+        @test size(Array(out.net)) == (nlay + 1, ncol)
+        @test size(Array(out.heating_rate)) == (nlay, ncol)
+        for f in (out.lw_up, out.lw_dn, out.sw_up, out.sw_dn, out.net)
+            @test all(isfinite, Array(f))
+        end
+        @test Array(out.net) ≈ Array(out.lw_net) .+ Array(out.sw_net)
+        # OLR is positive and bounded by σT⁴ of the warmest layer
+        @test 0 < Array(out.lw_up)[end, 1] < 600
+        # the profile is not aliased by the solve (arrays stay host-side, unclipped)
+        @test prof.p_lay isa Array
+    end
+    # cloud/aerosol methods are rejected with actionable errors
+    prof = RRTMGP.standard_atmosphere(Float64; nlay = 10)
+    @test_throws ErrorException RRTMGP.solve(
+        prof;
+        method = RRTMGP.AllSkyRadiation(false, false),
+    )
+    @test_throws ErrorException RRTMGP.solve(
+        prof;
+        method = RRTMGP.ClearSkyRadiation(true),
+    )
 end
 
 # Passing `op_sw = OneScalar` must route the constructor to a non-scattering

--- a/test/standalone_spectral.jl
+++ b/test/standalone_spectral.jl
@@ -1,0 +1,63 @@
+using Test
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+import RRTMGP
+using NCDatasets
+
+# The spectral half of the standalone front door: `solve(profile)` with the
+# default `ClearSkyRadiation`. Runs late in the suite because it needs the
+# NCDatasets extension (test/standalone.jl runs before NCDatasets loads, to
+# keep exercising the no-weakdeps gray path).
+@testset "clear-sky solve(profile) (spectral standalone)" begin
+    FT = Float64
+    nlay = 50
+    prof = RRTMGP.standard_atmosphere(FT; kind = :midlatitude_summer, nlay)
+    out = RRTMGP.solve(prof)
+    @test out isa RRTMGP.RadiationOutput
+    @test size(Array(out.lw_up)) == (nlay + 1, 1)
+    @test size(Array(out.heating_rate)) == (nlay, 1)
+    for f in (
+        out.lw_up,
+        out.lw_dn,
+        out.sw_up,
+        out.sw_dn,
+        out.sw_direct_dn,
+        out.net,
+        out.heating_rate,
+    )
+        @test all(isfinite, Array(f))
+    end
+    @test Array(out.net) ≈ Array(out.lw_net) .+ Array(out.sw_net)
+    # clear-sky OLR for an idealized midlatitude-summer column
+    olr = Array(out.lw_up)[end, 1]
+    @test 220 < olr < 320
+    # TOA downwelling shortwave is the solar constant times cos(zenith)
+    @test Array(out.sw_dn)[end, 1] ≈ 1361 * 0.5 rtol = 1e-3
+    # the direct beam never exceeds the total downwelling flux
+    @test all(Array(out.sw_direct_dn) .<= Array(out.sw_dn) .* (1 + eps(FT)))
+
+    # reusing the lookup tables skips the NetCDF re-read; a warmer atmosphere
+    # emits more
+    lookups = out.solver.lookups
+    olr_of(kind) =
+        Array(
+            RRTMGP.solve(RRTMGP.standard_atmosphere(FT; kind); lookups).lw_up,
+        )[
+            end,
+            1,
+        ]
+    @test olr_of(:tropical) > olr_of(:subarctic_winter)
+
+    # Float32 runs end-to-end (its own lookups: the tables are FT-typed)
+    out32 = RRTMGP.solve(RRTMGP.standard_atmosphere(Float32; nlay = 40))
+    @test eltype(Array(out32.net)) == Float32
+    @test all(isfinite, Array(out32.net))
+
+    # gas-name validation of `well_mixed_vmr`
+    prof_bad = RRTMGP.standard_atmosphere(FT; nlay = 10)
+    prof_bad.well_mixed_vmr["h2o"] = FT(0.01) # spatially varying, not well-mixed
+    @test_throws ErrorException RRTMGP.solve(prof_bad; lookups)
+    delete!(prof_bad.well_mixed_vmr, "h2o")
+    prof_bad.well_mixed_vmr["kryptonite"] = FT(1e-6) # not an RRTMGP gas
+    @test_throws ErrorException RRTMGP.solve(prof_bad; lookups)
+end


### PR DESCRIPTION
Brings the standalone / single-column ("Layer-3") RRTMGP work onto `main`. This is the content that was merged into `ts/kernel-refactor` via #604; here it is retargeted at `main` as a clean, linear branch (`main` is a direct ancestor of the tip, so there is no merge commit and no conflicts).

## What's included (5 commits)

- **`prepare_atmosphere!`** — the prepare/solve split, so hosts can inspect the prepared atmospheric state without solving (W5, part 1).
- **`standard_atmosphere`, `solve(profile)`, `RadiationOutput`** — the standalone single-column entry points that need no ClimaCore (W5, part 2).
- **Fortran-and-paper concordance docs page** — maps RRTMGP.jl names to the RTE-RRTMGP `mo_*`/`ty_*` names and the paper equations.
- **Code deduplication and robustness increases** — shared `compute_gas_optics_core`, stored per-band `flux_net`, shortwave two-stream resonance/energy-conservation robustness.
- **Lookup-sourced temperature clip bounds** — read the clip range from the lookup tables' reference temperatures (`t_ref_min`/`t_ref_max`) instead of ClimaParams, and remove the now-unused `optics_lookup_temperature_min/max` parameters.

## Notes

- Docbuild-critical fixes are already in the content: the `compute_gas_optics` docstring is on the public method and `get_t_min` is listed in `docs/src/api.md`, so the docs `missing_docs`/`docs_block` checks pass.
- One intermediate commit message has a typo ("tempe**Get**" → "temperature"); harmless if this PR is squash-merged.