### PR TITLE
Release v0.22.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ RRTMGP.jl Release Notes
 
 main
 ------
+
+v0.22.0
+-------
 - Internal compute buffers now use device-dependent physical layouts behind a
   uniform column-first `(ncol, nlay/nlev)` indexing convention: optical
   properties (`OneScalar`, `TwoStream`), source functions (`SourceLWNoScat`,

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.21.9"
+version = "0.22.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps the version **0.21.9 → 0.22.0** and rolls the NEWS `main` section into a `v0.22.0` heading.

This is the release commit for the work already merged to `main` (the API redesign in #608, the docs suite in #607, and the performance/dual-layout work in #610). No source changes here beyond `Project.toml` and `NEWS.md`