### PR TITLE
Docs cleanup and corrections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ RRTMGP.jl Release Notes
 main
 ------
 
+v0.22.3
+-------
+- Documentation cleanup and additions, including new how-to guides for interpolation and clouds/aerosols.
+- Added isothermal layer option in standalone runs and RCE calculations to remove noise.
+- RCE corrections.
+- Added NOTICE file.
+
 v0.22.2
 -------
 - New **`set_volume_mixing_ratio!(solver, name, value)`**, the write counterpart

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+RRTMGP.jl
+Copyright 2019-2026 California Institute of Technology and other contributors
+
+This product is developed by the Climate Modeling Alliance (CliMA),
+https://clima.caltech.edu/, and is licensed under the Apache License,
+Version 2.0 (see LICENSE).
+
+RRTMGP.jl is a Julia implementation of the algorithms of RTE+RRTMGP,
+https://github.com/earth-system-radiation/rte-rrtmgp, developed by
+Robert Pincus, Eli Mlawer, and Jennifer Delamere:
+
+  Copyright (c) 2015-2025, Atmospheric and Environmental Research,
+  Regents of the University of Colorado, and Trustees of Columbia
+  University in the City of New York. Distributed under the BSD 3-Clause
+  License.
+
+The gas, cloud, and aerosol lookup tables and the validation data are
+downloaded at run time from the rrtmgp-data repository,
+https://github.com/earth-system-radiation/rrtmgp-data, and are not
+distributed with this package.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.22.2"
+version = "0.22.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Pkg.add("RRTMGP")
 
 ### Basic Usage
 
-The standalone front door provides a quick start. A gray (single-band)
+The standalone entry points provide a quick start. A gray (single-band)
 atmosphere uses analytic formulas:
 
 ```julia
@@ -87,6 +87,10 @@ RRTMGP.update_fluxes!(solver)          # allocation-free, in place
 F = RRTMGP.net_flux(solver)            # (nlev, ncol) view into solver memory
 ```
 
+This snippet is schematic;
+[How to drive RRTMGP from a host model](https://clima.github.io/RRTMGP.jl/latest/howto/host_model/)
+shows the full construction, step by step.
+
 ## Key Features
 
 - **Full RRTMGP gas optics**: longwave and shortwave correlated-*k* lookup
@@ -94,16 +98,16 @@ F = RRTMGP.net_flux(solver)            # (nlev, ncol) view into solver memory
   aerosols, validated against the Fortran rte-rrtmgp reference fluxes.
 - **Gray radiation**: analytic single-band optics for idealized-climate and
   teaching use.
-- **Two-stream and no-scattering solvers** for both bands, with optional
-  per-band (spectrally resolved) flux output.
+- **Two-stream and no-scattering solvers** for the longwave and shortwave,
+  with optional per-band (spectrally resolved) flux output.
 - **CPU and GPU**: the same code runs single-threaded, multi-threaded, and on
   CUDA GPUs via [ClimaComms](https://github.com/CliMA/ClimaComms.jl).
 - **Zero-allocation driver**: `update_fluxes!` is allocation-free and
-  type-stable (asserted in CI with `@allocated` and JET), allowing it to run
-  fast within a climate simulation.
-- **Dual precision**: `Float32` and `Float64` throughout, with high accuracy
-  (~ 1e-3 W/m²) at `Float32` and an accuracy-ratchet test pinning the
-  `Float32`↔`Float64` flux differences.
+  type-stable, asserted in CI with `@allocated` and JET.
+- **Dual precision**: `Float32` and `Float64` throughout;
+  `Float32`↔`Float64` flux differences are of order 10⁻³ W/m² in the
+  longwave and 10⁻² W/m² in the shortwave, enforced by ratcheting CI
+  thresholds.
 
 ## Design
 
@@ -116,9 +120,9 @@ RRTMGP.jl is organized in three layers:
    workspaces; hosts exchange data through documented
    [getters](https://clima.github.io/RRTMGP.jl/latest/getters/) and drive it
    with `update_fluxes!`.
-3. **Standalone front door**: `solve_gray(FT)`, `standard_atmosphere(FT)`, and
-   `solve(profile)` for classroom use, single-column experiments, and quick
-   starts.
+3. **Standalone entry points**: `solve_gray(FT)`, `standard_atmosphere(FT)`,
+   and `solve(profile)` for classroom use, single-column experiments, and
+   quick starts.
 
 Readers coming from the Fortran implementation can use the
 [Fortran and paper concordance](https://clima.github.io/RRTMGP.jl/latest/concordance/)
@@ -128,6 +132,9 @@ to map names between the two code bases and the underlying papers.
 
 - **[Documentation home](https://clima.github.io/RRTMGP.jl/latest/)**: overview
   and page index.
+- **[Tutorials](https://clima.github.io/RRTMGP.jl/latest/tutorials/getting_started/)**:
+  a first radiation calculation, and Manabe's radiative-convective equilibrium
+  experiment as a single-column climate model.
 - **[Functional core](https://clima.github.io/RRTMGP.jl/latest/functional_core/)**:
   the solver kernels, with runnable gray and clear-sky examples.
 - **[Getter contract](https://clima.github.io/RRTMGP.jl/latest/getters/)**: the
@@ -159,7 +166,8 @@ guidance.
 
 ## Acknowledgments
 
-- [Robert Pincus](https://github.com/RobertPincus) for his invaluable help.
 - Robert Pincus, Eli Mlawer, and Jennifer Delamere, the developers of RTE+RRTMGP
   and its reference [Fortran implementation](https://github.com/earth-system-radiation/rte-rrtmgp),
   on which this code is based.
+- [Robert Pincus](https://github.com/RobertPincus) for his help and advice
+  during development.

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ shows the full construction, step by step.
   CUDA GPUs via [ClimaComms](https://github.com/CliMA/ClimaComms.jl).
 - **Zero-allocation driver**: `update_fluxes!` is allocation-free and
   type-stable, asserted in CI with `@allocated` and JET.
-- **Dual precision**: `Float32` and `Float64` throughout;
-  `Float32`↔`Float64` flux differences are of order 10⁻³ W/m² in the
-  longwave and 10⁻² W/m² in the shortwave, enforced by ratcheting CI
+- **Dual precision**: `Float32` and `Float64` throughout; measured
+  `Float32`↔`Float64` flux differences are a few 10⁻⁴ W/m² in the longwave
+  and a few 10⁻² W/m² in the shortwave, enforced by ratcheting CI
   thresholds.
 
 ## Design

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,6 +56,7 @@ makedocs(;
             "Functional core" => "functional_core.md",
             "RTE" => "RTE.md",
             "Optics" => "Optics.md",
+            "Level interpolation" => "interpolation.md",
             "Float32 and Float64" => "precision.md",
             "Fortran and paper concordance" => "concordance.md",
         ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -46,6 +46,7 @@ makedocs(;
         ],
         "How-to guides" => Any[
             "Drive RRTMGP from a host model" => "howto/host_model.md",
+            "Add clouds and aerosols" => "howto/clouds_aerosols.md",
             "Run on GPUs" => "howto/gpu.md",
             "Cache the lookup tables" => "howto/lookup_cache.md",
             "Get per-band (spectral) fluxes" => "howto/spectral_fluxes.md",

--- a/docs/src/Example.md
+++ b/docs/src/Example.md
@@ -1,12 +1,12 @@
-# Example
+# How to run the validated test problems
 
-The quickest way to run RRTMGP is the standalone gray-atmosphere one-liner,
-which needs no NetCDF data. It builds its column internally, with temperatures
-on the analytic semi-gray radiative-equilibrium profile of
+The quickest way to run RRTMGP is the standalone gray-atmosphere entry point
+`solve_gray`, which needs no NetCDF data. It builds its column internally, with
+temperatures on the analytic semi-gray radiative-equilibrium profile of
 [schneider2004](@cite), ``T(p) = T_t\,[1 + d_0\,(p/p_0)^α]^{1/4}``, where
-``T_t = 200`` K is the temperature at the top of the atmosphere and the
-optical depth ``d_0`` follows from a latitude-dependent radiative-equilibrium
-surface temperature (a single column defaults to the equator):
+``T_t = 200`` K is the temperature at the top of the atmosphere and the optical
+depth ``d_0`` follows from a latitude-dependent radiative-equilibrium surface
+temperature (a single column defaults to the equator):
 
 ```@example example
 using RRTMGP
@@ -20,18 +20,17 @@ To assemble the pieces yourself (the atmospheric state, the RTE workspaces, and
 `solve_lw!`/`solve_sw!`), see [The functional core](@ref), which walks through
 the gray problem and sketches the clear-sky path.
 
-Beyond that, the test suite doubles as a set of complete, validated examples,
-run from the repository root with the `test` project (`julia --project=test`).
-The gray driver checks the solvers against analytic solutions. The clear-sky
-and all-sky drivers build their states from standardized NetCDF inputs and
-compare the computed fluxes against the official results of the Fortran
-reference implementation
-[rte-rrtmgp](https://github.com/earth-system-radiation/rte-rrtmgp) for the
-RFMIP clear-sky and all-sky cases, distributed through the
-[rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data)
-repository and downloaded automatically as artifacts (see
-`test/reference_files.jl`). This is the same source of truth the Fortran
-implementation validates against, so the tolerances are directly comparable.
+Beyond that, the test suite serves as a set of complete, validated examples, run
+from the repository root with the `test` project (`julia --project=test`). The
+gray driver checks the solvers against analytic solutions. The clear-sky and
+all-sky drivers build their states from standardized NetCDF inputs and compare
+the computed fluxes against the reference results of the Fortran implementation
+[rte-rrtmgp](https://github.com/earth-system-radiation/rte-rrtmgp) for the RFMIP
+clear-sky case and the all-sky example, distributed through the
+[rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) repository
+and downloaded automatically as artifacts (see `test/reference_files.jl`). These
+are the same reference data the Fortran implementation validates against, so the
+tolerances are directly comparable.
 
 ## Gray radiation
 
@@ -47,12 +46,13 @@ julia> gray_atmos_lw_equil(ClimaComms.context(), TwoStreamLWRTE, Float64);
 Test Passed
 ```
 
-Here is the vertical profile of temperature (`T_ex_lev`) in radiative equilibrium:
+Here is the vertical profile of temperature (`T_ex_lev`) in radiative
+equilibrium:
 
 ![](assets/gray_lw_T.png)
 
-`gray_atmos_sw_test` computes shortwave-only gray fluxes and compares to the exact
-solution:
+`gray_atmos_sw_test` computes shortwave-only gray fluxes and compares to the
+exact solution:
 
 ```julia
 julia> gray_atmos_sw_test(ClimaComms.context(), TwoStreamSWRTE, Float64, 1);
@@ -82,9 +82,9 @@ Here are the vertical profiles of downward longwave (`flux_dn_lw`) and shortwave
 ## Cloud and aerosol optics (all sky)
 
 `test/all_sky_with_aerosols.jl` runs RRTMGP for all-sky atmosphere states with
-idealized clouds (uniform condensate and particle size in the troposphere,
-McICA cloud sampling) plus MERRA aerosols, and compares the results to the
-reference fluxes:
+idealized clouds (uniform condensate and particle size in the troposphere, McICA
+cloud sampling) plus MERRA aerosols, and compares the results to the reference
+fluxes:
 
 ```julia
 julia> include("test/all_sky_with_aerosols.jl")

--- a/docs/src/Optics.md
+++ b/docs/src/Optics.md
@@ -12,6 +12,7 @@ radiative properties of the atmosphere by taking the optical properties to be
 independent of wavelength, separately in the longwave and shortwave bands.
 
 ### Longwave
+
 Two options are currently supported for computing the optical depth for longwave
 radiation. The optical depth (``d``) for longwave radiation, with the
 "GrayOpticalThicknessSchneider2004" option, follows [schneider2004](@cite):
@@ -62,6 +63,7 @@ struct.
 
 The optical thickness of an atmosphere layer (the differential optical depth) of
 pressure thickness ``\Delta p`` is
+
 ```math
 \begin{align}
 \tau(\phi, p) = \alpha \frac{\Delta p}{p} \left[f_l \sigma + 4 (1 - f_l) \sigma^4 \right] \left[ \tau_e + (\tau_p - \tau_e) \sin^2\phi \right].
@@ -99,9 +101,11 @@ equations of the [RTE page](RTE.md) apply directly. The difficulty is spectral:
 across an absorption band, the monochromatic absorption coefficient ``k_\nu``
 sweeps over orders of magnitude through thousands of lines, so the band-averaged
 transmission over an absorber path ``u``,
+
 ```math
 \bar{t}(u) = \frac{1}{\Delta\nu} \int_{\Delta\nu} e^{-k_\nu u}\, d\nu,
 ```
+
 cannot be represented by any single mean absorption coefficient: the exponential
 weights weak and strong lines differently at every path length. The
 ``k``-distribution method [lacis1991](@cite) replaces the integral over
@@ -109,9 +113,11 @@ frequency by an integral over the cumulative distribution of absorption
 strength: with ``g(k)`` the fraction of the band where the absorption
 coefficient is below ``k``, reordering the spectrum by strength turns the ragged
 ``k_\nu`` into a smooth, monotonic ``k(g)`` on ``g \in [0, 1]``, and
+
 ```math
 \bar{t}(u) = \int_0^1 e^{-k(g)\,u}\, dg \approx \sum_{j=1}^{G} \omega_j\, e^{-k(g_j)\, u},
 ```
+
 a quadrature over a handful of *g-points*. The *correlated*-``k`` assumption is
 that the frequency-to-``g`` ordering is the same at all pressures and
 temperatures along the path, so a single ``g`` coordinate serves the whole
@@ -129,16 +135,20 @@ atmospheric state. (The volume mixing ratio relates to the mass fraction ``q``
 of a gas by ``\chi = q / q_d \cdot M_d / M``, where ``q_d = 1 - q_t`` is the
 dry-air mass fraction, ``M_d`` the molar mass of dry air, and ``M`` that of the
 gas.) The optical thickness of a layer splits into
+
 ```math
 \tau_g = \tau_\mathrm{major} + \tau_\mathrm{minor} + \tau_\mathrm{rayleigh},
 ```
+
 with the Rayleigh term present in the shortwave only.
 
 **Major species.** Within each band, absorption is dominated by at most two
 gases. Their relative abundance enters through the binary mixing parameter
+
 ```math
 \eta = \frac{\chi_1}{\chi_1 + r\,\chi_2},
 ```
+
 where ``r`` is the ratio of the two abundances in the reference atmosphere used
 to build the tables, so ``\eta`` runs from 0 (only species 2) to 1 (only species
 1). The absorption coefficient is tabulated on a ``(\eta, \log p, T)`` grid and
@@ -167,6 +177,7 @@ atmosphere. These per-g-point sources are where the quadrature weights of the
 weighting.
 
 ### Lookup tables
+
 The lookup tables for the spectral map between ``\nu`` and ``g`` are NetCDF
 files from the
 [rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) repository
@@ -231,6 +242,7 @@ radiative fluxes for highly asymmetric phase functions ([joseph1976](@cite)).
 that sees cloud (the cloud mask is described below).
 
 ### Lookup tables
+
 The lookup tables for cloud optics are NetCDF files from the same
 [rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) artifacts.
 The longwave and shortwave lookup tables are `rrtmgp-clouds-lw-bnd.nc` and
@@ -239,11 +251,14 @@ The tabulated information includes tabulated data of extinction coefficients,
 single scattering albedo, and asymmetry parameter for liquid and ice particles.
 The optical properties for liquid particles are computed at radius
 ``2.5\,\mathrm{\mu m} \le r_l \le 21.5\,\mathrm{\mu m}`` in increments of
-``1\,\mathrm{\mu m}``. The optical properties for ice particles are computed at
-radius ``10\,\mathrm{\mu m} \le r_i \le 180\,\mathrm{\mu m}`` in increments of
-``10\,\mathrm{\mu m}``.
+``1\,\mathrm{\mu m}``. The optical properties for ice particles are tabulated
+against diameter, ``10\,\mathrm{\mu m} \le d_i \le 180\,\mathrm{\mu m}`` in
+increments of ``10\,\mathrm{\mu m}``; `LookUpCld` halves these bounds on load,
+so the interpolation and the clamp applied to `cloud_ice_effective_radius` work
+in radius, ``5\,\mathrm{\mu m} \le r_i \le 90\,\mathrm{\mu m}``.
 
 ### Cloud overlap method
+
 Climate models predict grid-mean cloud fraction and cloud condensate, so the
 vertical overlap of clouds must be prescribed to compute radiative fluxes. The
 Monte Carlo independent column approximation (McICA) represents fractional
@@ -256,6 +271,7 @@ sky are randomly overlapped.
 Proceeding downward for each g-point, layer ``k`` sees cloud where its random
 number ``R_k`` exceeds one minus the layer's cloud fraction,
 ``R_k > 1 - \mathrm{CF}_k``, with
+
 ```math
 R_k =
 \begin{cases}
@@ -263,6 +279,7 @@ R_{k-1} & \text{if the g-point sees cloud in layer } k-1,\\
 u_k \, (1 - \mathrm{CF}_{k-1}) & \text{otherwise},
 \end{cases}
 ```
+
 where ``u_k \sim U(0, 1)`` is an independent uniform draw; the mixture of the
 two cases leaves ``R_k`` uniform on [0, 1]. Three properties follow. Each layer
 is cloudy with probability ``\mathrm{CF}_k``, so the sampled mask reproduces the

--- a/docs/src/Optics.md
+++ b/docs/src/Optics.md
@@ -1,13 +1,20 @@
 # RRTMGP Optics
 
-`compute_optical_props!` computes the optical properties and source functions given an atmospheric state. For the two-stream approximation, the optical properties include the optical thickness of the atmosphere layer (``\tau``), single-scattering albedo (``\omega_0``), and asymmetry parameter (``g``).
+`compute_optical_props!` computes the optical properties and source functions
+given an atmospheric state. For the two-stream approximation, the optical
+properties include the optical thickness of the atmosphere layer (``\tau``),
+single-scattering albedo (``\omega_0``), and asymmetry parameter (``g``).
 
 ## Gray atmosphere optics
 
-The gray atmosphere (more precisely, semi-gray atmosphere) approximates the radiative properties of the atmosphere by taking the optical properties to be independent of wavelength, separately in the longwave and shortwave bands. 
+The gray atmosphere (more precisely, semi-gray atmosphere) approximates the
+radiative properties of the atmosphere by taking the optical properties to be
+independent of wavelength, separately in the longwave and shortwave bands.
 
 ### Longwave
-Two options are currently supported for computing the optical depth for longwave radiation. The optical depth (``d``) for longwave radiation, with the "GrayOpticalThicknessSchneider2004" option, follows [schneider2004](@cite):
+Two options are currently supported for computing the optical depth for longwave
+radiation. The optical depth (``d``) for longwave radiation, with the
+"GrayOpticalThicknessSchneider2004" option, follows [schneider2004](@cite):
 
 ```math
 \begin{align}
@@ -15,7 +22,11 @@ d(\phi, p) = d_0(\phi) \left(\frac{p}{p_0}\right)^\alpha .
 \end{align}
 ```
 
-Here, ``\alpha``  is ratio of the pressure scale height to the partial-pressure scale height of the infrared absorber (``\alpha=3.5`` for water vapor); ``\phi`` is the latitude; ``p`` is the pressure, and ``p_0`` is the surface pressure. The optical depth at ``\phi`` and ``p_0``, ``d_0``, is calculated from the latitude-dependent radiative equilibrium temperature ``T_s(\phi)``:
+Here, ``\alpha`` is ratio of the pressure scale height to the partial-pressure
+scale height of the infrared absorber (``\alpha=3.5`` for water vapor); ``\phi``
+is the latitude; ``p`` is the pressure, and ``p_0`` is the surface pressure. The
+optical depth at ``\phi`` and ``p_0``, ``d_0``, is calculated from the
+latitude-dependent radiative equilibrium temperature ``T_s(\phi)``:
 
 ```math
 \begin{align}
@@ -24,9 +35,15 @@ d_0(\phi) = \left(\frac{T_s(\phi)}{T_t}\right)^4 - 1.
 \end{align}
 ```
 
-Here, ``T_e`` is the global-mean surface temperature in radiative equilibrium, ``T_t`` is the temperature at the top of the atmosphere, and ``\Delta T`` is the equator-to-pole temperature difference in radiative equilibrium. The default values are ``T_e = 300~\mathrm{K}``, ``T_t = 200~\mathrm{K}``, and ``\Delta T = 60~\mathrm{K}``.
+Here, ``T_e`` is the global-mean surface temperature in radiative equilibrium,
+``T_t`` is the temperature at the top of the atmosphere, and ``\Delta T`` is the
+equator-to-pole temperature difference in radiative equilibrium. The default
+values are ``T_e = 300~\mathrm{K}``, ``T_t = 200~\mathrm{K}``, and
+``\Delta T = 60~\mathrm{K}``.
 
-The optical depth (``d``) for longwave radiation, with the "GrayOpticalThicknessOGorman2008" option, follows [frierson2006](@cite) and [ogorman2008](@cite):
+The optical depth (``d``) for longwave radiation, with the
+"GrayOpticalThicknessOGorman2008" option, follows [frierson2006](@cite) and
+[ogorman2008](@cite):
 
 ```math
 \begin{align}
@@ -35,22 +52,34 @@ d(\phi, p) = \alpha \left[f_l \sigma + (1 - f_l) \sigma^4 \right] \left[ \tau_e 
 ```
 
 where ``f_l = 0.2``, ``\sigma = p / p_0`` is pressure ``p`` normalized by
-surface pressure ``p_0``, ``\phi`` is latitude, and the longwave optical thicknesses at the equator and at the pole are ``\tau_e = 7.2`` and ``\tau_p = 1.8``, respectively. The prefactor ``\alpha`` (default 1) rescales the total longwave optical depth; [ogorman2008](@citet) vary it to simulate a range of climates. This ``\alpha`` is unrelated to the exponent ``\alpha`` of the Schneider option above — each matches the ``α`` field of its own parameter struct.
+surface pressure ``p_0``, ``\phi`` is latitude, and the longwave optical
+thicknesses at the equator and at the pole are ``\tau_e = 7.2`` and
+``\tau_p = 1.8``, respectively. The prefactor ``\alpha`` (default 1) rescales
+the total longwave optical depth; [ogorman2008](@citet) vary it to simulate a
+range of climates. This ``\alpha`` is unrelated to the exponent ``\alpha`` of
+the Schneider option above; each matches the ``α`` field of its own parameter
+struct.
 
-The optical thickness of an atmosphere layer (the differential optical depth) of pressure thickness ``\Delta p`` is
+The optical thickness of an atmosphere layer (the differential optical depth) of
+pressure thickness ``\Delta p`` is
 ```math
 \begin{align}
 \tau(\phi, p) = \alpha \frac{\Delta p}{p} \left[f_l \sigma + 4 (1 - f_l) \sigma^4 \right] \left[ \tau_e + (\tau_p - \tau_e) \sin^2\phi \right].
 \end{align}
 ```
 
-The source function for longwave radiation is calculated as ``S = \sigma T^4 / \pi``, where ``T`` is the air temperature and ``\sigma`` is the Stefan–Boltzmann constant.
+The source function for longwave radiation is calculated as
+``S = \sigma T^4 / \pi``, where ``T`` is the air temperature and ``\sigma`` is
+the Stefan–Boltzmann constant.
 
 ### Shortwave
 
-Two options are currently supported for computing the optical depth for shortwave radiation. The optical depth (``d``) for shortwave radiation, with the "GrayOpticalThicknessSchneider2004" option, is 0.
+Two options are currently supported for computing the optical depth for
+shortwave radiation. The optical depth (``d``) for shortwave radiation, with the
+"GrayOpticalThicknessSchneider2004" option, is 0.
 
-The optical depth (``d``) for shortwave radiation, with the "GrayOpticalThicknessOGorman2008" option, follows [ogorman2008](@cite):
+The optical depth (``d``) for shortwave radiation, with the
+"GrayOpticalThicknessOGorman2008" option, follows [ogorman2008](@cite):
 
 ```math
 \begin{align}
@@ -58,7 +87,8 @@ d(p) = \tau_0 \left(\frac{p}{p_0}\right)^2 ,
 \end{align}
 ```
 
-where ``p`` is the pressure of the atmosphere layer and ``p_0`` is the surface pressure. The default value for ``\tau_0`` is 0.22.
+where ``p`` is the pressure of the atmosphere layer and ``p_0`` is the surface
+pressure. The default value for ``\tau_0`` is 0.22.
 
 The single scattering albedo and asymmetry parameter are zero.
 
@@ -66,19 +96,19 @@ The single scattering albedo and asymmetry parameter are zero.
 
 At any single frequency, gaseous absorption obeys Beer's law, and the transfer
 equations of the [RTE page](RTE.md) apply directly. The difficulty is spectral:
-across an absorption band, the monochromatic absorption coefficient
-``k_\nu`` sweeps over orders of magnitude through thousands of lines, so the
-band-averaged transmission over an absorber path ``u``,
+across an absorption band, the monochromatic absorption coefficient ``k_\nu``
+sweeps over orders of magnitude through thousands of lines, so the band-averaged
+transmission over an absorber path ``u``,
 ```math
 \bar{t}(u) = \frac{1}{\Delta\nu} \int_{\Delta\nu} e^{-k_\nu u}\, d\nu,
 ```
-cannot be represented by any single mean absorption coefficient — the exponential
+cannot be represented by any single mean absorption coefficient: the exponential
 weights weak and strong lines differently at every path length. The
 ``k``-distribution method [lacis1991](@cite) replaces the integral over
 frequency by an integral over the cumulative distribution of absorption
 strength: with ``g(k)`` the fraction of the band where the absorption
-coefficient is below ``k``, reordering the spectrum by strength turns the
-ragged ``k_\nu`` into a smooth, monotonic ``k(g)`` on ``g \in [0, 1]``, and
+coefficient is below ``k``, reordering the spectrum by strength turns the ragged
+``k_\nu`` into a smooth, monotonic ``k(g)`` on ``g \in [0, 1]``, and
 ```math
 \bar{t}(u) = \int_0^1 e^{-k(g)\,u}\, dg \approx \sum_{j=1}^{G} \omega_j\, e^{-k(g_j)\, u},
 ```
@@ -89,8 +119,8 @@ column, and each g-point behaves like one monochromatic radiative-transfer
 problem. RRTMGP's tables carry 16 g-points in each of 16 longwave and 14
 shortwave bands (256 and 224 in total); the bands are non-overlapping,
 contiguous, and span the thermal and solar spectra [pincus2019](@cite). The RTE
-is solved once per g-point and column, and fluxes simply add over g-points —
-the quadrature weights ``\omega_j`` enter through the per-g-point source terms
+is solved once per g-point and column, and fluxes add over g-points; the
+quadrature weights ``\omega_j`` enter through the per-g-point source terms
 described below.
 
 `compute_optical_props!` computes each g-point's optical properties from the
@@ -110,25 +140,24 @@ gases. Their relative abundance enters through the binary mixing parameter
 \eta = \frac{\chi_1}{\chi_1 + r\,\chi_2},
 ```
 where ``r`` is the ratio of the two abundances in the reference atmosphere used
-to build the tables, so ``\eta`` runs from 0 (only species 2) to 1 (only
-species 1). The absorption coefficient is tabulated on a
-``(\eta, \log p, T)`` grid and interpolated trilinearly
-(`compute_interp_frac_temp`/`_press`/`_η`); ``\tau_\mathrm{major}`` is the
-interpolated coefficient times the column amount of the binary mixture.
+to build the tables, so ``\eta`` runs from 0 (only species 2) to 1 (only species
+1). The absorption coefficient is tabulated on a ``(\eta, \log p, T)`` grid and
+interpolated trilinearly (`compute_interp_frac_temp`/`_press`/`_η`);
+``\tau_\mathrm{major}`` is the interpolated coefficient times the column amount
+of the binary mixture.
 
-**Minor species and Rayleigh scattering.** These contributions are linear in
-the respective column amounts, with coefficients tabulated against
-``(\eta, T)`` at a representative pressure — minor gases with additional
-density and scaling-gas corrections where the spectroscopy requires them
-(continua), and Rayleigh scattering in proportion to the column amount of air,
-water vapor included. In the shortwave,
-the single scattering albedo of the gas optics is
+**Minor species and Rayleigh scattering.** These contributions are linear in the
+respective column amounts, with coefficients tabulated against ``(\eta, T)`` at
+a representative pressure. Minor gases carry additional density and scaling-gas
+corrections where the spectroscopy requires them (continua); Rayleigh scattering
+is proportional to the column amount of air, water vapor included. In the
+shortwave, the single scattering albedo of the gas optics is
 ``\omega_0 = \tau_\mathrm{rayleigh} / \tau_g``, and the asymmetry parameter is
 zero (Rayleigh scattering is nearly symmetric fore–aft).
 
 **Source terms.** In the longwave, each g-point emits the fraction
-``f_g(\eta, p, T)`` — the *Planck fraction*, interpolated like the absorption
-coefficient — of the band-integrated Planck emission ``B_\mathrm{band}(T)``,
+``f_g(\eta, p, T)`` (the *Planck fraction*, interpolated like the absorption
+coefficient) of the band-integrated Planck emission ``B_\mathrm{band}(T)``,
 which is tabulated against temperature at 1 K resolution; the fractions of a
 band sum to one, so summing g-points recovers the band's blackbody emission. In
 the shortwave, each g-point carries a fixed fraction of the total solar
@@ -138,18 +167,45 @@ atmosphere. These per-g-point sources are where the quadrature weights of the
 weighting.
 
 ### Lookup tables
-The lookup tables for the spectral map between ``\nu`` and ``g`` are NetCDF files from the
-[rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) repository (v1.7),
-downloaded automatically as Julia artifacts. The longwave and shortwave lookup tables are
-`rrtmgp-gas-lw-g256.nc` and `rrtmgp-gas-sw-g224.nc`, respectively (see
-`RRTMGP.ArtifactPaths`). `LookUpLW` and `LookUpSW` read the lookup tables. The tabulated information includes the spectral discretization (bands), the major and minor gases considered in each band, and tabulated data of absorption coefficients, Planck fraction, and band-integrated Planck function. The absorption coefficients and Planck fraction are computed at pressures ``1\,\mathrm{Pa} \le p \le 109663\,\mathrm{Pa}`` in increments of ``\log(p/1\,\mathrm{Pa}) = 0.2``, temperatures ``160\,\mathrm{K} \le T \le 355\,\mathrm{K}`` in ``15\,\mathrm{K}`` increments, and ``0 \le \eta \le 1`` in ``1/8`` increments. The band-integrated Planck function is computed at temperatures ``160\,\mathrm{K} \le T \le 355\,\mathrm{K}`` in ``1\,\mathrm{K}`` increments. A more detailed description of the spectral structure of the lookup tables can be found in `Appendix A` in [pincus2019](@cite).
+The lookup tables for the spectral map between ``\nu`` and ``g`` are NetCDF
+files from the
+[rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) repository
+(v1.9), downloaded automatically as Julia artifacts. The longwave and shortwave
+lookup tables are `rrtmgp-gas-lw-g256.nc` and `rrtmgp-gas-sw-g224.nc`,
+respectively (see `RRTMGP.ArtifactPaths`). `LookUpLW` and `LookUpSW` read the
+lookup tables. The tabulated information includes the spectral discretization
+(bands), the major and minor gases considered in each band, and tabulated data
+of absorption coefficients, Planck fraction, and band-integrated Planck
+function. The absorption coefficients and Planck fraction are computed at
+pressures ``1\,\mathrm{Pa} \le p \le 109663\,\mathrm{Pa}`` in increments of
+``\log(p/1\,\mathrm{Pa}) = 0.2``, temperatures
+``160\,\mathrm{K} \le T \le 355\,\mathrm{K}`` in ``15\,\mathrm{K}`` increments,
+and ``0 \le \eta \le 1`` in ``1/8`` increments. The band-integrated Planck
+function is computed at temperatures
+``160\,\mathrm{K} \le T \le 355\,\mathrm{K}`` in ``1\,\mathrm{K}`` increments. A
+more detailed description of the spectral structure of the lookup tables can be
+found in `Appendix A` in [pincus2019](@cite).
 
 !!! note
-    Absorption by both major and minor species is treated separately in the upper and lower atmosphere, defined as pressures above and below the pressure defined in `press_ref_trop` in the lookup tables (~9948 Pa). This corresponds to element 13 in array `press_ref`. There is a single large table of absorption coefficients. Table elements 1:13 in the pressure dimension correspond to pressures >= `press_ref_trop`, while table elements 14:60 correspond to pressures <= `press_ref_trop`. Elements 13 and 14 refer to the same pressure but for the lower and upper atmosphere, respectively. This is why the absorption coefficients lookup table has a pressure dimension of 60, but there are only 59 reference pressure levels in `press_ref`.
+    Absorption by both major and minor species is treated separately in the
+    upper and lower atmosphere, defined as pressures above and below the
+    pressure defined in `press_ref_trop` in the lookup tables (~9948 Pa). This
+    corresponds to element 13 in array `press_ref`. There is a single large
+    table of absorption coefficients. Table elements 1:13 in the pressure
+    dimension correspond to pressures >= `press_ref_trop`, while table elements
+    14:60 correspond to pressures <= `press_ref_trop`. Elements 13 and 14 refer
+    to the same pressure but for the lower and upper atmosphere, respectively.
+    This is why the absorption coefficients lookup table has a pressure
+    dimension of 60, but there are only 59 reference pressure levels in
+    `press_ref`.
 
 ## Cloud optics
 
-`compute_lookup_cld_liq_props` and `compute_lookup_cld_ice_props` compute the optical properties of liquid and ice cloud particles, whose combination gives the cloud optical properties. The optical thickness (``\tau``), single scattering albedo (``\omega_0``), and asymmetry parameter (``g``) for clouds are:
+`compute_lookup_cld_liq_props` and `compute_lookup_cld_ice_props` compute the
+optical properties of liquid and ice cloud particles, whose combination gives
+the cloud optical properties. The optical thickness (``\tau``), single
+scattering albedo (``\omega_0``), and asymmetry parameter (``g``) for clouds
+are:
 
 ```math
 \begin{align}
@@ -159,20 +215,47 @@ g_c &= \frac{\tau_l \omega_{0l} g_l + \tau_i \omega_{0i} g_i}{\tau_l \omega_{0l}
 \end{align}
 ```
 
-where subscripts c, l, and i indicate cloud, liquid, and ice, respectively. The liquid cloud and ice cloud optical thicknesses are calculated by multiplying the cloud liquid and ice extinction coefficients (``\mu``) by the cloud liquid (lwp) and ice water paths (iwp), respectively. That is, ``\tau_l = \mu_l \mathrm{lwp}`` and ``\tau_i = \mu_i \mathrm{iwp}``. The extinction coefficient, single scattering albedo, and asymmetry parameter are computed by linearly interpolating the tabulated values in the liquid and ice particle effective radius. For ice particles, the optical properties also depend on the surface roughness, following [yang2013](@cite). The optical properties for shortwave bands are delta-scaled to reduce the biases in calculating radiative fluxes for highly asymmetric phase functions ([joseph1976](@cite)).
+where subscripts c, l, and i indicate cloud, liquid, and ice, respectively. The
+liquid cloud and ice cloud optical thicknesses are calculated by multiplying the
+cloud liquid and ice extinction coefficients (``\mu``) by the cloud liquid (lwp)
+and ice water paths (iwp), respectively. That is,
+``\tau_l = \mu_l \mathrm{lwp}`` and ``\tau_i = \mu_i \mathrm{iwp}``. The
+extinction coefficient, single scattering albedo, and asymmetry parameter are
+computed by linearly interpolating the tabulated values in the liquid and ice
+particle effective radius. For ice particles, the optical properties also depend
+on the surface roughness, following [yang2013](@cite). The optical properties
+for shortwave bands are delta-scaled to reduce the biases in calculating
+radiative fluxes for highly asymmetric phase functions ([joseph1976](@cite)).
 
-`add_cloud_optics_2stream!` adds cloud optics to the gas optics for each g-point that sees cloud (the cloud mask is described below).
+`add_cloud_optics_2stream!` adds cloud optics to the gas optics for each g-point
+that sees cloud (the cloud mask is described below).
 
 ### Lookup tables
 The lookup tables for cloud optics are NetCDF files from the same
-[rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) artifacts. The
-longwave and shortwave lookup tables are `rrtmgp-clouds-lw-bnd.nc` and
-`rrtmgp-clouds-sw-bnd.nc`, respectively. `LookUpCld` reads the lookup tables. The tabulated information includes tabulated data of extinction coefficients, single scattering albedo, and asymmetry parameter for liquid and ice particles. The optical properties for liquid particles are computed at radius ``2.5\,\mathrm{\mu m} \le r_l \le 21.5\,\mathrm{\mu m}`` in increments of ``1\,\mathrm{\mu m}``. The optical properties for ice particles are computed at radius ``10\,\mathrm{\mu m} \le r_i \le 180\,\mathrm{\mu m}`` in increments of ``10\,\mathrm{\mu m}``.
+[rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) artifacts.
+The longwave and shortwave lookup tables are `rrtmgp-clouds-lw-bnd.nc` and
+`rrtmgp-clouds-sw-bnd.nc`, respectively. `LookUpCld` reads the lookup tables.
+The tabulated information includes tabulated data of extinction coefficients,
+single scattering albedo, and asymmetry parameter for liquid and ice particles.
+The optical properties for liquid particles are computed at radius
+``2.5\,\mathrm{\mu m} \le r_l \le 21.5\,\mathrm{\mu m}`` in increments of
+``1\,\mathrm{\mu m}``. The optical properties for ice particles are computed at
+radius ``10\,\mathrm{\mu m} \le r_i \le 180\,\mathrm{\mu m}`` in increments of
+``10\,\mathrm{\mu m}``.
 
 ### Cloud overlap method
-Climate models predict grid-mean cloud fraction and cloud condensates, and the vertical structure of clouds needs to be prescribed using some overlap assumptions for calculating radiative fluxes. The Monte Carlo independent column approximation (McICA) allows us to have fractional cloud areas, by randomly assigning some wavelengths to see cloud and other wavelengths to see no cloud. `build_cloud_mask!` builds McICA-sampled cloud masks from cloud fraction. We use the maximum-random overlap method, which maximizes the cloud overlap between adjacent layers but randomly distributes clouds at different altitudes separated by clear sky. The random numbers are generated for each layer and each g-point. For a certain layer (layer 1), the g-points that have been assigned a random number larger than one minus the cloud fraction see cloud, and the other g-points see clear-sky. The random numbers are recalculated for the layer below (layer 2). If the g-point sees cloud in layer 1, its random number in layer 2 is changed to the one in layer 1. If the g-point sees clear-sky in layer 1, its random number in layer 2 is multiplied by one minus the cloud fraction of layer 1. This ensures that the random numbers in layer 2 are randomly distributed in the range [0, 1].
+Climate models predict grid-mean cloud fraction and cloud condensate, so the
+vertical overlap of clouds must be prescribed to compute radiative fluxes. The
+Monte Carlo independent column approximation (McICA) represents fractional
+cloudiness by assigning each g-point a random subcolumn that, in each layer,
+either sees cloud or sees clear sky; `build_cloud_mask!` builds these masks from
+the cloud fraction. We use the maximum-random overlap method: clouds in adjacent
+layers overlap maximally, while clouds at different altitudes separated by clear
+sky are randomly overlapped.
 
-Formally, proceeding downward for each g-point, layer ``k`` sees cloud where its random number ``R_k`` exceeds one minus the layer's cloud fraction, ``R_k > 1 - \mathrm{CF}_k``, with
+Proceeding downward for each g-point, layer ``k`` sees cloud where its random
+number ``R_k`` exceeds one minus the layer's cloud fraction,
+``R_k > 1 - \mathrm{CF}_k``, with
 ```math
 R_k =
 \begin{cases}
@@ -180,40 +263,52 @@ R_{k-1} & \text{if the g-point sees cloud in layer } k-1,\\
 u_k \, (1 - \mathrm{CF}_{k-1}) & \text{otherwise},
 \end{cases}
 ```
-where ``u_k \sim U(0, 1)`` is an independent uniform draw. Three properties follow. Each layer is cloudy with probability ``\mathrm{CF}_k``, so the sampled mask reproduces the prescribed cloud fractions in expectation. Vertically contiguous cloudy layers overlap maximally: a g-point that is cloudy in one layer stays cloudy in the next wherever the fractions allow, so a contiguous cloudy block has total cloud cover ``\max_k \mathrm{CF}_k``. Cloudy blocks separated by clear air are uncorrelated. Because every g-point carries an independent subcolumn, the broadband flux averages over the samples: the McICA estimate is unbiased, and its sampling noise largely cancels in the spectral integration. The all-sky methods' `reset_rng_seed` option reseeds the generator on each [`update_fluxes!`](@ref RRTMGP.update_fluxes!) call to make the sampling reproducible (see the reproducibility caveat in [How to run on GPUs](howto/gpu.md)).
+where ``u_k \sim U(0, 1)`` is an independent uniform draw; the mixture of the
+two cases leaves ``R_k`` uniform on [0, 1]. Three properties follow. Each layer
+is cloudy with probability ``\mathrm{CF}_k``, so the sampled mask reproduces the
+prescribed cloud fractions in expectation. Vertically contiguous cloudy layers
+overlap maximally: a g-point that is cloudy in one layer stays cloudy in the
+next wherever the fractions allow, so a contiguous cloudy block has total cloud
+cover ``\max_k \mathrm{CF}_k``. Cloudy blocks separated by clear air are
+uncorrelated. Because every g-point carries an independent subcolumn, the
+broadband flux averages over the samples: the McICA estimate is unbiased, and
+its sampling noise largely cancels in the spectral integration. The all-sky
+methods' `reset_rng_seed` option reseeds the generator on each
+[`update_fluxes!`](@ref RRTMGP.update_fluxes!) call to make the sampling
+reproducible (see the reproducibility caveat in [How to run on
+GPUs](howto/gpu.md)).
 
 ## Aerosol optics
 
 `add_aerosol_optics_1scalar!` and `add_aerosol_optics_2stream!` add aerosol
 extinction to the gas (and cloud) optical properties, using the MERRA aerosol
 tables shipped with the rrtmgp-data artifacts
-(`rrtmgp-aerosols-merra-lw.nc`/`-sw.nc`, read by `LookUpAerosolMerra`). For
-each species and band, the tables give the optical properties per unit column
-mass of aerosol; the host supplies the per-species column mass densities and
-particle sizes (the [`aerosol_column_mass_density`](@ref RRTMGP.aerosol_column_mass_density)
-and [`aerosol_radius`](@ref RRTMGP.aerosol_radius) getters), and layers
-without aerosol mass are skipped through a precomputed mask.
+(`rrtmgp-aerosols-merra-lw.nc`/`-sw.nc`, read by `LookUpAerosolMerra`). For each
+species and band, the tables give the optical properties per unit column mass of
+aerosol; the host supplies the per-species column mass densities and particle
+sizes (the [`aerosol_column_mass_density`](@ref
+RRTMGP.aerosol_column_mass_density) and [`aerosol_radius`](@ref
+RRTMGP.aerosol_radius) getters), and layers without aerosol mass are skipped
+through a precomputed mask.
 
 The MERRA set comprises 15 species: dust and sea salt in five size bins each,
 sulfate, and black and organic carbon each in a hydrophilic and a hydrophobic
 variant. Dust and sea salt select their size bin from the supplied particle
-radius. The hygroscopic species — sea salt, sulfate, and the hydrophilic
-carbon variants — are additionally interpolated in relative humidity, which
-enters from the atmospheric state; keeping `layer_relative_humidity` current
-is a host responsibility (see
-[Driving RRTMGP from a host model](howto/host_model.md)). Dust and the
-hydrophobic carbon variants are humidity-independent. Internally, the species
-occupy fixed positions in the aerosol state arrays: hosts should map their
-species through [`aerosol_index_map`](@ref RRTMGP.aerosol_index_map) (or
+radius. The hygroscopic species (sea salt, sulfate, and the hydrophilic carbon
+variants) are additionally interpolated in relative humidity, which enters from
+the atmospheric state; keeping `layer_relative_humidity` current is a host
+responsibility (see [Driving RRTMGP from a host model](howto/host_model.md)).
+Dust and the hydrophobic carbon variants are humidity-independent. Internally,
+the species occupy fixed positions in the aerosol state arrays: hosts should map
+their species through [`aerosol_index_map`](@ref RRTMGP.aerosol_index_map) (or
 [`aerosol_names`](@ref RRTMGP.aerosol_names)) rather than assume an ordering,
 and the named getters above handle this lookup.
 
 What each solver family receives mirrors the treatment of gas optics. The
 non-scattering longwave path adds only the aerosol absorption optical depth
 ``\tau (1 - \omega_0)``, while the two-stream path folds the full
-``(\tau, \omega_0, g)`` of each species into the running optical properties
-by the same ``\tau``-weighted mixing rules as for clouds, delta-scaled in the
+``(\tau, \omega_0, g)`` of each species into the running optical properties by
+the same ``\tau``-weighted mixing rules as for clouds, delta-scaled in the
 shortwave. In the shortwave band containing 550 nm, the summed extinction and
 scattering aerosol optical depths are retained as diagnostics
-(`aod_sw_extinction`, `aod_sw_scattering`), giving the standard AOD at
-negligible extra cost.
+(`aod_sw_extinction`, `aod_sw_scattering`), the standard aerosol optical depth.

--- a/docs/src/RTE.md
+++ b/docs/src/RTE.md
@@ -22,13 +22,14 @@ reads
 I_\lambda(\Omega')\, d\Omega',
 ```
 where ``B_\lambda(T)`` is the Planck function at the local temperature,
-``\omega_{0,\lambda}`` is the single-scattering albedo — the fraction of the
-extinction due to scattering — and ``P_\lambda(\Omega', \Omega)`` is the phase
+``\omega_{0,\lambda}`` is the single-scattering albedo (the fraction of the
+extinction due to scattering), and ``P_\lambda(\Omega', \Omega)`` is the phase
 function, the probability of scattering from direction ``\Omega'`` into
 ``\Omega``. The emission term ``B_\lambda`` follows from Kirchhoff's law under
-local thermodynamic equilibrium (absorptivity = emissivity at every
-wavelength), which is assumed to hold throughout the atmosphere RRTMGP models. The scattering integral couples all directions, which is what makes
-the general equation expensive; in the atmosphere, it matters for clouds and
+local thermodynamic equilibrium (absorptivity = emissivity at every wavelength),
+which is assumed to hold throughout the atmosphere RRTMGP models. The scattering
+integral couples all directions, which is what makes the general equation
+computationally demanding; in the atmosphere, scattering matters for clouds and
 aerosols in both the longwave and shortwave and for Rayleigh scattering in the
 shortwave. The two-stream approximation below reduces the angular coupling to
 two hemispheric fluxes.
@@ -43,12 +44,12 @@ with ``\tau_\lambda`` now the absorption optical depth.
 
 ## Two-stream approximation
 
-Resolving the full angular dependence of ``I_\lambda`` is too costly for a
+Resolving the full angular dependence of ``I_\lambda`` is impractical in a
 climate model, so the flux calculation collapses the radiation field into an
 upward flux ``F_\lambda^\uparrow`` and a downward flux ``F_\lambda^\downarrow``.
-In the plane-parallel column, the vertical optical depth ``\widehat{\tau}_\lambda``
-increases downward from zero at the top of the atmosphere. Neglecting
-scattering, the two streams obey
+In the plane-parallel column, the vertical optical depth
+``\widehat{\tau}_\lambda`` increases downward from zero at the top of the
+atmosphere. Neglecting scattering, the two streams obey
 ```math
 \frac{dF_\lambda^\uparrow}{d\widehat{\tau}_\lambda} = D\,(F_\lambda^\uparrow - \pi B_\lambda),
 \qquad
@@ -63,16 +64,16 @@ scattering albedo, and asymmetry parameter following [meador1980](@citet).
 
 ## Angular discretization
 
-The longwave no-scattering solver does better than a single diffusivity angle:
-it integrates the Schwarzschild equation along a small set of discrete zenith
+The longwave no-scattering solver improves on the single diffusivity angle: it
+integrates the Schwarzschild equation along a small set of discrete zenith
 angles and sums the results with Gauss quadrature weights, so the hemispheric
 flux is ``F_\lambda = \sum_i w_i\, I_\lambda(\mu_i)``. RRTMGP uses the
 Gauss-Jacobi-5 nodes of [hogan2024](@citet) with one to four angles
-([`AngularDiscretization`](@ref RRTMGP.AngularDiscretizations.AngularDiscretization)).
-The default single angle has secant ``D \approx 1.64``, close to Elsasser's
-classic diffusivity factor of ``1.66``, which the two-stream longwave solver
-adopts following [fu1997](@citet); adding angles improves the accuracy of the
-angular integral.
+([`AngularDiscretization`](@ref
+RRTMGP.AngularDiscretizations.AngularDiscretization)). The default single angle
+has secant ``D \approx 1.64``, close to Elsasser's classic diffusivity factor of
+``1.66``, which the two-stream longwave solver adopts following
+[fu1997](@citet); adding angles improves the accuracy of the angular integral.
 
 ## Radiative heating rate
 
@@ -83,8 +84,8 @@ net flux converges and cools where it diverges:
 \rho\, c_p \frac{\partial T}{\partial t} = -\frac{dF^{\mathrm{net}}}{dz}.
 ```
 Because the temperature tendency scales as ``1/\rho``, a given flux divergence
-warms thin, high-altitude air far more than dense air near the surface — one
-reason ozone's shortwave absorption heats the stratosphere so effectively.
+warms thin, high-altitude air more than dense air near the surface; this is one
+reason ozone's shortwave absorption heats the stratosphere effectively.
 [`heating_rate`](@ref RRTMGP.heating_rate) returns ``\partial T/\partial t`` in
 K/s.
 
@@ -127,12 +128,11 @@ from the top-of-atmosphere boundary condition, computing the downwelling flux
 F_i^{\downarrow} = \beta_i \left(T_i F_{i+1}^{\downarrow} + R_i G_i +
 S_i^{-}\right) + F_{i,\mathrm{dir}}^{\downarrow},
 ```
-where the last term is the direct solar beam, attenuated by Beer's law, and
-from it the upwelling flux ``F_i^{\uparrow} = \alpha_i F_i^{\downarrow} +
-G_i``. The result is the discrete counterpart of the integral solution of the
-transfer equation: the flux at each level accumulates every layer's emission,
-transmitted and reflected through the layers between the emitting layer and
-that level.
+where the last term is the direct solar beam, attenuated by Beer's law, and from
+it the upwelling flux ``F_i^{\uparrow} = \alpha_i F_i^{\downarrow} + G_i``. The
+result is the discrete counterpart of the integral solution of the transfer
+equation: the flux at each level accumulates every layer's emission, transmitted
+and reflected through the layers between the emitting layer and that level.
 
 ## No-scattering and two-stream solvers
 
@@ -150,11 +150,11 @@ scattering:
   is not negligible: clouds and aerosols in both bands, and Rayleigh scattering
   in the shortwave.
 
-Both families exist for the longwave and the shortwave
-([`NoScatLWRTE`](@ref RRTMGP.RTE.NoScatLWRTE) / [`TwoStreamLWRTE`](@ref RRTMGP.RTE.TwoStreamLWRTE)
-and [`NoScatSWRTE`](@ref RRTMGP.RTE.NoScatSWRTE) / [`TwoStreamSWRTE`](@ref RRTMGP.RTE.TwoStreamSWRTE)),
-and [`solve_lw!`](@ref RRTMGP.RTESolver.solve_lw!) / [`solve_sw!`](@ref RRTMGP.RTESolver.solve_sw!)
-dispatch on the workspace type.
+Both families exist for the longwave and the shortwave ([`NoScatLWRTE`](@ref
+RRTMGP.RTE.NoScatLWRTE) / [`TwoStreamLWRTE`](@ref RRTMGP.RTE.TwoStreamLWRTE) and
+[`NoScatSWRTE`](@ref RRTMGP.RTE.NoScatSWRTE) / [`TwoStreamSWRTE`](@ref
+RRTMGP.RTE.TwoStreamSWRTE)), and [`solve_lw!`](@ref RRTMGP.RTESolver.solve_lw!)
+/ [`solve_sw!`](@ref RRTMGP.RTESolver.solve_sw!) dispatch on the workspace type.
 
 ## Boundary conditions
 
@@ -162,12 +162,12 @@ The sweep needs conditions at both ends of the column. At the surface, the
 longwave upwelling radiance is the surface Planck emission scaled by the surface
 emissivity, and the shortwave reflection is set by the direct and diffuse
 albedos; the incident solar flux and the cosine of the solar zenith angle enter
-at the top. Any prescribed incident diffuse flux at the top defaults to zero, as does the downwelling longwave flux at the top.
+at the top. Any prescribed incident diffuse flux at the top defaults to zero, as
+does the downwelling longwave flux at the top.
 
 RRTMGP can also insert an **isothermal boundary layer**: an extra layer between
 the host model's top and the minimum pressure of the gas-optics tables, held at
 the model-top temperature, that represents the radiative effect of the
-atmosphere above the model lid. It is enabled through
-[`RRTMGPGridParams`](@ref RRTMGP.RRTMGPGridParams), and every getter masks it
-off so the host reads and writes arrays sized to its own grid (see
-[The getter contract](@ref)).
+atmosphere above the model lid. It is enabled through [`RRTMGPGridParams`](@ref
+RRTMGP.RRTMGPGridParams), and every getter masks it off so the host reads and
+writes arrays sized to its own grid (see [The getter contract](@ref)).

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -74,12 +74,17 @@ RRTMGP.Numerics.pow_fast
 ## Spectrally resolved fluxes
 
 Optional per-band fluxes, enabled with `spectral_fluxes = true` when
-constructing the [`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver). The
-[`spectral_lw_flux_up`](@ref RRTMGP.spectral_lw_flux_up) docstring covers the
-full `spectral_{lw,sw}_flux_{up,dn,net}` family.
+constructing the [`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver). Summing a getter
+over its band dimension recovers the corresponding broadband flux; see
+[Get per-band (spectral) fluxes](howto/spectral_fluxes.md).
 
 ```@docs
 RRTMGP.spectral_lw_flux_up
+RRTMGP.spectral_lw_flux_dn
+RRTMGP.spectral_lw_flux_net
+RRTMGP.spectral_sw_flux_up
+RRTMGP.spectral_sw_flux_dn
+RRTMGP.spectral_sw_flux_net
 RRTMGP.lw_band_bounds
 RRTMGP.sw_band_bounds
 RRTMGP.Fluxes.FluxBand

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,9 +1,10 @@
 # API
 
-RRTMGP has an API for creating various types of solvers, and accessing data
-passed to it. Hosts read and write a solver's data through named getters; their
-uniform layout/domain-masking/writability contract (the RRTMGP–ClimaCore
-decoupling mechanism) is spelled out under [The getter contract](@ref).
+This page lists the public API: the radiation methods, the solver and its
+constructors, the flux update, and the named getters through which hosts read
+and write a solver's data. The getters' layout, domain-masking, and writability
+contract (the mechanism that decouples RRTMGP from ClimaCore) is spelled out
+under [The getter contract](@ref).
 
 ```@meta
 CurrentModule = RRTMGP
@@ -70,12 +71,12 @@ RRTMGP.Numerics.μ₀_min
 RRTMGP.Numerics.pow_fast
 ```
 
-## Spectrally-resolved fluxes
+## Spectrally resolved fluxes
 
-Optional per-band fluxes, enabled with `spectral_fluxes = true` when constructing the
-[`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver). The [`spectral_lw_flux_up`](@ref
-RRTMGP.spectral_lw_flux_up) docstring covers the full `spectral_{lw,sw}_flux_{up,dn,net}`
-family.
+Optional per-band fluxes, enabled with `spectral_fluxes = true` when
+constructing the [`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver). The
+[`spectral_lw_flux_up`](@ref RRTMGP.spectral_lw_flux_up) docstring covers the
+full `spectral_{lw,sw}_flux_{up,dn,net}` family.
 
 ```@docs
 RRTMGP.spectral_lw_flux_up

--- a/docs/src/concordance.md
+++ b/docs/src/concordance.md
@@ -2,14 +2,14 @@
 
 RRTMGP.jl is a Julia implementation of the algorithms in the reference Fortran
 package [rte-rrtmgp](https://github.com/earth-system-radiation/rte-rrtmgp)
-[pincus2019](@cite). If you know the Fortran code (or the papers it
-implements), the tables below map its `mo_*` modules, `ty_*` derived types, and
-kernel subroutines to their RRTMGP.jl counterparts, with the papers whose
-equations each kernel implements.
+[pincus2019](@cite). If you know the Fortran code (or the papers it implements),
+the tables below map its `mo_*` modules, `ty_*` derived types, and kernel
+subroutines to their RRTMGP.jl counterparts, with the papers whose equations
+each kernel implements.
 
 Fortran names follow rte-rrtmgp v1.7; where a kernel was merged or renamed
-across Fortran versions, both names are given. The shared vocabulary is the
-same in both codes: `lay` for layer centers (`nlay`), `lev` for level faces
+across Fortran versions, both names are given. The shared vocabulary is the same
+in both codes: `lay` for layer centers (`nlay`), `lev` for level faces
 (`nlev = nlay + 1`), `gpt` for correlated-``k`` g-points, `bnd` for spectral
 bands, `sfc` for surface, and the radiative-transfer symbols ``τ`` (optical
 depth), ``ω₀``/`ssa` (single-scattering albedo), ``g`` (asymmetry parameter),
@@ -90,14 +90,14 @@ The Fortran gas-optics kernels live in
 
 ## RRTMGP.jl-only layers
 
-These represent Julia-specific additions; the closest analog is the example driver
+These are Julia-specific additions; the closest analog is the example driver
 programs (`examples/rfmip-clear-sky`, `examples/all-sky`), which each user of
-the Fortran code re-writes.
+the Fortran code rewrites.
 
 | RRTMGP.jl | Role |
 |:----------|:-----|
 | `RRTMGPSolver`, `update_fluxes!`, `prepare_atmosphere!`, the named getters | Layer-2 host convenience: construct once, drive the functional core each radiation step (see [The getter contract](@ref)) |
-| `standard_atmosphere`, `solve(profile)`, `RadiationOutput`, `solve_gray` | Layer-3 standalone front door (teaching, single-column experiments) |
+| `standard_atmosphere`, `solve(profile)`, `RadiationOutput`, `solve_gray` | Layer-3 standalone entry points (teaching, single-column experiments) |
 | `GrayAtmosphere` module and the gray optics kernels | analytic gray-atmosphere radiation [schneider2004](@cite), [frierson2006](@cite), [ogorman2008](@cite) |
 | `Numerics` module (`k_min`, `τ_thresh`, `resonance_window`, `μ₀_min`) | documented numerical guard constants (hard-coded literals in the Fortran kernels) |
 | `LookupBundle` caching via `save_lookup_tables` / `load_lookup_tables` | NetCDF-free lookup reuse |

--- a/docs/src/functional_core.md
+++ b/docs/src/functional_core.md
@@ -1,15 +1,15 @@
 # The functional core
 
-RRTMGP's API is layered, and this page documents its center: a **functional
-core** that you can use in a class, in a standalone single-column experiment,
-or as the foundation the [`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver) is built
-upon. If you want results before concepts, start with the
+RRTMGP's API is layered, and this page documents the innermost layer: a
+**functional core** that you can use in a class, in a standalone single-column
+experiment, or as the foundation the [`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver)
+is built upon. If you want results before concepts, start with the
 [tutorials](tutorials/getting_started.md) and return here for what `solve`
 assembles internally.
 
 ## The model: three inputs and one action
 
-A radiative-transfer solve is split into separately-owned pieces:
+A radiative-transfer solve is split into separately owned pieces:
 
 1. **Immutable lookup tables**: the correlated-k gas/cloud/aerosol optics data,
    loaded once and shared across columns and timesteps. (Gray radiation uses
@@ -23,26 +23,27 @@ A radiative-transfer solve is split into separately-owned pieces:
 3. **A preallocated per-band workspace**: one of [`NoScatLWRTE`](@ref
    RRTMGP.RTE.NoScatLWRTE) / [`TwoStreamLWRTE`](@ref RRTMGP.RTE.TwoStreamLWRTE)
    / [`NoScatSWRTE`](@ref RRTMGP.RTE.NoScatSWRTE) / [`TwoStreamSWRTE`](@ref
-   RRTMGP.RTE.TwoStreamSWRTE) which owns the optics scratch and the output
-   flux buffers, operating in place.
+   RRTMGP.RTE.TwoStreamSWRTE) which owns the optics scratch and the output flux
+   buffers, operating in place.
 
-The action is a single function call: [`solve_lw!`](@ref RRTMGP.RTESolver.solve_lw!) /
-[`solve_sw!`](@ref RRTMGP.RTESolver.solve_sw!) reads the state and writes the
-workspace's flux buffers in place, and you can read the results:
+The action is a single function call: [`solve_lw!`](@ref
+RRTMGP.RTESolver.solve_lw!) / [`solve_sw!`](@ref RRTMGP.RTESolver.solve_sw!)
+reads the state and writes the workspace's flux buffers in place, and you can
+read the results:
 
 ```julia
 solve_lw!(slv_lw, state, lookup_lw)   # or solve_lw!(slv_lw, state) for gray
 F = slv_lw.flux.flux_net              # (ncol, nlev) [W/m²]
 ```
 
-Note the axis order: the raw flux buffers are indexed column-first, `(ncol,
-nlev)`, on every device. On the GPU they are also stored that way, so that
-neighboring threads (one per column) access consecutive memory; on the CPU
-the storage is vertical-first under a lazy wrapper, which keeps the
-per-column sweeps stride-1 without changing the indexing. Only the Layer-2
-getters (`net_flux`, `lw_flux_up`, ...) present the vertical-first
-`(nlev, ncol)` orientation, from presentation copies that `update_fluxes!`
-refreshes at the end of each call.
+Note the axis order: the raw flux buffers are indexed column-first,
+`(ncol, nlev)`, on every device. On the GPU they are also stored that way, so
+that neighboring threads (one per column) access consecutive memory; on the CPU
+the storage is vertical-first under a lazy wrapper, which keeps the per-column
+sweeps stride-1 without changing the indexing. Only the Layer-2 getters
+(`net_flux`, `lw_flux_up`, ...) present the vertical-first `(nlev, ncol)`
+orientation, from presentation copies that `update_fluxes!` refreshes at the end
+of each call.
 
 This is what RRTMGP's own tests drive, and what [`RRTMGPSolver`](@ref
 RRTMGP.RRTMGPSolver) wraps behind [`update_fluxes!`](@ref RRTMGP.update_fluxes!)
@@ -50,15 +51,16 @@ and the named getters.
 
 ## Gray radiation
 
-The gray path uses analytic formulas and runs after `using RRTMGP`. It
-builds a gray profile, longwave and shortwave two-stream workspaces, solves, and
-reads the net fluxes:
+The gray path uses analytic formulas and runs after `using RRTMGP`. It builds a
+gray profile, longwave and shortwave two-stream workspaces, solves, and reads
+the net fluxes:
 
 ```@example functional_core
 using RRTMGP
 using RRTMGP.RTE: TwoStreamLWRTE, TwoStreamSWRTE
 using RRTMGP.RTESolver: solve_lw!, solve_sw!
-using RRTMGP.AtmosphericStates: setup_gray_as_pr_grid, GrayOpticalThicknessOGorman2008
+using RRTMGP.AtmosphericStates: setup_gray_as_pr_grid
+using RRTMGP.AtmosphericStates: GrayOpticalThicknessOGorman2008
 import ClimaComms
 ClimaComms.@import_required_backends
 
@@ -96,7 +98,7 @@ net = lw_net .+ sw_net
 net[1, end]                     # net flux at the top of the atmosphere [W/m²]
 ```
 
-The one-liner [`solve_gray`](@ref RRTMGP.solve_gray) wraps this.
+[`solve_gray`](@ref RRTMGP.solve_gray) wraps this in a single call.
 
 ## Clear-sky and all-sky radiation (with lookup tables)
 
@@ -124,7 +126,8 @@ as = ...   # e.g., setup_clear_sky_as in test/read_clear_sky.jl
 grid_params = RRTMGP.RRTMGPGridParams(FT; context, domain_nlay = nlay, ncol)
 slv_lw = TwoStreamLWRTE(grid_params; params, sfc_emis, inc_flux = nothing)
 slv_sw = TwoStreamSWRTE(grid_params; cos_zenith, toa_flux,
-                        sfc_alb_direct, inc_flux_diffuse = nothing, sfc_alb_diffuse)
+                        sfc_alb_direct, inc_flux_diffuse = nothing,
+                        sfc_alb_diffuse)
 
 # pass the lookup tables to the solve (add cloud/aerosol lookups and a
 # metric_scaling argument for cloudy or deep-atmosphere runs)
@@ -140,23 +143,23 @@ it for the cloud and aerosol lookups.
 
 ## Optional grid adaptation
 
-`solve_*!` assumes a complete, valid state. If a host supplies only
-layer-center values, or wants the isothermal boundary layer (an extra buffer
-layer above the model top; see [Boundary conditions](RTE.md) on the RTE page),
-or must clip unphysical inputs, RRTMGP provides separable, in-place helpers: [`interpolate_levels!`](@ref
-RRTMGP.interpolate_levels!), [`add_isothermal_boundary_layer!`](@ref
-RRTMGP.add_isothermal_boundary_layer!), [`clip!`](@ref RRTMGP.clip!), and
-[`update_concentrations!`](@ref RRTMGP.update_concentrations!), each usable
-independently. (Relative humidity is a host responsibility; see
-[`update_concentrations!`](@ref RRTMGP.update_concentrations!).)
+`solve_*!` assumes a complete, valid state. If a host supplies only layer-center
+values, or wants the isothermal boundary layer (an extra buffer layer above the
+model top; see [Boundary conditions](RTE.md) on the RTE page), or must clip
+unphysical inputs, RRTMGP provides separable, in-place helpers:
+[`interpolate_levels!`](@ref RRTMGP.interpolate_levels!),
+[`add_isothermal_boundary_layer!`](@ref RRTMGP.add_isothermal_boundary_layer!),
+[`clip!`](@ref RRTMGP.clip!), and [`update_concentrations!`](@ref
+RRTMGP.update_concentrations!), each usable independently. (Relative humidity is
+a host responsibility; see [`update_concentrations!`](@ref
+RRTMGP.update_concentrations!).)
 
 ## From the core to the host aggregate
 
-For a host that runs radiation every step or every ``n`` steps (as is common
-in atmosphere models because of the relatively large computational expense of
-radiation), [`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver) bundles the two
-workspaces, the state, and the lookups, and drives the pipeline with
-[`update_fluxes!`](@ref RRTMGP.update_fluxes!).
-Inputs and outputs are exchanged through named getters following the uniform
-contract on [The getter contract](@ref) page. See the [API](@ref) reference for
-the solver and getter listing.
+For a host that runs radiation every step or every ``n`` steps (common in
+atmosphere models because radiation is computationally expensive),
+[`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver) bundles the two workspaces, the
+state, and the lookups, and drives the pipeline with [`update_fluxes!`](@ref
+RRTMGP.update_fluxes!). Inputs and outputs are exchanged through named getters
+following the uniform contract on [The getter contract](@ref) page. See the
+[API](@ref) reference for the solver and getter listing.

--- a/docs/src/getters.md
+++ b/docs/src/getters.md
@@ -20,8 +20,8 @@ the solver's own buffer**, following one invariant:
   surface/column quantities are `(ncol,)` (except the spectral surface
   properties like emissivity and albedos, which are `(nbnd, ncol)`).
 - **Domain-masked.** When the solver carries an internal isothermal boundary
-  layer (`isothermal_boundary_layer = true`), the getters exclude that extra
-  top layer/level, so the returned arrays are sized to the physical domain
+  layer (`isothermal_boundary_layer = true`), the getters exclude that extra top
+  layer/level, so the returned arrays are sized to the physical domain
   (`domain_nlay` / `domain_nlay + 1`) and line up with the host's grid. The
   getter returns a concrete `view` type, keeping [`update_fluxes!`](@ref
   RRTMGP.update_fluxes!) type-stable.
@@ -49,28 +49,27 @@ Inputs are written *before* the solve, outputs read *after* it:
 ᶜT .= my_temperatures
 RRTMGP.update_fluxes!(solver, seed)             # runs the radiation update
 
-F = RRTMGP.net_flux(solver)                      # (nlev, ncol) view of the result
+F = RRTMGP.net_flux(solver)            # (nlev, ncol) view of the result
 ```
 
 With ClimaCore, this forms the bridge: `array2field(getter(solver), space)`
-wraps a getter's view as a `Field` — for an input, writes flow into the solver's
-buffer; for an output, the `Field` reads the buffer in place — and
+wraps a getter's view as a `Field` (for an input, writes flow into the solver's
+buffer; for an output, the `Field` reads the buffer in place), and
 `field2array(dst) .= getter(solver)` copies an output into an existing
 destination field. Both directions are copy-free: the getters are single-level
 views of plain `(nlev, ncol)` buffers, so `array2field`'s lazy `reshape` wraps
 them without materializing anything. Do **not** `copy(getter(solver))` before
-wrapping — the view is directly wrappable, and copying allocates a full
+wrapping: the view is directly wrappable, and copying allocates a full
 `(nlev, ncol)` field on every call (reading many fluxes per step this way adds
 up to large per-step allocations). Likewise avoid `parent(getter(solver))` as a
 shortcut: `parent` returns the full boundary-extended buffer, undoing the domain
-masking.
-On the GPU, the returned views are plain `SubArray`s of device arrays; to
-bring one to the CPU, use `Array(getter(solver))` (or the element-wise `.=`
+masking. On the GPU, the returned views are plain `SubArray`s of device arrays;
+to bring one to the CPU, use `Array(getter(solver))` (or the element-wise `.=`
 copy above). One subtlety: the solver's compute buffers are indexed
 column-first, `(ncol, nlev)` (with the physical layout chosen per device for
-performance), and `update_fluxes!` ends by copying them into the
-`(nlev, ncol)` presentation arrays the flux getters expose — so read fluxes
-after `update_fluxes!`, not between manual Layer-1 solves.
+performance), and `update_fluxes!` ends by copying them into the `(nlev, ncol)`
+presentation arrays the flux getters expose; read fluxes after `update_fluxes!`,
+not between manual Layer-1 solves.
 
 ## Responsibilities: what the host provides vs what RRTMGP derives
 
@@ -86,8 +85,8 @@ The host **writes** the inputs through the getters before calling
 
 RRTMGP **derives** the rest inside `update_fluxes!`: the optional preparation
 cascade (level values from centers, the isothermal boundary layer, input
-clipping, and the dry-air column amount via `compute_col_gas!`), then the
-optics and RTE solve, then the net-flux combine.
+clipping, and the dry-air column amount via `compute_col_gas!`), then the optics
+and RTE solve, then the net-flux combine.
 
 Two things are **deliberately the host's job**:
 
@@ -98,11 +97,11 @@ Two things are **deliberately the host's job**:
 
 ## Getter reference
 
-Getters marked with a link have full docstrings; the rest follow the contract
-above. All vertical/layer getters are domain-masked views into solver-owned
-buffers.
+Every getter has a docstring for REPL help; the tables below give the
+overview, and the contract above supplies the shared rules. All vertical/layer
+getters are domain-masked views into solver-owned buffers.
 
-### Layer-center state — inputs, `(nlay, ncol)`
+### Layer-center state: inputs, `(nlay, ncol)`
 
 | Getter | Quantity |
 |---|---|
@@ -110,14 +109,14 @@ buffers.
 | `layer_temperature` | layer-center temperature [K] |
 | `layer_relative_humidity` | layer-center relative humidity |
 
-### Level (face) state — inputs, `(nlev, ncol)`
+### Level (face) state: inputs, `(nlev, ncol)`
 
 | Getter | Quantity |
 |---|---|
 | `level_pressure` | level pressure [Pa] |
 | `level_temperature` | level temperature [K] |
 
-### Surface and top-of-atmosphere — inputs
+### Surface and top-of-atmosphere: inputs
 
 | Getter | Quantity | Shape |
 |---|---|---|
@@ -130,7 +129,7 @@ buffers.
 | `top_of_atmosphere_lw_flux_dn` | prescribed incident longwave flux [W/m²] | `(ngpt, ncol)`, or `nothing` |
 | `top_of_atmosphere_diffuse_sw_flux_dn` | prescribed incident diffuse shortwave flux [W/m²] | `(ngpt, ncol)`, or `nothing` |
 
-### Fluxes — outputs, `(nlev, ncol)` [W/m²]
+### Fluxes: outputs, `(nlev, ncol)` [W/m²]
 
 | Getter | Quantity |
 |---|---|
@@ -168,3 +167,51 @@ mirror these: `clear_lw_flux_up`/`clear_lw_flux_dn`/`clear_lw_flux`,
 | [`radiation_method`](@ref RRTMGP.radiation_method) | the solver's radiation method |
 | `isothermal_boundary_layer` | whether the internal boundary layer is present |
 | `optical_thickness_parameter` | gray optical-thickness parameters, or `nothing` (non-gray) |
+
+## Docstrings
+
+```@docs
+RRTMGP.layer_pressure
+RRTMGP.layer_temperature
+RRTMGP.layer_relative_humidity
+RRTMGP.level_pressure
+RRTMGP.level_temperature
+RRTMGP.surface_temperature
+RRTMGP.surface_emissivity
+RRTMGP.latitude
+RRTMGP.cos_zenith
+RRTMGP.toa_flux
+RRTMGP.direct_sw_surface_albedo
+RRTMGP.diffuse_sw_surface_albedo
+RRTMGP.top_of_atmosphere_lw_flux_dn
+RRTMGP.top_of_atmosphere_diffuse_sw_flux_dn
+RRTMGP.lw_flux_up
+RRTMGP.lw_flux_dn
+RRTMGP.lw_flux_net
+RRTMGP.sw_flux_up
+RRTMGP.sw_flux_dn
+RRTMGP.sw_flux_net
+RRTMGP.sw_direct_flux_dn
+RRTMGP.net_flux
+RRTMGP.clear_lw_flux_up
+RRTMGP.clear_lw_flux_dn
+RRTMGP.clear_lw_flux
+RRTMGP.clear_sw_flux_up
+RRTMGP.clear_sw_flux_dn
+RRTMGP.clear_sw_direct_flux_dn
+RRTMGP.clear_sw_flux
+RRTMGP.clear_net_flux
+RRTMGP.cloud_liquid_effective_radius
+RRTMGP.cloud_ice_effective_radius
+RRTMGP.cloud_liquid_water_path
+RRTMGP.cloud_ice_water_path
+RRTMGP.cloud_fraction
+RRTMGP.lw_cloud_cover
+RRTMGP.sw_cloud_cover
+RRTMGP.aod_sw_extinction
+RRTMGP.aod_sw_scattering
+RRTMGP.center_z
+RRTMGP.face_z
+RRTMGP.deep_atmosphere_inverse_scaling
+RRTMGP.isothermal_boundary_layer
+```

--- a/docs/src/howto/clouds_aerosols.md
+++ b/docs/src/howto/clouds_aerosols.md
@@ -61,10 +61,12 @@ cloud_state = CloudState(
 )
 ```
 
-The effective radii must lie within the cloud lookup tables' ranges
-(liquid 2.5–21.5 µm, ice 10–180 µm; see [Optics](../Optics.md)). `ice_rgh`
-selects the ice-particle surface roughness of the [yang2013](@citet) ice
-optics.
+The effective radii are clamped to the cloud lookup table ranges (liquid
+2.5–21.5 µm, ice 5–90 µm; see [Optics](../Optics.md)), so values outside them
+are used at the nearest table edge without warning. Note that the ice tables
+are tabulated against diameter in the NetCDF file and halved to radii on
+load. `ice_rgh` selects the ice-particle surface roughness of the
+[yang2013](@citet) ice optics.
 
 ## 3. Build the aerosol state
 

--- a/docs/src/howto/clouds_aerosols.md
+++ b/docs/src/howto/clouds_aerosols.md
@@ -1,0 +1,175 @@
+# How to add clouds and aerosols
+
+The all-sky radiation methods extend the clear-sky gas optics with cloud and
+aerosol optics. This is the production configuration of the CliMA atmosphere.
+The steps below assume the setup of
+[How to drive RRTMGP from a host model](host_model.md) and cover only what
+clouds and aerosols add: the [`CloudState`](@ref
+RRTMGP.AtmosphericStates.CloudState) and [`AerosolState`](@ref
+RRTMGP.AtmosphericStates.AerosolState), the McICA sampling options, and the
+aerosol species ordering. The underlying optics (lookup tables, McICA
+cloud-overlap sampling, MERRA aerosol species) are described on the
+[Optics](../Optics.md) page.
+
+## 1. Choose an all-sky method
+
+```julia
+using RRTMGP, NCDatasets
+
+method = RRTMGP.AllSkyRadiationWithClearSkyDiagnostics(
+    true,  # aerosol_radiation
+    false, # reset_rng_seed (see step 5)
+)
+lookups = RRTMGP.lookup_tables(grid_params, method)
+```
+
+[`AllSkyRadiation`](@ref RRTMGP.AllSkyRadiation) computes all-sky fluxes;
+[`AllSkyRadiationWithClearSkyDiagnostics`](@ref
+RRTMGP.AllSkyRadiationWithClearSkyDiagnostics) additionally retains clear-sky
+fluxes from the same state (the difference is the cloud radiative effect).
+With `aerosol_radiation = true`, [`lookup_tables`](@ref RRTMGP.lookup_tables)
+loads the MERRA aerosol tables alongside the gas and cloud tables.
+
+## 2. Build the cloud state
+
+The host owns the [`CloudState`](@ref RRTMGP.AtmosphericStates.CloudState) and
+fills its physical inputs: effective radii [µm], water paths [g/m²], and cloud
+fraction, all `(nlay, ncol)` on the device. Layers without cloud carry zeros.
+The two `Bool` mask arrays are only allocated by the host; RRTMGP fills them
+by McICA sampling on every solve. The two optional cloud-cover arrays,
+`(ncol,)`, receive the sampled column cloud cover as a diagnostic (readable
+through [`lw_cloud_cover`](@ref RRTMGP.lw_cloud_cover) /
+[`sw_cloud_cover`](@ref RRTMGP.sw_cloud_cover)); a 9-argument constructor
+without them is available if the diagnostic is not needed.
+
+```julia
+using RRTMGP.AtmosphericStates: CloudState, MaxRandomOverlap
+
+zeros_lay() = DA(zeros(FT, nlay, ncol))
+cloud_state = CloudState(
+    zeros_lay(),                  # cld_r_eff_liq [µm]
+    zeros_lay(),                  # cld_r_eff_ice [µm]
+    zeros_lay(),                  # cld_path_liq [g/m²]
+    zeros_lay(),                  # cld_path_ice [g/m²]
+    zeros_lay(),                  # cld_frac in [0, 1]
+    DA{FT}(undef, ncol),          # cld_cover_sw (diagnostic)
+    DA{FT}(undef, ncol),          # cld_cover_lw (diagnostic)
+    DA{Bool}(undef, nlay, ncol),  # mask_lw (built each solve)
+    DA{Bool}(undef, nlay, ncol),  # mask_sw (built each solve)
+    MaxRandomOverlap(),           # cloud-overlap assumption
+    2,                            # ice_rgh: 1 none, 2 medium, 3 rough
+)
+```
+
+The effective radii must lie within the cloud lookup tables' ranges
+(liquid 2.5–21.5 µm, ice 10–180 µm; see [Optics](../Optics.md)). `ice_rgh`
+selects the ice-particle surface roughness of the [yang2013](@citet) ice
+optics.
+
+## 3. Build the aerosol state
+
+The host owns the [`AerosolState`](@ref RRTMGP.AtmosphericStates.AerosolState)
+and fills, per species and layer, the aerosol column mass `aero_mass` [kg/m²]
+and, for dust and sea salt, the particle radius `aero_size` [µm], both
+`(n_aero, nlay, ncol)`. The mask is allocated only (RRTMGP rebuilds it from
+`aero_mass` on every solve), and the two `(ncol,)` optical-depth arrays are
+diagnostics the solver fills (readable through
+[`aod_sw_extinction`](@ref RRTMGP.aod_sw_extinction) /
+[`aod_sw_scattering`](@ref RRTMGP.aod_sw_scattering)).
+
+```julia
+using RRTMGP.AtmosphericStates: AerosolState
+
+n_aero = length(RRTMGP.aerosol_names())   # 15 MERRA species
+aerosol_state = AerosolState(
+    DA{FT}(undef, ncol),                  # aod_sw_ext (diagnostic)
+    DA{FT}(undef, ncol),                  # aod_sw_sca (diagnostic)
+    DA{Bool}(undef, nlay, ncol),          # aero_mask (built each solve)
+    DA(zeros(FT, n_aero, nlay, ncol)),    # aero_size [µm]
+    DA(zeros(FT, n_aero, nlay, ncol)),    # aero_mass [kg/m²]
+)
+```
+
+!!! warning "Map aerosol species by name, not by position"
+    The first index of `aero_mass` and `aero_size` selects the MERRA species,
+    in an order fixed by RRTMGP. Filling these arrays positionally, from a
+    host species list assumed to be in the same order, produces no error when
+    the orders disagree: every species silently receives another species'
+    optics. Resolve indices by name instead, through
+    [`aerosol_index_map`](@ref RRTMGP.aerosol_index_map) (or
+    [`aerosol_names`](@ref RRTMGP.aerosol_names), which lists the species in
+    index order), or write through the named getters of step 4. RRTMGP's own
+    ordering is locked by `test/aerosol_name_map.jl`; the host-side mapping is
+    the host's responsibility.
+
+The 15 species are `dust1` … `dust5` and `sea_salt1` … `sea_salt5` (five size
+bins each), `sulfate`, and `black_carbon` / `organic_carbon`, each with a
+hygroscopic `_rh` variant. The hygroscopic species (sea salt, sulfate, and the
+`_rh` carbon variants) are interpolated in relative humidity, so keep
+`layer_relative_humidity(solver)` current (see
+[How to drive RRTMGP from a host model](host_model.md)).
+
+## 4. Construct the solver and write the state each step
+
+The cloud and aerosol states are the last two arguments of the
+[`AtmosphericState`](@ref RRTMGP.AtmosphericStates.AtmosphericState):
+
+```julia
+as = RRTMGP.AtmosphericStates.AtmosphericState(
+    lon, lat, layerdata, p_lev, t_lev, t_sfc, vmr,
+    cloud_state, aerosol_state,
+)
+solver = RRTMGP.RRTMGPSolver(
+    grid_params, method, params, bcs_lw, bcs_sw, as;
+    lookups,
+)
+```
+
+After construction, update the cloud and aerosol inputs through the getters,
+like the rest of the state; the aerosol getters take the species name and
+resolve the index internally:
+
+```julia
+RRTMGP.cloud_fraction(solver) .= cf                  # (nlay, ncol)
+RRTMGP.cloud_liquid_water_path(solver) .= lwp        # [g/m²]
+RRTMGP.cloud_liquid_effective_radius(solver) .= r_liq  # [µm]
+
+RRTMGP.aerosol_column_mass_density(solver, "sulfate") .= so4_mass  # [kg/m²]
+RRTMGP.aerosol_radius(solver, "dust1") .= dust1_radius             # [µm]
+
+RRTMGP.update_fluxes!(solver)
+```
+
+`test/read_all_sky_with_aerosols.jl` is a complete worked example of filling
+both states from data.
+
+## 5. McICA sampling and reproducibility
+
+With partial cloud fractions (`0 < cld_frac < 1`), the solvers sample the
+cloud masks stochastically on every solve (McICA with maximum-random overlap;
+see [Optics](../Optics.md)), drawing from the global random-number generator.
+For reproducible fluxes, construct the method with `reset_rng_seed = true` and
+pass a seed to the solve:
+
+```julia
+RRTMGP.update_fluxes!(solver, seed)   # reseeds the RNG before sampling
+```
+
+Without `reset_rng_seed = true`, the seed argument is ignored. On multiple
+threads and on the GPU, the sampling of partially cloudy columns is
+statistically but not bitwise reproducible; see the caveat in
+[How to run on GPUs](gpu.md). Overcast (`cld_frac = 1`) and clear layers are
+deterministic.
+
+## 6. Read the diagnostics
+
+With `AllSkyRadiationWithClearSkyDiagnostics`, the clear-sky counterparts of
+every flux getter (`clear_lw_flux_up`, `clear_sw_flux_dn`, `clear_net_flux`,
+…) hold the fluxes the same state would produce without clouds, so the cloud
+radiative effect is, for example,
+`RRTMGP.lw_flux_net(solver) .- RRTMGP.clear_lw_flux(solver)`. The sampled
+column cloud covers and the 550 nm aerosol optical depths are available
+through [`lw_cloud_cover`](@ref RRTMGP.lw_cloud_cover) /
+[`sw_cloud_cover`](@ref RRTMGP.sw_cloud_cover) and
+[`aod_sw_extinction`](@ref RRTMGP.aod_sw_extinction) /
+[`aod_sw_scattering`](@ref RRTMGP.aod_sw_scattering).

--- a/docs/src/howto/gpu.md
+++ b/docs/src/howto/gpu.md
@@ -40,21 +40,21 @@ F = Array(RRTMGP.net_flux(solver))   # one device→host copy
 
 Broadcasted writes into getters (`layer_temperature(solver) .= T_dev`) are
 device-side and safe. Two getters do not return views:
-`volume_mixing_ratio(solver, name)` for well-mixed gases returns a host
-scalar, and `heating_rate(solver)` allocates a fresh device array; read them
-outside hot loops.
+`volume_mixing_ratio(solver, name)` for well-mixed gases returns a host scalar,
+and `heating_rate(solver)` allocates a fresh device array; read them outside hot
+loops.
 
 ## Checkpointing and device transfer
 
 `RRTMGPSolver` supports [Adapt](https://github.com/JuliaGPU/Adapt.jl), so
 `Adapt.adapt(Array, solver)` produces a host copy (e.g., for serialization) and
 `Adapt.adapt(CuArray, solver)` moves it back. RRTMGP's custom `adapt_structure`
-methods preserve the internal view topology (scratch views into packed
-buffers), so an adapted solver keeps the zero-allocation property. Adapt
-preserves each buffer's physical layout, so round-tripping a GPU solver
-through the host is lossless; adapting a CPU-*constructed* solver to the GPU
-runs correctly but keeps the CPU layout (uncoalesced) — for GPU work,
-construct the solver on the GPU.
+methods preserve the internal view topology (scratch views into packed buffers),
+so an adapted solver keeps the zero-allocation property. Adapt preserves each
+buffer's physical layout, so round-tripping a GPU solver through the host is
+lossless; adapting a CPU-*constructed* solver to the GPU runs correctly but
+keeps the CPU layout (uncoalesced), so for GPU work, construct the solver on the
+GPU.
 
 ## Reproducibility caveat: McICA cloud sampling
 
@@ -74,54 +74,64 @@ this independence, with the same per-(g-point, column) kernel bodies shared by
 both backends:
 
 - On the GPU, each CUDA thread owns one column and loops over its g-points,
-  accumulating the column's broadband fluxes thread-locally — no atomics and no
-  synchronization between threads. Parallelism therefore scales with `ncol`,
-  and a GPU pays off with many columns, the regime the benchmarks below target.
+  accumulating the column's broadband fluxes thread-locally, with no atomics and
+  no synchronization between threads. Parallelism therefore scales with `ncol`,
+  and the GPU speedup requires many columns, the regime the benchmarks below
+  target.
 - On the CPU, the loop order is inverted: for each g-point, the columns are
   distributed across threads (`ClimaComms.@threaded`), which keeps that
-  g-point's lookup-table slices hot in cache while sweeping the columns. With
-  a single-threaded context, the same code runs serially.
+  g-point's lookup-table slices in cache while sweeping the columns. With a
+  single-threaded context, the same code runs serially.
 
 The memory layout matches the thread mapping on each device. On the GPU, the
-internal scratch and output buffers are stored column-first, `(ncol, nlev)`,
-so consecutive threads write consecutive addresses (coalesced access), and
-the frequently re-read state arrays (layer pressures and temperatures, level
+internal scratch and output buffers are stored column-first, `(ncol, nlev)`, so
+consecutive threads write consecutive addresses (coalesced access), and the
+frequently re-read state arrays (layer pressures and temperatures, level
 temperatures) are copied into a column-first `TransposedStateCache` once per
 solve so the g-point loop also reads coalesced memory. On the CPU, the same
-buffers are stored vertical-first under a lazy wrapper — each thread's
-vertical sweep is then stride-1 — and the kernels read the
-`AtmosphericState` directly, so both devices run identical kernel code on
-their preferred layout. The caller-owned `AtmosphericState` and the getter
-views keep their vertical-first `(nlev, ncol)` presentation throughout.
+buffers are stored vertical-first under a lazy wrapper (each thread's vertical
+sweep is then stride-1), and the kernels read the `AtmosphericState` directly,
+so both devices run identical kernel code on their preferred layout. The
+caller-owned `AtmosphericState` and the getter views keep their vertical-first
+`(nlev, ncol)` presentation throughout.
 
 ## Performance expectations
 
-CI benchmarks the kernels on GPUs (see `perf/benchmark_ratchet.jl`
-and the Buildkite "Benchmarks" group). Indicative behavior:
+CI benchmarks the kernels on GPUs (see `perf/benchmark_ratchet.jl` and the
+Buildkite "Benchmarks" group). Indicative behavior:
 
 - Work scales with `ncol × nlay × ngpt`; the g-point loop dominates.
 - `update_fluxes!` allocates nothing on either device; data movement is the
   host's choice (the getters return views).
-- `Float32` roughly halves memory traffic; see
-  [Float32 and Float64](../precision.md) for the accuracy achieved at single
-  precision and the numerics behind it.
+- `Float32` roughly halves memory traffic; see [Float32 and
+  Float64](../precision.md) for the accuracy achieved at single precision and
+  the numerics behind it.
 
 ## GPU versus CPU performance
 
 Wall times per full radiation step (`solve_lw!` + `solve_sw!`) comparing the
-multi-threaded CPU strategy against the GPU strategy across single (`Float32`) and double (`Float64`) precision.
+multi-threaded CPU strategy against the GPU strategy across single (`Float32`)
+and double (`Float64`) precision.
 
 ### Benchmark problem dimensions
 
-Every configuration evaluated by the benchmark (see [`perf/benchmark_ratchet.jl`](https://github.com/CliMA/RRTMGP.jl/blob/main/perf/benchmark_ratchet.jl)) operates on an identical, uniform spatial grid representative of a high-resolution atmospheric model:
+Every configuration evaluated by the benchmark (see
+[`perf/benchmark_ratchet.jl`](https://github.com/CliMA/RRTMGP.jl/blob/main/perf/benchmark_ratchet.jl))
+operates on the same grid, representative of a high-resolution atmospheric
+model:
 
-- **Columns (`ncol`)**: **`86,400` horizontal columns** (`30² elements × 6 panels × 4² quadrature points`).
-- **Vertical structure**: **`63` layers (`64` levels)** across every test profile (`5.53 × 10⁶` uniform 3D spatial coordinates, `ncol × nlev`), aligned with GPU warp sizes and memory boundaries.
-- **Spectral quadrature points (`ngpt`)**: **`480` spectral g-points** (`256` longwave + `224` shortwave) across all problems, resulting in approximately `2.65 × 10⁹` total cell evaluations per `solve_lw!` + `solve_sw!` step.
+- **Columns (`ncol`)**: `86,400` horizontal columns
+  (`30² elements × 6 panels × 4² quadrature points`).
+- **Vertical structure**: `63` layers (`64` levels), giving `5.53 × 10⁶` grid
+  cells (`ncol × nlev`).
+- **Spectral quadrature points (`ngpt`)**: `480` g-points (`256` longwave +
+  `224` shortwave), giving about `2.65 × 10⁹` cell evaluations per `solve_lw!` +
+  `solve_sw!` step.
 
-### Single precision (`Float32`) — Primary target
+### Single precision (`Float32`)
 
-At `Float32` precision, memory traffic across lookup-table interpolations and solver evaluations is halved compared to `Float64`, enabling large GPU speedups:
+At `Float32` precision, the memory traffic of the lookup-table interpolations
+and solver evaluations is halved compared to `Float64`:
 
 | Configuration | CPU (Intel Xeon, 12 threads) | GPU (NVIDIA A100 40GB) | Speedup |
 |---|---|---|---|
@@ -131,7 +141,7 @@ At `Float32` precision, memory traffic across lookup-table interpolations and so
 
 ### Double precision (`Float64`)
 
-For reference, running the identical uniform benchmark sweep in double precision (`Float64`) yields:
+The same benchmark sweep in double precision (`Float64`) yields:
 
 | Configuration | CPU (Intel Xeon, 12 threads) | GPU (NVIDIA A100 40GB) | Speedup |
 |---|---|---|---|

--- a/docs/src/howto/host_model.md
+++ b/docs/src/howto/host_model.md
@@ -1,8 +1,8 @@
 # How to drive RRTMGP from a host model
 
-This guide walks through embedding RRTMGP.jl in a host model (a GCM, a
-single-column model, or any code with its own time loop): construct the solver
-once, then exchange data through the [getter contract](../getters.md) and call
+This guide shows how to embed RRTMGP.jl in a host model (a GCM, a single-column
+model, or any code with its own time loop): construct the solver once, then
+exchange data through the [getter contract](../getters.md) and call
 [`update_fluxes!`](@ref RRTMGP.update_fluxes!) every radiation step. The
 [Functional core](../functional_core.md) page explains what these pieces are;
 this page shows the order in which to assemble them.
@@ -48,15 +48,15 @@ method = RRTMGP.AllSkyRadiationWithClearSkyDiagnostics(
 lookups = RRTMGP.lookup_tables(grid_params, method)
 ```
 
-Build the tables once and pass them to every solver you construct; see
-[How to cache the lookup tables](lookup_cache.md) to skip the NetCDF read
-across sessions.
+Build the tables once and pass them to every solver you construct; see [How to
+cache the lookup tables](lookup_cache.md) to skip the NetCDF read across
+sessions.
 
 ## 3. Build the state and boundary conditions
 
-The host owns the [`AtmosphericState`](@ref RRTMGP.AtmosphericStates.AtmosphericState)
-(pressures, temperatures, mixing ratios, optional
-[`CloudState`](@ref RRTMGP.AtmosphericStates.CloudState) and
+The host owns the [`AtmosphericState`](@ref
+RRTMGP.AtmosphericStates.AtmosphericState) (pressures, temperatures, mixing
+ratios, optional [`CloudState`](@ref RRTMGP.AtmosphericStates.CloudState) and
 [`AerosolState`](@ref RRTMGP.AtmosphericStates.AerosolState)) and the boundary
 conditions ([`LwBCs`](@ref RRTMGP.BCs.LwBCs), [`SwBCs`](@ref RRTMGP.BCs.SwBCs)).
 All arrays live on the device described by `grid_params`, with the vertical
@@ -65,15 +65,15 @@ worked example of filling these from data.
 
 The boundary conditions close the column at both ends. At the top, the
 insolation enters through the incident solar flux `toa_flux` [W/m²] and the
-cosine of the solar zenith angle `cos_zenith`, both `(ncol,)`; the host
-computes them from its solar and orbital code. The CliMA package
+cosine of the solar zenith angle `cos_zenith`, both `(ncol,)`; the host computes
+them from its solar and orbital code. The CliMA package
 [Insolation.jl](https://github.com/CliMA/Insolation.jl) provides both as
-functions of latitude, longitude, and time, from the orbital parameters. At the bottom, the longwave surface
-emissivity `sfc_emis` and the shortwave direct and diffuse albedos are
-`(nbnd, ncol)`, i.e., **per band**, so the surface can be spectrally selective —
-vegetation, for example, absorbs strongly in the visible and reflects in the
-near-infrared, and snow does the reverse. For a spectrally flat surface, fill
-the band dimension with one value:
+functions of latitude, longitude, and time, from the orbital parameters. At the
+bottom, the longwave surface emissivity `sfc_emis` and the shortwave direct and
+diffuse albedos are `(nbnd, ncol)`, i.e., **per band**, so the surface can be
+spectrally selective: vegetation, for example, absorbs strongly in the visible
+and reflects in the near-infrared, and snow does the reverse. For a spectrally
+flat surface, fill the band dimension with one value:
 
 ```julia
 FT = Float64
@@ -88,15 +88,16 @@ cos_zenith  = DA{FT}(undef, ncolumns)                 # filled each step (below)
 toa_flux    = DA{FT}(undef, ncolumns)
 alb_direct  = fill!(DA{FT}(undef, nbnd_sw, ncolumns), FT(0.06))
 alb_diffuse = copy(alb_direct)
-bcs_sw = RRTMGP.BCs.SwBCs(cos_zenith, toa_flux, alb_direct, nothing, alb_diffuse)
+bcs_sw = RRTMGP.BCs.SwBCs(cos_zenith, toa_flux, alb_direct, nothing,
+                          alb_diffuse)
 ```
 
 The two `nothing` slots are prescribed incident fluxes at the top (longwave and
 diffuse shortwave), used for offline intercomparison cases; a host model
 normally leaves them off, so the top boundary sees only the direct solar beam.
-After construction, the host updates all of these through the getters —
-`cos_zenith(solver)`, `toa_flux(solver)`, `surface_emissivity(solver)`,
-`direct_sw_surface_albedo(solver)`, `diffuse_sw_surface_albedo(solver)` — as in
+After construction, the host updates all of these through the getters
+(`cos_zenith(solver)`, `toa_flux(solver)`, `surface_emissivity(solver)`,
+`direct_sw_surface_albedo(solver)`, `diffuse_sw_surface_albedo(solver)`) as in
 step 5, so a time-varying sun or a changing surface needs no reconstruction.
 
 ## 4. Construct the solver
@@ -106,7 +107,7 @@ solver = RRTMGP.RRTMGPSolver(
     grid_params, method, params, bcs_lw, bcs_sw, as;
     lookups,
     interpolation = RRTMGP.ArithmeticMean(),  # fill level values from layers
-    # center_z, face_z,                       # required for BestFit/HydrostaticBottom
+    # center_z, face_z,              # required for BestFit/HydrostaticBottom
     # deep_atmosphere_inverse_scaling,        # (nlev, ncol) metric factor
 )
 ```
@@ -119,8 +120,8 @@ z-based schemes need `center_z`/`face_z` at construction.
 
 ## 5. The radiation step
 
-Write the current model state through the getters (they are writable views
-into solver-owned device memory), then solve:
+Write the current model state through the getters (they are writable views into
+solver-owned device memory), then solve:
 
 ```julia
 RRTMGP.layer_temperature(solver) .= T_from_host
@@ -131,7 +132,8 @@ RRTMGP.cos_zenith(solver) .= μ₀
 RRTMGP.update_fluxes!(solver)   # allocation-free; returns nothing
 
 F_net = RRTMGP.net_flux(solver) # (nlev, ncol) domain-masked view
-hr    = RRTMGP.heating_rate(solver) # allocates; prefer net-flux divergence in hot loops
+# heating_rate allocates; prefer the net-flux divergence in inner loops
+hr    = RRTMGP.heating_rate(solver)
 ```
 
 `update_fluxes!` runs the full cascade: level interpolation, boundary-layer
@@ -139,24 +141,24 @@ fill, clipping to the lookup tables' valid range, column amounts, longwave and
 shortwave solves, and the combined net flux. To inspect the prepared state
 without solving, call [`prepare_atmosphere!`](@ref RRTMGP.prepare_atmosphere!).
 
-Two host responsibilities to remember (details in the
-[getter contract](../getters.md)):
+Two host responsibilities to remember (details in the [getter
+contract](../getters.md)):
 
 - **Relative humidity** feeds RH-dependent aerosol optics; update
   `layer_relative_humidity(solver)` (or call `compute_relative_humidity!`) if
   needed.
-- **Reading well-mixed gases** via `volume_mixing_ratio(solver, "co2")`
-  returns a host scalar; do this during setup.
+- **Reading well-mixed gases** via `volume_mixing_ratio(solver, "co2")` returns
+  a host scalar; do this during setup.
 
 ## 6. Per-band (spectral) fluxes
 
-The getters above return broadband fluxes. Components that need the spectral
-decomposition — an atmospheric-chemistry scheme whose photolysis rates depend
-on the ultraviolet and visible fluxes, or a land model that partitions the
+The getters above return broadband fluxes. Some components need the spectral
+decomposition: an atmospheric-chemistry scheme whose photolysis rates depend on
+the ultraviolet and visible fluxes, or a land model that partitions the
 radiation absorbed by a canopy into photosynthetically active (visible) and
-near-infrared bands — can have the solver retain per-band fluxes. Request them
-at construction and read them like the broadband getters, with the band as a
-third dimension:
+near-infrared bands. For these, the solver can retain per-band fluxes. Request
+them at construction and read them like the broadband getters, with the band as
+a third dimension:
 
 ```julia
 solver = RRTMGP.RRTMGPSolver(
@@ -167,15 +169,15 @@ solver = RRTMGP.RRTMGPSolver(
 RRTMGP.update_fluxes!(solver)
 
 F_sw = RRTMGP.spectral_sw_flux_dn(solver)    # (nlev, ncol, nbnd_sw) view
-wn = RRTMGP.sw_band_bounds(solver)           # (2, nbnd_sw) wavenumber edges [cm⁻¹]
+wn = RRTMGP.sw_band_bounds(solver)   # (2, nbnd_sw) wavenumber edges [cm⁻¹]
 ```
 
 The band edges from [`sw_band_bounds`](@ref RRTMGP.sw_band_bounds) /
 [`lw_band_bounds`](@ref RRTMGP.lw_band_bounds) identify each band's spectral
 interval, so the host can sum the surface downwelling flux over the bands its
-chemistry or canopy scheme needs. See
-[How to get per-band (spectral) fluxes](spectral_fluxes.md) for the full
-recipe and the supported configurations.
+chemistry or canopy scheme needs. See [How to get per-band (spectral)
+fluxes](spectral_fluxes.md) for the full recipe and the supported
+configurations.
 
 ## 7. Debugging: opt-in input validation
 
@@ -185,7 +187,7 @@ During development, enable range checks on every solve:
 RRTMGP.check_values[] = true   # validate_inputs runs inside update_fluxes!
 ```
 
-Out-of-range inputs (negative pressures, `cos_zenith` outside [-1, 1],
-albedos outside [0, 1], negative mixing ratios, NaNs) raise an error naming
-the offending field. The checks reduce over device arrays, so keep the toggle
-off in production to maintain peak performance.
+Out-of-range inputs (negative pressures, `cos_zenith` outside [-1, 1], albedos
+outside [0, 1], negative mixing ratios, NaNs) raise an error naming the
+offending field. The checks reduce over device arrays, so keep the toggle off in
+production to maintain peak performance.

--- a/docs/src/howto/host_model.md
+++ b/docs/src/howto/host_model.md
@@ -57,7 +57,8 @@ sessions.
 The host owns the [`AtmosphericState`](@ref
 RRTMGP.AtmosphericStates.AtmosphericState) (pressures, temperatures, mixing
 ratios, optional [`CloudState`](@ref RRTMGP.AtmosphericStates.CloudState) and
-[`AerosolState`](@ref RRTMGP.AtmosphericStates.AerosolState)) and the boundary
+[`AerosolState`](@ref RRTMGP.AtmosphericStates.AerosolState); see
+[How to add clouds and aerosols](clouds_aerosols.md)) and the boundary
 conditions ([`LwBCs`](@ref RRTMGP.BCs.LwBCs), [`SwBCs`](@ref RRTMGP.BCs.SwBCs)).
 All arrays live on the device described by `grid_params`, with the vertical
 dimension first and columns last. `test/read_all_sky_with_aerosols.jl` is a

--- a/docs/src/howto/host_model.md
+++ b/docs/src/howto/host_model.md
@@ -117,7 +117,9 @@ If your model provides level (face) pressures and temperatures directly, keep
 the default `interpolation = NoInterpolation()`. Otherwise pick an
 [`AbstractInterpolation`](@ref RRTMGP.AbstractInterpolation) and
 [`AbstractBottomExtrapolation`](@ref RRTMGP.AbstractBottomExtrapolation);
-z-based schemes need `center_z`/`face_z` at construction.
+z-based schemes need `center_z`/`face_z` at construction. The
+[Level interpolation](../interpolation.md) page derives the schemes and gives
+guidance on choosing one.
 
 ## 5. The radiation step
 

--- a/docs/src/howto/lookup_cache.md
+++ b/docs/src/howto/lookup_cache.md
@@ -15,7 +15,8 @@ solver (and to every [`solve`](@ref RRTMGP.solve) call):
 using RRTMGP, NCDatasets
 
 lookups = RRTMGP.lookup_tables(grid_params, method)
-solver_a = RRTMGP.RRTMGPSolver(grid_params, method, params, bcs_lw, bcs_sw, as_a; lookups)
+solver_a = RRTMGP.RRTMGPSolver(grid_params, method, params, bcs_lw, bcs_sw,
+                               as_a; lookups)
 out = RRTMGP.solve(profile; lookups)
 ```
 
@@ -40,4 +41,4 @@ out = RRTMGP.solve(profile; lookups)
 !!! warning "A cache, not an interchange format"
     The file uses Julia's `Serialization` stdlib and is tied to the Julia
     version and package layout that wrote it. Regenerate it when environments
-    change; the NetCDF artifacts remain the source of truth.
+    change; the NetCDF artifacts remain the authoritative data.

--- a/docs/src/howto/spectral_fluxes.md
+++ b/docs/src/howto/spectral_fluxes.md
@@ -1,12 +1,12 @@
 # How to get per-band (spectral) fluxes
 
-By default, RRTMGP retains only broadband fluxes. For applications that need
-the spectral decomposition, the solver can retain per-band fluxes. Examples
-include atmospheric chemistry, where photolysis rates depend on the
-ultraviolet and visible fluxes; land models, where the radiation a canopy
-absorbs divides into photosynthetically active (visible) and near-infrared
-bands with very different vegetation albedos; band-by-band forcing
-diagnostics; and satellite-channel proxies.
+By default, RRTMGP retains only broadband fluxes. For applications that need the
+spectral decomposition, the solver can retain per-band fluxes. Examples include
+atmospheric chemistry, where photolysis rates depend on the ultraviolet and
+visible fluxes; land models, where the radiation a canopy absorbs divides into
+photosynthetically active (visible) and near-infrared bands with very different
+vegetation albedos; band-by-band forcing diagnostics; and satellite-channel
+proxies.
 
 ## Request per-band fluxes at construction
 
@@ -19,8 +19,8 @@ solver = RRTMGP.RRTMGPSolver(
 RRTMGP.update_fluxes!(solver)
 ```
 
-This is supported for the spectral (non-gray) methods with two-stream optics
-in both bands; other configurations raise an informative error at
+This is supported for the spectral (non-gray) methods with two-stream optics in
+both the longwave and the shortwave; other configurations raise an error at
 construction. The per-band buffers add `(nlev, ncol, n_bnd)` arrays per band
 set, so they are opt-in.
 
@@ -43,14 +43,14 @@ buffer, updated on every solve like the `up`/`dn` buffers.
 
 ## Identify the bands
 
-[`lw_band_bounds`](@ref RRTMGP.lw_band_bounds) and
-[`sw_band_bounds`](@ref RRTMGP.sw_band_bounds) return the `(2, n_bnd)`
-wavenumber edges (cm⁻¹) of each band:
+[`lw_band_bounds`](@ref RRTMGP.lw_band_bounds) and [`sw_band_bounds`](@ref
+RRTMGP.sw_band_bounds) return the `(2, n_bnd)` wavenumber edges (cm⁻¹) of each
+band:
 
 ```julia
 wn = RRTMGP.lw_band_bounds(solver)
 wn[:, 1]   # lower/upper wavenumber of longwave band 1
 ```
 
-The RRTMGP longwave tables have 16 bands and the shortwave tables 14,
-following [pincus2019](@citet).
+The RRTMGP longwave tables have 16 bands and the shortwave tables 14, following
+[pincus2019](@citet).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,27 +1,29 @@
 # RRTMGP.jl
 
 RRTMGP.jl is a Julia implementation of the radiative transfer solver RTE
-(Radiative Transfer for Energetics) and the RRTMGP (RRTM for General
-circulation model applications—Parallel) correlated-``k`` gas optics
-([pincus2019](@citet)), based on the reference Fortran implementation
-[rte-rrtmgp](https://github.com/earth-system-radiation/rte-rrtmgp). It
-computes longwave and shortwave fluxes and heating rates for clear, cloudy,
-and aerosol-laden atmospheres, as well as an analytic gray-radiation mode for
-idealized studies, on CPUs and GPUs. It is the radiation scheme of the
+(Radiative Transfer for Energetics) and the RRTMGP (RRTM for General circulation
+model applications—Parallel) correlated-``k`` gas optics ([pincus2019](@citet)),
+based on the reference Fortran implementation
+[rte-rrtmgp](https://github.com/earth-system-radiation/rte-rrtmgp). It computes
+longwave and shortwave fluxes and heating rates for clear, cloudy, and
+aerosol-laden atmospheres on CPUs and GPUs, and it includes an analytic
+gray-radiation mode for idealized studies. It is the radiation scheme of the
 [CliMA](https://clima.caltech.edu/) Earth System Model.
 
 ## Quick start
 
-Build an idealized atmospheric column, then solve it: gray radiation uses
-analytic formulas and needs no input data, while the full gas optics loads
-NCDatasets to download and parse the lookup tables:
+Build an idealized atmospheric column, then solve it. Gray radiation uses
+analytic formulas and needs no input data:
 
 ```@example index
 using RRTMGP
 profile = RRTMGP.standard_atmosphere(Float64; kind = :tropical)
 out = RRTMGP.solve(profile; method = RRTMGP.GrayRadiation())  # gray optics
-out.heating_rate[1, 1]                          # heating rate at bottom layer [K/s]
+out.heating_rate[1, 1]                # heating rate at bottom layer [K/s]
 ```
+
+The full gas optics reads lookup tables, downloaded on first use; loading
+NCDatasets activates it:
 
 ```@example index
 using NCDatasets                                # activates the gas optics
@@ -33,42 +35,40 @@ out.lw_up[end, 1]                                # OLR [W/m²]
 
 RRTMGP is split into two parts:
 
-- **Optics** computes optical properties and source functions given
-  atmospheric conditions (pressure, temperature, gas concentrations, clouds,
-  aerosols).
+- **Optics** computes optical properties and source functions given atmospheric
+  conditions (pressure, temperature, gas concentrations, clouds, aerosols).
 - **RTE** computes radiative fluxes given optical properties and source
   functions.
 
-On top of this functional core sits the [`RRTMGPSolver`](@ref RRTMGP.RRTMGPSolver),
-which host models drive through the [getter contract](getters.md), and a standalone
-front door (`solve_gray`, `standard_atmosphere`, `solve`) for single-column work.
+On top of this functional core sit the [`RRTMGPSolver`](@ref
+RRTMGP.RRTMGPSolver), which host models drive through the [getter
+contract](getters.md), and standalone entry points (`solve_gray`,
+`standard_atmosphere`, `solve`) for single-column work.
 
 ## How the documentation is organized
 
-- **Tutorials** (learning-oriented, runnable end to end):
-  [A first radiation calculation](tutorials/getting_started.md) and
-  [Radiative-convective equilibrium](tutorials/manabe_rce.md) (Manabe's
-  classic climate-sensitivity experiment). Start here if you want to learn
-  about radiative transfer and how to run this code.
-- **How-to guides** (task-oriented recipes):
-  [driving RRTMGP from a host model](howto/host_model.md),
-  [running on GPUs](howto/gpu.md),
-  [caching the lookup tables](howto/lookup_cache.md),
-  [per-band fluxes](howto/spectral_fluxes.md), and
-  [the validated test problems](Example.md). Start here if you are wiring
-  RRTMGP into a climate model.
-- **Explanation** (the concepts and the math):
-  [the functional core](functional_core.md), the [RTE solvers](RTE.md), the
-  [optics](Optics.md), and the
-  [Fortran and paper concordance](concordance.md) for readers coming from
-  rte-rrtmgp.
-- **Reference**: the [API](api.md) and the [getter contract](getters.md).
+- **Tutorials** (learning-oriented, runnable end to end): [A first radiation
+  calculation](tutorials/getting_started.md) and [Radiative-convective
+  equilibrium](tutorials/manabe_rce.md) (Manabe's classic climate-sensitivity
+  experiment). Start here if you want to learn about radiative transfer and how
+  to run this code.
+- **How-to guides** (task-oriented recipes): [driving RRTMGP from a host
+  model](howto/host_model.md), [running on GPUs](howto/gpu.md), [caching the
+  lookup tables](howto/lookup_cache.md), [per-band
+  fluxes](howto/spectral_fluxes.md), and [the validated test
+  problems](Example.md). Start here if you are coupling RRTMGP to a climate
+  model.
+- **Explanation** (the concepts and the math): [the functional
+  core](functional_core.md), the [RTE solvers](RTE.md), the [optics](Optics.md),
+  [Float32 and Float64](precision.md), and the [Fortran and paper
+  concordance](concordance.md) for readers coming from rte-rrtmgp.
+- **Reference**: the [API](api.md), the [getter contract](getters.md), and
+  per-module reference pages.
 
 ## Authors
 
-`RRTMGP.jl` is being developed by the
-[Climate Modeling Alliance](https://clima.caltech.edu/). It is based on
-RTE+RRTMGP and its reference
-[Fortran implementation](https://github.com/earth-system-radiation/rte-rrtmgp),
-developed by Robert Pincus, Eli Mlawer, and Jennifer Delamere
-([pincus2019](@citet)).
+`RRTMGP.jl` is developed by the [Climate Modeling
+Alliance](https://clima.caltech.edu/). It is based on RTE+RRTMGP and its
+reference [Fortran
+implementation](https://github.com/earth-system-radiation/rte-rrtmgp), developed
+by Robert Pincus, Eli Mlawer, and Jennifer Delamere ([pincus2019](@citet)).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -61,6 +61,7 @@ contract](getters.md), and standalone entry points (`solve_gray`,
   model.
 - **Explanation** (the concepts and the math): [the functional
   core](functional_core.md), the [RTE solvers](RTE.md), the [optics](Optics.md),
+  [level interpolation](interpolation.md),
   [Float32 and Float64](precision.md), and the [Fortran and paper
   concordance](concordance.md) for readers coming from rte-rrtmgp.
 - **Reference**: the [API](api.md), the [getter contract](getters.md), and

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,8 +53,9 @@ contract](getters.md), and standalone entry points (`solve_gray`,
   experiment). Start here if you want to learn about radiative transfer and how
   to run this code.
 - **How-to guides** (task-oriented recipes): [driving RRTMGP from a host
-  model](howto/host_model.md), [running on GPUs](howto/gpu.md), [caching the
-  lookup tables](howto/lookup_cache.md), [per-band
+  model](howto/host_model.md), [adding clouds and
+  aerosols](howto/clouds_aerosols.md), [running on GPUs](howto/gpu.md),
+  [caching the lookup tables](howto/lookup_cache.md), [per-band
   fluxes](howto/spectral_fluxes.md), and [the validated test
   problems](Example.md). Start here if you are coupling RRTMGP to a climate
   model.

--- a/docs/src/interpolation.md
+++ b/docs/src/interpolation.md
@@ -56,7 +56,7 @@ For a face between the adjacent layer centers ``(p_1, T_1)`` (below) and
 ``(p_2, T_2)`` (above):
 
 | Scheme | Assumption | Face values |
-|:-------|:-----------|:------------|
+| :------- | :----------- | :------------ |
 | `NoInterpolation` | levels are supplied by the host | none computed (default) |
 | `ArithmeticMean` | none | ``T = (T_1 + T_2)/2``, ``p = (p_1 + p_2)/2`` |
 | `GeometricMean` | face midway in ``\ln p`` | ``T = \sqrt{T_1 T_2}``, ``p = \sqrt{p_1 p_2}`` |
@@ -78,10 +78,17 @@ at construction.
 
 At the top and bottom of the column, the face lies outside the layer centers
 and the schemes extrapolate instead. With ``(p^+, T^+)`` the nearest layer and
-``(p^{++}, T^{++})`` the next one in, `ArithmeticMean` and `UniformZ`
-extrapolate the temperature linearly, ``T = (3T^+ - T^{++})/2``, and
-`GeometricMean` and `UniformP` do the same in logarithms; each scheme then
-completes the ``(p, T)`` pair the same way as in its interior rule.
+``(p^{++}, T^{++})`` the next one in, each scheme extrapolates whichever of the
+two variables it averages in the interior, then completes the ``(p, T)`` pair
+by its interior rule:
+
+| Scheme | Extrapolated variable | Face value |
+| :------- | :---------------------- | :----------- |
+| `ArithmeticMean` | both, linearly | ``T = (3T^+ - T^{++})/2``, ``p = (3p^+ - p^{++})/2`` |
+| `GeometricMean` | both, in logarithms | ``T = \sqrt{(T^+)^3/T^{++}}``, ``p = \sqrt{(p^+)^3/p^{++}}`` |
+| `UniformZ` | temperature, linearly | ``T = (3T^+ - T^{++})/2``, ``p = p(T)`` from the power law |
+| `UniformP` | pressure, linearly | ``p = (3p^+ - p^{++})/2``, ``T = p^{-1}(p)`` by inverting the power law |
+| `BestFit` | temperature, linearly in ``z`` | ``T(z)`` at the true face altitude, ``p = p(T)`` from the power law |
 
 The bottom face can instead be tied to the ground through
 `bottom_extrapolation`:

--- a/docs/src/interpolation.md
+++ b/docs/src/interpolation.md
@@ -8,9 +8,12 @@ and `bottom_extrapolation` options of [`RRTMGPSolver`](@ref
 RRTMGP.RRTMGPSolver) and [`solve`](@ref RRTMGP.solve) select a scheme, and
 [`interpolate_levels!`](@ref RRTMGP.interpolate_levels!) applies it inside
 every [`update_fluxes!`](@ref RRTMGP.update_fluxes!) call, so a driver that
-marches the layer temperatures keeps consistent faces automatically (the
-[radiative-convective equilibrium tutorial](tutorials/manabe_rce.md) works
-this way). This page derives the schemes and gives guidance on choosing one.
+marches the layer temperatures keeps consistent faces automatically. A driver
+can also march the level temperatures and fill the layers itself, keeping the
+default `NoInterpolation`; the
+[radiative-convective equilibrium tutorial](tutorials/manabe_rce.md) does
+this to suppress a computational mode of layer marching. This page derives
+the schemes and gives guidance on choosing one.
 
 ## The underlying model
 

--- a/docs/src/interpolation.md
+++ b/docs/src/interpolation.md
@@ -1,0 +1,125 @@
+# Level interpolation and extrapolation
+
+The RTE solvers need pressures and temperatures both at layer centers, where
+the optical properties are computed, and at the level faces, where the fluxes
+are defined and the longwave source varies. A host that carries only
+layer-center values asks RRTMGP to reconstruct the faces: the `interpolation`
+and `bottom_extrapolation` options of [`RRTMGPSolver`](@ref
+RRTMGP.RRTMGPSolver) and [`solve`](@ref RRTMGP.solve) select a scheme, and
+[`interpolate_levels!`](@ref RRTMGP.interpolate_levels!) applies it inside
+every [`update_fluxes!`](@ref RRTMGP.update_fluxes!) call, so a driver that
+marches the layer temperatures keeps consistent faces automatically (the
+[radiative-convective equilibrium tutorial](tutorials/manabe_rce.md) works
+this way). This page derives the schemes and gives guidance on choosing one.
+
+## The underlying model
+
+Every scheme treats the atmosphere between two known points ``(p_1, T_1)`` and
+``(p_2, T_2)`` (two layer centers, or a layer center and the surface) as a
+hydrostatic ideal-gas column with a constant lapse rate, so the temperature is
+linear in height:
+
+```math
+T(z) = T_1 + \frac{T_2 - T_1}{z_2 - z_1}\,(z - z_1).
+```
+
+Hydrostatic balance, ``dp/p = -g\,dz/(R_d T)``, integrates under this linear
+``T(z)`` to a power law between pressure and temperature,
+
+```math
+p(T) = p_1 \left(\frac{T}{T_1}\right)^{B},
+\qquad
+B = \frac{\ln(p_2/p_1)}{\ln(T_2/T_1)},
+```
+
+where requiring the curve to pass through both endpoints fixes the exponent
+``B`` without knowing ``g``, ``R_d``, or the lapse rate individually. In the
+isothermal limit ``T_1 = T_2``, the power law degenerates and the pressure
+instead decays exponentially with height,
+``p(z) = p_1\, e^{-(z - z_1)/H}`` with scale height ``H = R_d T_1 / g``.
+Fitting the two endpoints eliminates ``H`` and gives the form used in the
+code,
+
+```math
+p(z) = p_1 \left(\frac{p_2}{p_1}\right)^{(z - z_1)/(z_2 - z_1)},
+```
+
+which is the same exponential: the base ``p_2/p_1`` is constant and the
+exponent is linear in ``z``.
+
+The schemes differ only in what they assume about where the face lies between
+the two layer centers, and in whether they use the true face altitude.
+
+## Interior faces
+
+For a face between the adjacent layer centers ``(p_1, T_1)`` (below) and
+``(p_2, T_2)`` (above):
+
+| Scheme | Assumption | Face values |
+|:-------|:-----------|:------------|
+| `NoInterpolation` | levels are supplied by the host | none computed (default) |
+| `ArithmeticMean` | none | ``T = (T_1 + T_2)/2``, ``p = (p_1 + p_2)/2`` |
+| `GeometricMean` | face midway in ``\ln p`` | ``T = \sqrt{T_1 T_2}``, ``p = \sqrt{p_1 p_2}`` |
+| `UniformZ` | face midway in height | ``T = (T_1 + T_2)/2``, ``p = p(T)`` from the power law |
+| `UniformP` | face midway in pressure | ``p = (p_1 + p_2)/2``, ``T = p^{-1}(p)`` by inverting the power law |
+| `BestFit` | face at its true altitude ``z`` | ``T(z)`` from the linear profile, ``p = p(T)`` from the power law |
+
+`ArithmeticMean` averages pressure and temperature independently; the pair is
+not exactly hydrostatic, but the scheme is the simplest and needs no
+assumptions. The other schemes place the face on the constant-lapse-rate
+curve, so their ``(p, T)`` pairs are hydrostatically consistent: under the
+power law, ``\ln T`` is linear in ``\ln p``, so the geometric means of
+`GeometricMean` are exactly the power-law state at the log-pressure midpoint.
+`BestFit` is the only interior scheme that uses the actual face position
+rather than assuming one; it requires the altitudes `center_z` and `face_z`
+at construction.
+
+## Boundary faces
+
+At the top and bottom of the column, the face lies outside the layer centers
+and the schemes extrapolate instead. With ``(p^+, T^+)`` the nearest layer and
+``(p^{++}, T^{++})`` the next one in, `ArithmeticMean` and `UniformZ`
+extrapolate the temperature linearly, ``T = (3T^+ - T^{++})/2``, and
+`GeometricMean` and `UniformP` do the same in logarithms; each scheme then
+completes the ``(p, T)`` pair the same way as in its interior rule.
+
+The bottom face can instead be tied to the ground through
+`bottom_extrapolation`:
+
+- `SameAsInterpolation` (default): extrapolate like any boundary face. The
+  bottom-face air temperature is then set by the atmosphere alone and may
+  differ from the ground temperature, which enters separately through the
+  surface-emission boundary condition. This difference is physical: pure
+  radiative equilibrium produces air at the surface colder than the ground
+  beneath it (see the
+  [radiative-convective equilibrium tutorial](tutorials/manabe_rce.md)).
+- `UseSurfaceTempAtBottom`: set the bottom-face air temperature to the ground
+  temperature ``T_s``, the limit of strong turbulent heat exchange at the
+  surface. The pressure follows the dry isentrope through the first layer,
+  ``p = p^+ (T_s/T^+)^{c_p/R_d}``.
+- `HydrostaticBottom`: extend the first layer downward at the dry-adiabatic
+  lapse rate, ``T = T^+ + (g/c_p)(z^+ - z)``, with the same isentropic
+  pressure; requires altitudes.
+
+## Choosing a scheme
+
+- **The host has level values**: keep the default `NoInterpolation` and write
+  them through the getters.
+- **Layer centers only, no altitudes**: `ArithmeticMean` is the simplest
+  choice and adequate for smooth profiles. Use `GeometricMean`, `UniformZ`,
+  or `UniformP` when hydrostatically consistent face pairs matter; they
+  differ only in the assumed face position, and the differences shrink with
+  layer thickness.
+- **Layer centers and altitudes**: `BestFit` places each face where it
+  actually is and is the most accurate of the schemes.
+- **Bottom face**: keep the default when the air-ground temperature
+  difference matters (radiative equilibrium, weak surface coupling); use
+  `UseSurfaceTempAtBottom` to remove it (strong surface coupling);
+  `HydrostaticBottom` extends the column dry-adiabatically when altitudes are
+  available.
+
+The interpolation runs on the device inside `update_fluxes!` on every call;
+[`interpolate_levels!`](@ref RRTMGP.interpolate_levels!) can also be called on
+its own. See [`AbstractInterpolation`](@ref RRTMGP.AbstractInterpolation) and
+[`AbstractBottomExtrapolation`](@ref RRTMGP.AbstractBottomExtrapolation) for
+the type reference.

--- a/docs/src/precision.md
+++ b/docs/src/precision.md
@@ -1,48 +1,48 @@
 # Float32 and Float64
 
 Every RRTMGP.jl kernel is generic in the working precision: the float type
-chosen at construction (through [`RRTMGPGridParams`](@ref RRTMGP.RRTMGPGridParams),
-[`solve`](@ref RRTMGP.solve), or [`solve_gray`](@ref RRTMGP.solve_gray)) flows
-through the lookup tables, the optics, and the RTE solve. `Float64` is the
-reference; `Float32` halves the memory traffic of the bandwidth-bound kernels
-and is the precision at which the CliMA atmosphere runs radiation on GPUs.
+chosen at construction (through [`RRTMGPGridParams`](@ref
+RRTMGP.RRTMGPGridParams), [`solve`](@ref RRTMGP.solve), or [`solve_gray`](@ref
+RRTMGP.solve_gray)) flows through the lookup tables, the optics, and the RTE
+solve. `Float64` is the reference; `Float32` halves the memory traffic of the
+bandwidth-bound kernels and is the precision at which the CliMA atmosphere runs
+radiation on GPUs.
 
 ## Accuracy achieved at Float32
 
-A consistency harness (`test/float32_consistency.jl`) solves the same gray,
+A consistency test (`test/float32_consistency.jl`) solves the same gray,
 clear-sky, and cloudy problems at both precisions, with the `Float32` states
-rounded from the `Float64` ones, and pins the end-to-end difference — input
-rounding, gas and cloud optics, and the RTE solve together. The measured
-maximum broadband flux differences are:
+rounded from the `Float64` ones, and measures the end-to-end difference: input
+rounding, gas and cloud optics, and the RTE solve together. The measured maximum
+broadband flux differences are:
 
-- every longwave path sits at its interpolation-noise floor of about
-  2–5 × 10⁻⁴ W/m², roughly 25–90 times better than before the
-  single-precision program described below;
-- shortwave differences are about 1–2 × 10⁻² W/m² in clear skies and about
-  5 × 10⁻² W/m² with clouds. These were verified to be per-g-point
-  interpolation and coefficient noise rather than accumulation error:
-  repeating the runs with full `Float64` broadband accumulation left them
-  unchanged, so compensated summation was deliberately not added.
+- every longwave path is at its interpolation-noise floor of about 2–5 × 10⁻⁴
+  W/m², 25–90 times smaller than before the single-precision measures described
+  below;
+- shortwave differences are about 1–2 × 10⁻² W/m² in clear skies and about 5 ×
+  10⁻² W/m² with clouds. These were verified to be per-g-point interpolation and
+  coefficient noise rather than accumulation error: repeating the runs with full
+  `Float64` broadband accumulation left them unchanged, so compensated summation
+  was deliberately not added.
 
 For scale, these differences are orders of magnitude below both typical flux
 magnitudes (hundreds of W/m²) and the accuracy of the correlated-``k``
 approximation itself; the Fortran reference (rte-rrtmgp) accepts an absolute
-flux error of 0.35 W/m² in its own validation. CI locks them in with ratcheting thresholds
-(gray 10⁻³ W/m² and 10⁻⁸ K/s for the heating rate; longwave 10⁻³ W/m²;
-shortwave 3 × 10⁻² clear and 1.2 × 10⁻¹ W/m² cloudy) that are tightened as
-numerics fixes land and never loosened. The reference comparisons against the
-official rte-rrtmgp results also run at both precisions.
+flux error of 0.35 W/m² in its own validation. CI enforces ratcheting thresholds
+(gray 10⁻³ W/m² and 10⁻⁸ K/s for the heating rate; longwave 10⁻³ W/m²; shortwave
+3 × 10⁻² clear and 1.2 × 10⁻¹ W/m² cloudy) that are tightened as numerics fixes
+land and never loosened. The comparisons against the rte-rrtmgp reference
+results also run at both precisions.
 
 ## How: the single-precision numerics
 
 The `Float32` accuracy rests on evaluating exact reformulations instead of
 cancellation-prone ones, and on switching to series expansions where
-cancellation is unavoidable. The measures, roughly in the order radiation
-flows:
+cancellation is unavoidable. The measures, roughly in the order radiation flows:
 
 - **Gas optics.** The interpolation fraction in the binary species parameter
   ``η`` is computed relative to its clamped table cell, so it stays continuous
-  at ``η = 1`` — a value `Float32` rounds to far more often than `Float64`.
+  at ``η = 1``, a value `Float32` rounds to more often than `Float64`.
 - **Longwave, no scattering.** The linear-in-``τ`` source factor
   ``(1 - t)/\tau - t`` ([clough1992](@citet), Eq. 13) loses
   ``\sim\!\mathrm{eps}/\tau^2`` to cancellation for thin layers; it switches to
@@ -50,29 +50,27 @@ flows:
   curves cross.
 - **Two-stream coefficients.** The diffusion eigenvalue
   ``k = \sqrt{(\gamma_1-\gamma_2)(\gamma_1+\gamma_2)}`` uses exact
-  ``\gamma_1 - \gamma_2`` identities rather than subtracting near-equal
-  numbers, with ``k^2`` floored at ``\sqrt{\mathrm{eps}}``; thin-layer factors
+  ``\gamma_1 - \gamma_2`` identities rather than subtracting near-equal numbers,
+  with ``k^2`` floored at ``\sqrt{\mathrm{eps}}``; thin-layer factors
   ``1 - e^{-k\tau}`` are evaluated with `expm1`.
 - **Longwave two-stream source.** The [toon1989](@citet) source terms are
   factored so that no term divides by ``\tau`` and no small difference of
-  near-equal quantities appears (exact ``1 \mp R_{\mathrm{dif}} -
-  T_{\mathrm{dif}}`` factorizations).
+  near-equal quantities appears (exact
+  ``1 \mp R_{\mathrm{dif}} - T_{\mathrm{dif}}`` factorizations).
 - **Shortwave direct beam.** The direct reflectance and transmittance of
   [meador1980](@citet) (Eqs. 14–15) have a removable singularity at
   ``k\mu_0 = 1``; ``k\mu_0`` is nudged off resonance symmetrically within a
   ``\sqrt{\mathrm{eps}}`` window, keeping numerator and denominator mutually
   consistent. An energy-conservation clamp then bounds the direct reflectance
-  and transmittance by the energy the unscattered beam leaves behind,
-  following [ukkonen2024](@citet); and the direct-beam profile itself is built
-  by accumulating optical depth downward rather than by repeated
-  multiplication.
+  and transmittance by the energy the unscattered beam leaves behind, following
+  [ukkonen2024](@citet); and the direct-beam profile itself is built by
+  accumulating optical depth downward rather than by repeated multiplication.
 - **Delta scaling.** The ``f = g^2`` similarity scaling of cloud and aerosol
-  optics ([joseph1976](@citet)) is evaluated in exact, non-cancelling forms
-  (for example ``g' = g/(1+g)`` instead of ``(g - g^2)/(1 - g^2)``).
+  optics ([joseph1976](@citet)) is evaluated in exact, non-cancelling forms (for
+  example ``g' = g/(1+g)`` instead of ``(g - g^2)/(1 - g^2)``).
 
 All the guard constants involved (`k_min`, `τ_thresh`, `resonance_window`,
-`μ₀_min`) live in the `RRTMGP.Numerics` module, each with the derivation of
-its value, and all scale with `eps(FT)` — so the kernels behave consistently
-at either precision, and the same policy would extend to other float types.
-Where a threshold matches the Fortran reference (rte-rrtmgp), the docstring
-says so.
+`μ₀_min`) live in the `RRTMGP.Numerics` module, each with the derivation of its
+value, and all scale with `eps(FT)`, so the kernels behave consistently at
+either precision, and the same policy would extend to other float types. Where a
+threshold matches the Fortran reference (rte-rrtmgp), the docstring says so.

--- a/docs/tutorials/getting_started.jl
+++ b/docs/tutorials/getting_started.jl
@@ -1,8 +1,8 @@
 # # A first radiation calculation
 #
-# This tutorial computes radiative fluxes and heating rates with RRTMGP.jl in
-# a few lines, first for a gray (single-band) atmosphere and then with the
-# full RRTMGP correlated-``k`` gas optics. The gray model is analytic, and the
+# This tutorial computes radiative fluxes and heating rates with RRTMGP.jl in a
+# few lines, first for a gray (single-band) atmosphere and then with the full
+# RRTMGP correlated-``k`` gas optics. The gray model is analytic, and the
 # gas-optics lookup tables download automatically.
 
 using RRTMGP
@@ -12,44 +12,45 @@ using CairoMakie
 #
 # Radiation needs an atmospheric state to act on: temperatures, pressures, and
 # composition. Each [`standard_atmosphere`](@ref RRTMGP.standard_atmosphere) is
-# an analytic clear-sky column, loosely following the Air Force Geophysics Laboratory
-# reference climatology ([anderson1986](@citet)): a two-segment temperature profile
-# with constant tropospheric lapse rate up to the tropopause, then a warming
-# stratosphere, hydrostatic pressure, water vapor decaying exponentially from
-# the surface with a floor in the stratosphere, an ozone layer peaked near
-# 30 km, and present-day well-mixed gases (CO₂, CH₄, N₂O, …). The three
-# `kind`s — `:tropical`, `:midlatitude_summer`, and `:subarctic_winter` —
-# differ in surface temperature, tropopause height, and moisture, from warm and
-# moist to cold and dry. It needs no input data:
+# an analytic clear-sky column, loosely following the Air Force Geophysics
+# Laboratory reference climatology ([anderson1986](@citet)): a two-segment
+# temperature profile with constant tropospheric lapse rate up to the
+# tropopause, then a warming stratosphere, hydrostatic pressure, water vapor
+# decaying exponentially from the surface with a floor in the stratosphere, an
+# ozone layer peaked near 30 km, and present-day well-mixed gases (CO₂, CH₄,
+# N₂O, …). The three `kind`s (`:tropical`, `:midlatitude_summer`, and
+# `:subarctic_winter`) differ in surface temperature, tropopause height, and
+# moisture, from warm and moist to cold and dry. Building a profile needs no
+# input data:
 
 profile = RRTMGP.standard_atmosphere(Float64; kind = :tropical, nlay = 60);
 
 # ## Gray radiation
 #
 # The gray atmosphere replaces the full spectral dependence of gas optics by a
-# single prescribed longwave optical-thickness profile, the workhorse of
+# single prescribed longwave optical-thickness profile; it is widely used in
 # idealized-climate studies. RRTMGP's default follows [frierson2006](@citet) and
-# [ogorman2008](@citet): the
-# vertical longwave optical depth blends a linear and a quartic dependence on the
-# normalized pressure ``σ = p/p_s``,
+# [ogorman2008](@citet): the vertical longwave optical depth blends a linear and
+# a quartic dependence on the normalized pressure ``σ = p/p_s``,
 # ```math
-# \widehat{\tau}(σ) \propto f_\ell\,σ + (1 - f_\ell)\,σ^4,
+# \widehat{\tau}(σ) \propto f_\ell\,σ + (1 - f_\ell)\,σ^4.
 # ```
-# so it stays finite aloft and thickens toward the surface. Because the gray
+# The quartic term concentrates the absorption near the surface, as for water
+# vapor; the linear term retains some absorption aloft. Because the gray
 # equations are analytically tractable, the semi-gray column also has a
-# closed-form radiative-equilibrium solution, ``T(\widehat{\tau}) = T_e\,[(1 +
-# D\widehat{\tau})/2]^{1/4}`` with diffusivity factor ``D``; RRTMGP's test suite
-# integrates the gray longwave solver to equilibrium and checks the computed
-# temperatures against the analytic radiative-equilibrium balance ``\sigma T^4 =
-# (F^\uparrow + F^\downarrow)/2``. Solving the column with gray optics takes one
-# call (no lookup tables are needed; the temperatures are the profile's):
+# closed-form radiative-equilibrium solution,
+# ``T(\widehat{\tau}) = T_e\,[(1 + D\widehat{\tau})/2]^{1/4}`` with diffusivity
+# factor ``D``; RRTMGP's test suite integrates the gray longwave solver to
+# equilibrium and checks the computed temperatures against the analytic
+# radiative-equilibrium balance ``\sigma T^4 = (F^\uparrow + F^\downarrow)/2``.
+# Solving the column with gray optics takes one call; no lookup tables are
+# needed, and the profile's temperatures are used as given:
 
 out = RRTMGP.solve(profile; method = RRTMGP.GrayRadiation());
 
-# The result is a [`RadiationOutput`](@ref RRTMGP.RadiationOutput) whose
-# fields are `(nlev, ncol)` fluxes in W/m² plus the heating rate in K/s.
-# Plot the longwave and shortwave net fluxes and the heating rate against
-# pressure:
+# The result is a [`RadiationOutput`](@ref RRTMGP.RadiationOutput) whose fields
+# are `(nlev, ncol)` fluxes in W/m² plus the heating rate in K/s. Plot the
+# longwave and shortwave net fluxes and the heating rate against pressure:
 
 p_lev = Array(RRTMGP.level_pressure(out.solver)) ./ 100  # [hPa]
 p_lay = Array(RRTMGP.layer_pressure(out.solver)) ./ 100
@@ -78,11 +79,11 @@ fig
 # ## Configuring the gray optical depth
 #
 # The optical-thickness model is a keyword argument. The [schneider2004](@citet)
-# form exposes a single pressure exponent ``α`` through ``\widehat{\tau}(p) = d_0\,
-# (p/p_s)^α``, which controls how the absorber is distributed with height:
-# ``α = 1`` for a well-mixed absorber (constant mixing ratio, no pressure
-# broadening), larger ``α`` for one concentrated near the surface. Change it in
-# one line:
+# form exposes a single pressure exponent ``α`` through
+# ``\widehat{\tau}(p) = d_0\, (p/p_s)^α``, which controls how the absorber is
+# distributed with height: ``α = 1`` for a well-mixed absorber (constant mixing
+# ratio, no pressure broadening), larger ``α`` for one concentrated near the
+# surface. Change it in one line:
 
 using RRTMGP.AtmosphericStates: GrayOpticalThicknessSchneider2004
 
@@ -94,28 +95,28 @@ out_wellmixed = RRTMGP.solve(
 println("surface net flux, α = 1: ",
         round(Array(out_wellmixed.net)[1, 1]; digits = 1), " W/m²")
 
-# ([`solve_gray`](@ref RRTMGP.solve_gray) is a related one-liner that builds an
-# analytic, latitude-dependent gray column internally instead of taking a
-# profile.)
+# ([`solve_gray`](@ref RRTMGP.solve_gray) is a related single-call entry point
+# that builds an analytic, latitude-dependent gray column internally instead of
+# taking a profile.)
 
-# The longwave net flux converges toward the outgoing longwave radiation at
-# the top; the corresponding heating rate is the radiative cooling that
+# At the top of the atmosphere, the longwave net flux equals the outgoing
+# longwave radiation; the heating rate below it is the radiative cooling that
 # convection balances in the troposphere.
 #
 # ## Clear-sky gas optics
 #
-# For the real gas optics, load NCDatasets (which activates RRTMGP's
-# lookup-table support, downloading the tables on first use) and solve the
-# same column with the full correlated-``k`` treatment:
+# For the full gas optics, load NCDatasets (which activates RRTMGP's
+# lookup-table support, downloading the tables on first use) and solve the same
+# column with the full correlated-``k`` treatment:
 
 using NCDatasets
 
 out_cs = RRTMGP.solve(profile);
 
 # `out_cs.solver.lookups` holds the parsed lookup tables; pass them back via
-# `solve(profile; lookups)` to skip the NetCDF read when solving many
-# profiles. The outgoing longwave radiation (OLR) is the upwelling longwave
-# flux at the top level:
+# `solve(profile; lookups)` to skip the NetCDF read when solving many profiles.
+# The outgoing longwave radiation (OLR) is the upwelling longwave flux at the
+# top level:
 
 olr(kind, lookups) = Array(
     RRTMGP.solve(
@@ -134,10 +135,9 @@ end
 #
 # ## The effect of doubling CO₂
 #
-# Because the profile carries its well-mixed gases as a dictionary, changing
-# the CO₂ concentration is one line. Comparing the OLR at fixed temperature
-# quantifies the *instantaneous radiative forcing* at the top of the
-# atmosphere:
+# Because the profile carries its well-mixed gases as a dictionary, changing the
+# CO₂ concentration is one line. Comparing the OLR at fixed temperature
+# quantifies the *instantaneous radiative forcing* at the top of the atmosphere:
 
 profile_2x = RRTMGP.standard_atmosphere(Float64; kind = :tropical, nlay = 60)
 profile_2x.well_mixed_vmr["co2"] = 2 * profile.well_mixed_vmr["co2"]
@@ -147,10 +147,10 @@ out_2x = RRTMGP.solve(profile_2x; lookups)
 println("ΔOLR from doubling CO₂: $(round(ΔOLR; digits = 2)) W/m²")
 
 # Doubling CO₂ reduces the OLR by a few W/m², creating the energy imbalance that
-# forces the climate to warm. How much the surface must warm to restore
-# balance is the subject of the
-# [radiative-convective equilibrium tutorial](manabe_rce.md), which turns
-# this experiment into Manabe's classic climate-sensitivity calculation.
+# forces the climate to warm. How much the surface must warm to restore balance
+# is the subject of the [radiative-convective equilibrium
+# tutorial](manabe_rce.md), which turns this experiment into Manabe's classic
+# climate-sensitivity calculation.
 #
 # ## The clear-sky heating rate
 #
@@ -184,4 +184,4 @@ fig2
 # - The [getter contract](../getters.md) documents how a host model exchanges
 #   data with an `RRTMGPSolver` in place.
 # - [How to get per-band (spectral) fluxes](../howto/spectral_fluxes.md) shows
-#   how to retain the band-by-band fluxes behind these broadband results.
+#   how to retain the band-by-band fluxes underlying the broadband results.

--- a/docs/tutorials/manabe_rce.jl
+++ b/docs/tutorials/manabe_rce.jl
@@ -37,14 +37,17 @@ using CairoMakie
 # ## The column
 #
 # Start from the idealized midlatitude-summer standard atmosphere on 60 layers
-# up to 45 km. Its pressure grid, ozone profile, and well-mixed gases (CO₂ = 420
+# up to 60 km. Its pressure grid, ozone profile, and well-mixed gases (CO₂ = 420
 # ppmv, etc.) stay fixed; the temperature, and, in most experiments, the water
 # vapor, are overwritten by the RCE iteration. We keep a copy of the
 # standard-atmosphere temperature to overlay later as a reference.
+#
+# Every column in this tutorial is built with the same settings, so we
+# collect them once:
 
 const FT = Float64
-nlay = 60
-profile = RRTMGP.standard_atmosphere(FT; kind = :midlatitude_summer, nlay);
+const column = (; kind = :midlatitude_summer, nlay = 60, z_top = 60.0e3)
+profile = RRTMGP.standard_atmosphere(FT; column...);
 T_obs = copy(profile.t_lay[:, 1]);
 
 # Like Manabe and collaborators, we force the column with the **global-mean
@@ -62,9 +65,9 @@ insolation = (; cos_zenith = cosd(47.9), toa_flux = 509.0, surface_albedo = 0.3)
 # Both RRTMGP and
 # [Thermodynamics.jl](https://github.com/CliMA/Thermodynamics.jl) read their
 # physical constants from
-# [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl), the single source
-# of truth for CliMA parameters, so the constants used across the radiation and
-# thermodynamics calculations here are consistent. We build both parameter sets
+# [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl), so the constants
+# used across the radiation and thermodynamics calculations here are
+# consistent. We build both parameter sets
 # from it and take the gravitational acceleration, the dry-air gas constant, and
 # the dry-air heat capacity from them:
 
@@ -78,14 +81,28 @@ g = RRTMGP.Parameters.grav(params)   # gravitational acceleration [m/s²]
 # rebuild the level (cell-face) temperatures and pressures from the layer
 # (cell-center) values on every [`update_fluxes!`](@ref RRTMGP.update_fluxes!)
 # call: `interpolation = ArithmeticMean()` averages the adjacent layers on
-# interior faces and extrapolates linearly at the boundary faces. We collect
-# this, the parameters, and the insolation into one configuration shared by
-# every column in this tutorial. One call then builds the clear-sky solver
-# (downloading the RRTMGP lookup tables on first use) and solves the initial
-# state; its state is exposed as writable views, which the iteration overwrites
-# in place:
+# interior faces and extrapolates linearly at the boundary faces.
+#
+# We also add an **isothermal boundary layer** at the top. A column that
+# stops at 60 km receives no downward longwave flux at its top face: the
+# topmost layer emits through both faces but absorbs only through one, so it
+# cools at tens of kelvin per day. This truncation artifact can spread a
+# sawtooth temperature pattern of several kelvin amplitude through the layers
+# below. `isothermal_boundary_layer = true` extends the column with one
+# isothermal layer reaching the lookup tables' minimum pressure, which
+# supplies the missing downward flux.
+#
+# We collect this setup, the parameters, and the insolation into one shared
+# configuration. One call then builds the clear-sky solver (downloading the
+# RRTMGP lookup tables on first use) and solves the initial state; its state
+# is exposed as writable views, which the iteration overwrites in place:
 
-setup = (; params, insolation..., interpolation = RRTMGP.ArithmeticMean())
+setup = (;
+    params,
+    insolation...,
+    interpolation = RRTMGP.ArithmeticMean(),
+    isothermal_boundary_layer = true,
+)
 out = RRTMGP.solve(profile; setup...)
 solver = out.solver;
 
@@ -288,7 +305,7 @@ T_bot_re = Array(RRTMGP.level_temperature(solver_re))[1, 1]
 println("Bottom-face air temperature (radiative): $(round(T_bot_re; digits = 1)) K")
 println("Implied surface convective flux (radiative): $(round(sfc_convective_flux(solver_re); digits = 2)) W/m²")
 
-# Radiative equilibrium *without* convection leads to a surface 26 K warmer,
+# Radiative equilibrium *without* convection leads to a surface 25 K warmer,
 # with a profile that departs from the observed atmosphere (here, the idealized
 # midlatitude-summer standard atmosphere we started from) at every height: the
 # temperature decreases from the surface upward at two to three times the dry
@@ -354,7 +371,7 @@ println("Tropopause height ≈ $(round(tropopause_height(solver, Ts_1x) / 1000; 
 co2_1x = profile.well_mixed_vmr["co2"]
 
 function balanced_co2(factor; fixed_rh = true, bracket = (Ts_1x, Ts_1x + 3))
-    prof = RRTMGP.standard_atmosphere(FT; kind = :midlatitude_summer, nlay)
+    prof = RRTMGP.standard_atmosphere(FT; column...)
     prof.well_mixed_vmr["co2"] = factor * co2_1x
     slv = RRTMGP.solve(prof; lookups = solver.lookups, setup...).solver
     RRTMGP.layer_temperature(slv) .= T_1x                      # warm start
@@ -446,7 +463,7 @@ ax3 = Axis(
     title = "Sensitivity to the critical lapse rate",
 )
 for Γ_km in (9.8, 6.5, 3.0)
-    prof = RRTMGP.standard_atmosphere(FT; kind = :midlatitude_summer, nlay)
+    prof = RRTMGP.standard_atmosphere(FT; column...)
     slv = RRTMGP.solve(prof; lookups = solver.lookups, setup...).solver
     Ts = balanced_surface_temperature!(slv, FT(270), FT(292); Γ = Γ_km * 1e-3)
     z_top = tropopause_height(slv, Ts; Γ = Γ_km * 1e-3) / 1000
@@ -472,7 +489,7 @@ fig3
 # CO₂ by setting its well-mixed value to zero before the state is built.
 
 function rce_without(absorber, T1, T2)
-    prof = RRTMGP.standard_atmosphere(FT; kind = :midlatitude_summer, nlay)
+    prof = RRTMGP.standard_atmosphere(FT; column...)
     absorber === :co2 && (prof.well_mixed_vmr["co2"] = 0.0)
     slv = RRTMGP.solve(prof; lookups = solver.lookups, setup...).solver
     absorber === :o3 && (RRTMGP.volume_mixing_ratio(slv, "o3") .= 0)
@@ -500,9 +517,9 @@ end
 # the most: removing it reduces the surface temperature by 24 K, below the
 # freezing point. Carbon dioxide comes next, at a 17 K reduction. Ozone
 # contributes 4 K at the surface, but by absorbing solar ultraviolet radiation
-# it creates the stratospheric inversion. Without ozone, the inversion is gone:
-# the temperature decreases with height toward a nearly isothermal ≈ 160 K at
-# the top of the column. Without CO₂, the stratosphere runs *warmer* than the
+# it creates the stratospheric inversion. Without ozone, the pronounced
+# inversion disappears, and the upper stratosphere is nearly isothermal at
+# 165–170 K. Without CO₂, the stratosphere runs *warmer* than the
 # reference: ozone still absorbs sunlight up there, but the main emitter of
 # thermal infrared is gone, so the stratosphere must warm until the remaining
 # gases radiate the heating away.

--- a/docs/tutorials/manabe_rce.jl
+++ b/docs/tutorials/manabe_rce.jl
@@ -4,14 +4,13 @@
 # calculations of [manabe1964](@citet) and [manabe1967](@citet) with RRTMGP's
 # clear-sky gas optics. It calculates RCE for a single atmospheric column with
 #
-# - a **prescribed tropospheric lapse rate** (convective adjustment to
-#   6.5 K/km),
+# - a **prescribed tropospheric lapse rate** (convective adjustment to 6.5
+#   K/km),
 # - a **prescribed relative-humidity profile** (water vapor follows the
 #   temperature),
 # - a stratosphere in **radiative equilibrium**, and
-# - a **surface temperature diagnosed from the energy balance**: it is
-#   iterated until the net radiative flux at the top of the atmosphere
-#   vanishes.
+# - a **surface temperature diagnosed from the energy balance**: it is iterated
+#   until the net radiative flux at the top of the atmosphere vanishes.
 #
 # [kluft2019](@citet) used a similar setup with the single-column model
 # [konrad](https://github.com/atmtools/konrad) to revisit the calculations by
@@ -19,15 +18,15 @@
 #
 # We reproduce four of Manabe's results: the
 # radiative-versus-radiative-convective comparison, the surface warming under
-# CO₂ increases with the water-vapor feedback (fixed relative rather than
-# fixed absolute humidity), the dependence of the equilibrium on the assumed
-# lapse rate, and the decomposition of the greenhouse effect into its
-# individual absorbers (water vapor, CO₂, ozone).
+# CO₂ increases with the water-vapor feedback (fixed relative rather than fixed
+# absolute humidity), the dependence of the equilibrium on the assumed lapse
+# rate, and the decomposition of the greenhouse effect into its individual
+# absorbers (water vapor, CO₂, ozone).
 #
 # Along the way, this tutorial demonstrates the host-model workflow of
-# RRTMGP.jl: build a solver, then mutate its state via the
-# [getter contract](../getters.md) and call
-# [`update_fluxes!`](@ref RRTMGP.update_fluxes!) inside a time loop.
+# RRTMGP.jl: build a solver, then mutate its state via the [getter
+# contract](../getters.md) and call [`update_fluxes!`](@ref
+# RRTMGP.update_fluxes!) inside a time loop.
 
 using RRTMGP
 using NCDatasets # activates RRTMGP's lookup-table extension
@@ -38,9 +37,9 @@ using CairoMakie
 # ## The column
 #
 # Start from the idealized midlatitude-summer standard atmosphere on 60 layers
-# up to 45 km. Its pressure grid, ozone profile, and well-mixed gases
-# (CO₂ = 420 ppmv, etc.) stay fixed; the temperature, and, in most experiments,
-# the water vapor, are overwritten by the RCE iteration. We keep a copy of the
+# up to 45 km. Its pressure grid, ozone profile, and well-mixed gases (CO₂ = 420
+# ppmv, etc.) stay fixed; the temperature, and, in most experiments, the water
+# vapor, are overwritten by the RCE iteration. We keep a copy of the
 # standard-atmosphere temperature to overlay later as a reference.
 
 const FT = Float64
@@ -49,21 +48,22 @@ profile = RRTMGP.standard_atmosphere(FT; kind = :midlatitude_summer, nlay);
 T_obs = copy(profile.t_lay[:, 1]);
 
 # Like Manabe and collaborators, we force the column with the **global-mean
-# insolation** ``S_0/4 \approx 341`` W/m².
-# The incident flux and the zenith angle have to be chosen together, since the
-# zenith angle sets the path length available for shortwave absorption
-# [cronin2014](@cite). Like [kluft2019](@citet), we take a zenith angle of
-# 47.9° (``\cos θ \approx 0.67``); an incident flux of 509 W/m² then delivers
-# ``509 \times \cos(47.9^\circ) \approx 341`` W/m² at the top of the
-# atmosphere. The surface albedo of 0.3 stands in for the shortwave reflection
-# of the clouds, which this clear-sky column omits:
+# insolation** ``S_0/4 \approx 341`` W/m². The incident flux and the zenith
+# angle have to be chosen together, since the zenith angle sets the path length
+# available for shortwave absorption [cronin2014](@cite). Like
+# [kluft2019](@citet), we take a zenith angle of 47.9°
+# (``\cos θ \approx 0.67``); an incident flux of 509 W/m² then delivers
+# ``509 \times \cos(47.9^\circ) \approx 341`` W/m² at the top of the atmosphere.
+# The surface albedo of 0.3 stands in for the shortwave reflection of the
+# clouds, which this clear-sky column omits:
 
 insolation = (; cos_zenith = cosd(47.9), toa_flux = 509.0, surface_albedo = 0.3);
 
-# Both RRTMGP and [Thermodynamics.jl](https://github.com/CliMA/Thermodynamics.jl)
-# read their physical constants from
-# [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl), the single source of
-# truth for CliMA parameters, so the constants used across the radiation and
+# Both RRTMGP and
+# [Thermodynamics.jl](https://github.com/CliMA/Thermodynamics.jl) read their
+# physical constants from
+# [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl), the single source
+# of truth for CliMA parameters, so the constants used across the radiation and
 # thermodynamics calculations here are consistent. We build both parameter sets
 # from it and take the gravitational acceleration, the dry-air gas constant, and
 # the dry-air heat capacity from them:
@@ -76,13 +76,14 @@ g = RRTMGP.Parameters.grav(params)   # gravitational acceleration [m/s²]
 
 # The iteration below marches the layer temperatures, so we ask the solver to
 # rebuild the level (cell-face) temperatures and pressures from the layer
-# (cell-center) values on every [`update_fluxes!`](@ref RRTMGP.update_fluxes!) call:
-# `interpolation = ArithmeticMean()` averages the adjacent layers on interior
-# faces and extrapolates linearly at the boundary faces. We collect this, the
-# parameters, and the insolation into one configuration shared by every column
-# in this tutorial. One call then builds the clear-sky solver (downloading the
-# RRTMGP lookup tables on first use) and solves the initial state; its state is
-# exposed as writable views, which the iteration overwrites in place:
+# (cell-center) values on every [`update_fluxes!`](@ref RRTMGP.update_fluxes!)
+# call: `interpolation = ArithmeticMean()` averages the adjacent layers on
+# interior faces and extrapolates linearly at the boundary faces. We collect
+# this, the parameters, and the insolation into one configuration shared by
+# every column in this tutorial. One call then builds the clear-sky solver
+# (downloading the RRTMGP lookup tables on first use) and solves the initial
+# state; its state is exposed as writable views, which the iteration overwrites
+# in place:
 
 setup = (; params, insolation..., interpolation = RRTMGP.ArithmeticMean())
 out = RRTMGP.solve(profile; setup...)
@@ -91,15 +92,16 @@ solver = out.solver;
 # ## Fixed relative humidity
 #
 # Manabe and Wetherald prescribed the relative-humidity profile
-# ``h(p) = 0.77\,(p/p_s - 0.02)/(1 - 0.02)``, so the specific humidity rises
-# and falls with the temperature (the water-vapor feedback in its simplest
-# form). The saturation vapor pressure ``e^*(T)`` comes from [Thermodynamics.jl](https://github.com/CliMA/Thermodynamics.jl),
-# which integrates the Clausius-Clapeyron relation under the Rankine-Kirchhoff
+# ``h(p) = 0.77\,(p/p_s - 0.02)/(1 - 0.02)``, so the specific humidity rises and
+# falls with the temperature (the water-vapor feedback in its simplest form).
+# The saturation vapor pressure ``e^*(T)`` comes from
+# [Thermodynamics.jl](https://github.com/CliMA/Thermodynamics.jl), which
+# integrates the Clausius-Clapeyron relation under the Rankine-Kirchhoff
 # (constant heat capacity) approximation [romps2021](@cite) used throughout the
-# CliMA model stack. From the vapor partial pressure
-# ``e = h\,e^*``, the water-vapor volume mixing ratio (moles of vapor per mole
-# of dry air, RRTMGP's convention) is ``e/(p - e)``. We floor it at the
-# stratospheric minimum Manabe used (a vmr of ≈ 4.8 × 10⁻⁶).
+# CliMA model stack. From the vapor partial pressure ``e = h\,e^*``, the
+# water-vapor volume mixing ratio (moles of vapor per mole of dry air, RRTMGP's
+# convention) is ``e/(p - e)``. We floor it at the stratospheric minimum Manabe
+# used (a vmr of ≈ 4.8 × 10⁻⁶).
 
 e_sat(T) = TD.saturation_vapor_pressure(td_params, T, TD.Liquid()) # [Pa]
 rel_hum(p, p_sfc) = max(0.77 * (p / p_sfc - 0.02) / (1 - 0.02), 0.0)
@@ -133,10 +135,9 @@ println("Dry adiabatic lapse rate g/cₚ = $(round(1000 * Γ_dry; digits = 1)) K
 # is assumed to instantaneously restore the critical profile
 # ``T(z) = T_s - Γ z``, anchored at a trial surface temperature ``T_s``. The
 # lapse rate is defined as a derivative with respect to height, yet no altitudes
-# are needed to apply it:
-# combining ``dT/dz = -Γ`` with hydrostatic balance and the ideal-gas law gives
-# ``dT/T = (Γ R_d / g)\, dp/p``, so in the solver's native pressure coordinate,
-# the critical profile is the power law
+# are needed to apply it: combining ``dT/dz = -Γ`` with hydrostatic balance and
+# the ideal-gas law gives ``dT/T = (Γ R_d / g)\, dp/p``, so in the solver's
+# native pressure coordinate, the critical profile is the power law
 # ```math
 # T_c(p) = T_s \left(\frac{p}{p_s}\right)^{Γ R_d / g},
 # ```
@@ -144,13 +145,13 @@ println("Dry adiabatic lapse rate g/cₚ = $(round(1000 * Γ_dry; digits = 1)) K
 # Layers warmer than ``T_c`` (the stratosphere) are left untouched, so the
 # tropopause emerges from the calculation.
 #
-# The convective adjustment warms the layers colder than ``T_c`` and leaves the surface
-# at the trial ``T_s``, so it adds energy to the column. To reach equilibrium, the
-# surface temperature is iteratively adjusted until the net radiative flux at
-# the top of the atmosphere vanishes. Each equilibration below computes the
-# radiative-convective state of a column at a **trial** ``T_s``, and the next
-# section varies that trial value until the budget closes and equilibrium is
-# reached.
+# The convective adjustment warms the layers colder than ``T_c`` and leaves the
+# surface at the trial ``T_s``, so it adds energy to the column. To reach
+# equilibrium, the surface temperature is iteratively adjusted until the net
+# radiative flux at the top of the atmosphere vanishes. Each equilibration below
+# computes the radiative-convective state of a column at a **trial** ``T_s``,
+# and the next section varies that trial value until the budget closes and
+# equilibrium is reached.
 
 const Γ_crit = 6.5e-3 # critical lapse rate [K/m]
 
@@ -179,8 +180,8 @@ end;
 # troposphere balances convective heating.
 #
 # One iteration serves every experiment: `convection = false` gives pure
-# radiative equilibrium, `humidity = false` holds the water vapor constant
-# (used below to remove water vapor, and to prescribe an absolute humidity
+# radiative equilibrium, `humidity = false` holds the water vapor constant (used
+# below to remove water vapor, and to prescribe an absolute humidity
 # distribution), and the `Γ` keyword changes the critical lapse rate. The
 # adjustment and humidity are synced before each solve, including on the final
 # step, so the reported fluxes match the temperatures.
@@ -239,8 +240,8 @@ function balanced_surface_temperature!(
     return T2
 end
 
-# We start from two guesses for the surface temperature to obtain
-# the radiative-convective equilibrium at present-day CO₂:
+# We start from two guesses for the surface temperature to obtain the
+# radiative-convective equilibrium at present-day CO₂:
 
 Ts_1x = balanced_surface_temperature!(solver, FT(285), FT(290))
 T_1x = copy(Array(RRTMGP.layer_temperature(solver)))
@@ -249,17 +250,17 @@ vmr_1x = copy(Array(RRTMGP.volume_mixing_ratio(solver, "h2o"))) # reference vapo
 println("Equilibrium Tₛ (1 × CO₂): $(round(Ts_1x; digits = 2)) K")
 
 # Closing the budget at the top of the atmosphere leaves a residual radiative
-# flux into the ground. That residual is the sensible and latent heat flux
-# that is implicit in the RCE calculation.
+# flux into the ground. That residual is the sensible and latent heat flux that
+# is implicit in the RCE calculation.
 
 sfc_convective_flux(solver) = -RRTMGP.net_flux(solver)[1, 1]
 println("Implied surface convective flux: $(round(sfc_convective_flux(solver); digits = 1)) W/m²")
 
-# The figures below mark a column's ground temperature with a dot at the
-# surface pressure, in the color of that column's curve. The center of the
-# lowest layer lies above the surface, so the horizontal offset between a dot
-# and the bottom of its curve is the temperature difference between the ground
-# and the air above it.
+# The figures below mark a column's ground temperature with a dot at the surface
+# pressure, in the color of that column's curve. The center of the lowest layer
+# lies above the surface, so the horizontal offset between a dot and the bottom
+# of its curve is the temperature difference between the ground and the air
+# above it.
 
 p_sfc_hPa = Array(RRTMGP.level_pressure(solver))[1, 1] / 100
 mark_ground!(ax, curve, T_sfc) = scatter!(ax, [T_sfc], [p_sfc_hPa]; color = curve.color, markersize = 9)
@@ -293,7 +294,7 @@ println("Implied surface convective flux (radiative): $(round(sfc_convective_flu
 # temperature decreases from the surface upward at two to three times the dry
 # adiabatic lapse rate, runs 45 K below the standard atmosphere through the
 # middle and upper troposphere, and forms no tropopause. The air at the bottom
-# face is several kelvin colder than the ground beneath it — the surface
+# face is several kelvin colder than the ground beneath it, the surface
 # discontinuity of radiative equilibrium. This radiative equilibrium state is
 # unstable to convection, and the turbulent heat fluxes that the convective
 # adjustment stands in for erase it.
@@ -330,11 +331,10 @@ fig
 # doubled CO₂ is the equilibrium climate sensitivity of the radiative-convective
 # column.
 
-# The reference tropopause, the highest layer on the convective profile,
-# lies just above 11 km. On that profile, height and temperature are
-# interchangeable, ``z = (T_s - T)/Γ``, so the height follows from the
-# temperature of the highest adjusted layer, again with no altitude
-# reconstruction:
+# The reference tropopause, the highest layer on the convective profile, lies
+# just above 11 km. On that profile, height and temperature are interchangeable,
+# ``z = (T_s - T)/Γ``, so the height follows from the temperature of the highest
+# adjusted layer, again with no altitude reconstruction:
 
 function tropopause_height(solver, T_sfc; Γ = Γ_crit)
     T = Array(RRTMGP.layer_temperature(solver))[:, 1]
@@ -346,11 +346,10 @@ end
 println("Tropopause height ≈ $(round(tropopause_height(solver, Ts_1x) / 1000; digits = 1)) km")
 
 # Now scale the CO₂ and re-balance. `balanced_co2` builds a fresh column with a
-# scaled CO₂ concentration, starts it from the 1 × CO₂ equilibrium, and
-# finds its balanced surface temperature. With `fixed_rh = false`, the water
-# vapor is frozen at its reference (1 × CO₂) values (**fixed absolute
-# humidity**) which removes the water-vapor feedback and isolates the direct
-# effect of CO₂.
+# scaled CO₂ concentration, starts it from the 1 × CO₂ equilibrium, and finds
+# its balanced surface temperature. With `fixed_rh = false`, the water vapor is
+# frozen at its reference (1 × CO₂) values (**fixed absolute humidity**) which
+# removes the water-vapor feedback and isolates the direct effect of CO₂.
 
 co2_1x = profile.well_mixed_vmr["co2"]
 
@@ -427,14 +426,14 @@ fig2
 # ## Sensitivity to the critical lapse rate
 #
 # The assumed critical lapse rate ``Γ_c`` shapes the equilibrium. Re-balancing
-# the reference column for lapse rates between 3.0 K/km and the dry adiabat
-# (9.8 K/km) shows that a shallower lapse rate cools the surface but lifts the
-# tropopause: the troposphere stretches vertically, because the gentler
-# gradient needs more depth to bridge the surface and stratospheric
-# temperatures. Each column is balanced, so each emits to space the sunlight it
-# absorbs; the three absorb within about 1 W/m² of each other, so they settle
-# on nearly the same outgoing longwave flux from temperature profiles whose
-# surface temperatures span 9 K.
+# the reference column for lapse rates between 3.0 K/km and the dry adiabat (9.8
+# K/km) shows that a shallower lapse rate cools the surface but lifts the
+# tropopause: the troposphere stretches vertically, because the gentler gradient
+# needs more depth to bridge the surface and stratospheric temperatures. Each
+# column is balanced, so each emits to space the sunlight it absorbs; the three
+# absorb within about 1 W/m² of each other, so they settle on nearly the same
+# outgoing longwave flux from temperature profiles whose surface temperatures
+# span 9 K.
 
 fig3 = Figure(size = (500, 500))
 ax3 = Axis(
@@ -501,12 +500,12 @@ end
 # the most: removing it reduces the surface temperature by 24 K, below the
 # freezing point. Carbon dioxide comes next, at a 17 K reduction. Ozone
 # contributes 4 K at the surface, but by absorbing solar ultraviolet radiation
-# it creates the stratospheric inversion. Without ozone, the inversion is
-# gone: the temperature decreases with height toward a nearly isothermal
-# ≈ 160 K at the top of the column. Without CO₂, the stratosphere runs
-# *warmer* than the reference: ozone still absorbs sunlight up there, but the
-# main emitter of thermal infrared is gone, so the stratosphere must warm
-# until the remaining gases radiate the heating away.
+# it creates the stratospheric inversion. Without ozone, the inversion is gone:
+# the temperature decreases with height toward a nearly isothermal ≈ 160 K at
+# the top of the column. Without CO₂, the stratosphere runs *warmer* than the
+# reference: ozone still absorbs sunlight up there, but the main emitter of
+# thermal infrared is gone, so the stratosphere must warm until the remaining
+# gases radiate the heating away.
 
 fig4 = Figure(size = (500, 500))
 ax4 = Axis(
@@ -532,6 +531,6 @@ fig4
 
 # ## Where to go from here
 #
-# - Vary the critical lapse rate or the relative-humidity profile and watch
-#   the sensitivity respond (cf. [kluft2021](@citet)).
+# - Vary the critical lapse rate or the relative-humidity profile and watch the
+#   sensitivity respond (cf. [kluft2021](@citet)).
 # - Swap `:midlatitude_summer` for `:tropical` or `:subarctic_winter`.

--- a/docs/tutorials/manabe_rce.jl
+++ b/docs/tutorials/manabe_rce.jl
@@ -77,11 +77,15 @@ R_d = TD.Parameters.R_d(td_params)
 cp_d = TD.Parameters.cp_d(td_params)
 g = RRTMGP.Parameters.grav(params)   # gravitational acceleration [m/s²]
 
-# The iteration below marches the layer temperatures, so we ask the solver to
-# rebuild the level (cell-face) temperatures and pressures from the layer
-# (cell-center) values on every [`update_fluxes!`](@ref RRTMGP.update_fluxes!)
-# call: `interpolation = ArithmeticMean()` averages the adjacent layers on
-# interior faces and extrapolates linearly at the boundary faces.
+# RRTMGP needs temperatures both at the layer centers, where the optical
+# properties are evaluated, and at the level (cell-face) boundaries, where the
+# longwave source varies. A driver has to decide which of the two it marches.
+# We march the **levels** and set each layer to the mean of the two levels
+# bounding it, so `interpolation = NoInterpolation()` leaves the level values
+# as the iteration writes them. Marching the layers instead, with levels
+# reconstructed by interpolation, admits a computational mode: a grid-scale
+# oscillation of the layer temperatures leaves the interpolated levels
+# unchanged, so the radiation cannot damp it.
 #
 # We also add an **isothermal boundary layer** at the top. A column that
 # stops at 60 km receives no downward longwave flux at its top face: the
@@ -100,7 +104,7 @@ g = RRTMGP.Parameters.grav(params)   # gravitational acceleration [m/s²]
 setup = (;
     params,
     insolation...,
-    interpolation = RRTMGP.ArithmeticMean(),
+    interpolation = RRTMGP.NoInterpolation(),
     isothermal_boundary_layer = true,
 )
 out = RRTMGP.solve(profile; setup...)
@@ -159,10 +163,10 @@ println("Dry adiabatic lapse rate g/cₚ = $(round(1000 * Γ_dry; digits = 1)) K
 # T_c(p) = T_s \left(\frac{p}{p_s}\right)^{Γ R_d / g},
 # ```
 # which reduces to the dry adiabat ``T \propto p^{R_d/c_p}`` for ``Γ = g/c_p``.
-# Layers warmer than ``T_c`` (the stratosphere) are left untouched, so the
+# Levels warmer than ``T_c`` (the stratosphere) are left untouched, so the
 # tropopause emerges from the calculation.
 #
-# The convective adjustment warms the layers colder than ``T_c`` and leaves the
+# The convective adjustment warms the levels colder than ``T_c`` and leaves the
 # surface at the trial ``T_s``, so it adds energy to the column. To reach
 # equilibrium, the surface temperature is iteratively adjusted until the net
 # radiative flux at the top of the atmosphere vanishes. Each equilibration below
@@ -173,24 +177,29 @@ println("Dry adiabatic lapse rate g/cₚ = $(round(1000 * Γ_dry; digits = 1)) K
 const Γ_crit = 6.5e-3 # critical lapse rate [K/m]
 
 function convective_adjustment!(solver, T_sfc; Γ = Γ_crit)
-    T = RRTMGP.layer_temperature(solver)
-    p = RRTMGP.layer_pressure(solver)
-    p_sfc = RRTMGP.level_pressure(solver)[1, 1]
+    T = RRTMGP.level_temperature(solver)
+    p = RRTMGP.level_pressure(solver)
+    p_sfc = p[1, 1]
     @. T = max(T, T_sfc * (p / p_sfc)^(Γ * R_d / g)) # critical profile T_c(p)
     return nothing
 end;
 
 # ## Compute radiative-convective state at a trial surface temperature
 #
-# Each step applies the convective adjustment, updates the water vapor to the
-# fixed relative humidity, solves the radiative transfer, and marches the
-# temperature with the radiative heating rate. The ground temperature enters
-# separately, through the surface-emission boundary condition
-# (`surface_temperature`); keeping the two distinct lets the air at the bottom
-# face be colder than the ground, as radiative equilibrium requires. The
-# `UseSurfaceTempAtBottom` extrapolation option ties the bottom face to the
-# ground temperature instead, which removes that difference (corresponding to
-# the limit of strong turbulent heat exchange at the surface).
+# Each step applies the convective adjustment, fills the layer temperatures
+# from the levels, updates the water vapor to the fixed relative humidity,
+# solves the radiative transfer, and marches the level temperatures with the
+# radiative heating rate. The heating rate is a layer quantity, so each
+# interior level is advanced with the mean of the heating rates of the two
+# layers meeting at it, and the bottom and top levels with the single adjacent
+# layer's.
+#
+# The ground temperature enters separately, through the surface-emission
+# boundary condition (`surface_temperature`); keeping the two distinct lets the
+# air at the bottom face be colder than the ground, as radiative equilibrium
+# requires. Where convection is active, the adjustment ties the bottom face to
+# the ground temperature, the limit of strong turbulent heat exchange at the
+# surface.
 #
 # The column has settled when successive adjusted profiles stop changing. That
 # is the equilibrium state, in which radiative cooling in the convecting
@@ -214,15 +223,24 @@ function equilibrate!(
     tol = 1e-4,
 )
     RRTMGP.surface_temperature(solver) .= T_sfc
-    T = RRTMGP.layer_temperature(solver)
-    T_prev = fill!(similar(T), 0)
+    T_lev = RRTMGP.level_temperature(solver)
+    T_lay = RRTMGP.layer_temperature(solver)
+    nlev = size(T_lev, 1)
+    nlay = nlev - 1
+    T_prev = fill!(similar(T_lev), 0)
+    dT = similar(Array(T_lev))
     for _ in 1:maxsteps
         convection && convective_adjustment!(solver, T_sfc; Γ)
+        @views @. T_lay = (T_lev[1:nlay, :] + T_lev[2:nlev, :]) / 2
         humidity && set_humidity!(solver)
         RRTMGP.update_fluxes!(solver)
-        maximum(abs, T .- T_prev) < tol && break
-        T_prev .= T
-        T .+= clamp.(dt .* Array(RRTMGP.heating_rate(solver)), -2, 2)
+        maximum(abs, T_lev .- T_prev) < tol && break
+        T_prev .= T_lev
+        Q = Array(RRTMGP.heating_rate(solver))
+        @views @. dT[2:nlay, :] = (Q[1:(nlay - 1), :] + Q[2:nlay, :]) / 2
+        @views dT[1, :] .= Q[1, :]
+        @views dT[nlev, :] .= Q[nlay, :]
+        T_lev .+= clamp.(dt .* dT, -2, 2)
     end
     return nothing
 end;
@@ -262,6 +280,7 @@ end
 
 Ts_1x = balanced_surface_temperature!(solver, FT(285), FT(290))
 T_1x = copy(Array(RRTMGP.layer_temperature(solver)))
+T_lev_1x = copy(Array(RRTMGP.level_temperature(solver))) # for warm starts
 p_lay = copy(Array(RRTMGP.layer_pressure(solver)))
 vmr_1x = copy(Array(RRTMGP.volume_mixing_ratio(solver, "h2o"))) # reference vapor
 println("Equilibrium Tₛ (1 × CO₂): $(round(Ts_1x; digits = 2)) K")
@@ -309,7 +328,7 @@ println("Implied surface convective flux (radiative): $(round(sfc_convective_flu
 # with a profile that departs from the observed atmosphere (here, the idealized
 # midlatitude-summer standard atmosphere we started from) at every height: the
 # temperature decreases from the surface upward at two to three times the dry
-# adiabatic lapse rate, runs 45 K below the standard atmosphere through the
+# adiabatic lapse rate, runs 44 K below the standard atmosphere through the
 # middle and upper troposphere, and forms no tropopause. The air at the bottom
 # face is several kelvin colder than the ground beneath it, the surface
 # discontinuity of radiative equilibrium. This radiative equilibrium state is
@@ -374,7 +393,7 @@ function balanced_co2(factor; fixed_rh = true, bracket = (Ts_1x, Ts_1x + 3))
     prof = RRTMGP.standard_atmosphere(FT; column...)
     prof.well_mixed_vmr["co2"] = factor * co2_1x
     slv = RRTMGP.solve(prof; lookups = solver.lookups, setup...).solver
-    RRTMGP.layer_temperature(slv) .= T_1x                      # warm start
+    RRTMGP.level_temperature(slv) .= T_lev_1x                  # warm start
     fixed_rh || (RRTMGP.volume_mixing_ratio(slv, "h2o") .= vmr_1x) # freeze reference vapor
     Ts = balanced_surface_temperature!(slv, bracket...; humidity = fixed_rh)
     return Ts, copy(Array(RRTMGP.layer_temperature(slv)))

--- a/docs/tutorials/manabe_rce.jl
+++ b/docs/tutorials/manabe_rce.jl
@@ -2,30 +2,30 @@
 #
 # This tutorial reproduces the classic radiative-convective equilibrium (RCE)
 # calculations of [manabe1964](@citet) and [manabe1967](@citet) with RRTMGP's
-# clear-sky gas optics: a single atmospheric column with
+# clear-sky gas optics. It calculates RCE for a single atmospheric column with
 #
 # - a **prescribed tropospheric lapse rate** (convective adjustment to
 #   6.5 K/km),
 # - a **prescribed relative-humidity profile** (water vapor follows the
-#   temperature), and
-# - a stratosphere in **radiative equilibrium**.
+#   temperature),
+# - a stratosphere in **radiative equilibrium**, and
+# - a **surface temperature diagnosed from the energy balance**: it is
+#   iterated until the net radiative flux at the top of the atmosphere
+#   vanishes.
 #
-# The same setup (hard convective adjustment plus fixed relative humidity)
-# is the default configuration of the single-column model
-# [konrad](https://github.com/atmtools/konrad), and [kluft2019](@citet) showed
-# that it reproduces Manabe's headline result: an equilibrium climate
-# sensitivity of about 2 K per doubling of CO₂ when relative humidity is held
-# fixed.
+# [kluft2019](@citet) used a similar setup with the single-column model
+# [konrad](https://github.com/atmtools/konrad) to revisit the calculations by
+# Manabe and collaborators.
 #
-# From this one setup, we reproduce Manabe's classic results: the
-# radiative-versus-radiative-convective comparison, the decomposition of the
-# greenhouse effect into its individual absorbers (water vapor, CO₂, ozone),
-# the dependence of the equilibrium on the assumed lapse rate, and the surface
-# warming under CO₂ increases with the water-vapor feedback isolated by
-# contrasting fixed relative and fixed absolute humidity.
+# We reproduce four of Manabe's results: the
+# radiative-versus-radiative-convective comparison, the surface warming under
+# CO₂ increases with the water-vapor feedback (fixed relative rather than
+# fixed absolute humidity), the dependence of the equilibrium on the assumed
+# lapse rate, and the decomposition of the greenhouse effect into its
+# individual absorbers (water vapor, CO₂, ozone).
 #
 # Along the way, this tutorial demonstrates the host-model workflow of
-# RRTMGP.jl: build a solver once, then mutate its state through the
+# RRTMGP.jl: build a solver, then mutate its state via the
 # [getter contract](../getters.md) and call
 # [`update_fluxes!`](@ref RRTMGP.update_fluxes!) inside a time loop.
 
@@ -39,9 +39,9 @@ using CairoMakie
 #
 # Start from the idealized midlatitude-summer standard atmosphere on 60 layers
 # up to 45 km. Its pressure grid, ozone profile, and well-mixed gases
-# (CO₂ = 420 ppmv, etc.) stay fixed; temperature and water vapor will be
-# overwritten by the RCE iteration. We keep a copy of the standard-atmosphere
-# temperature to overlay later as the "observed" reference.
+# (CO₂ = 420 ppmv, etc.) stay fixed; the temperature, and, in most experiments,
+# the water vapor, are overwritten by the RCE iteration. We keep a copy of the
+# standard-atmosphere temperature to overlay later as a reference.
 
 const FT = Float64
 nlay = 60
@@ -49,13 +49,14 @@ profile = RRTMGP.standard_atmosphere(FT; kind = :midlatitude_summer, nlay);
 T_obs = copy(profile.t_lay[:, 1]);
 
 # Like Manabe and collaborators, we force the column with the **global-mean
-# insolation** ``S_0/4 \approx 341`` W/m² (the solar constant spread over the sphere).
-# Because the mean solar zenith angle sets the shortwave absorption path length
-# [cronin2014](@cite), we use a representative zenith angle of 47.9°
-# (``\cos θ \approx 0.67``) with an incident flux of 509 W/m², so that
-# ``509 \times \cos(47.9^\circ) \approx 341`` W/m². The surface albedo is set to 0.3, higher
-# than a bare surface, to stand in for the shortwave reflection of the clouds
-# this clear-sky column omits:
+# insolation** ``S_0/4 \approx 341`` W/m².
+# The incident flux and the zenith angle have to be chosen together, since the
+# zenith angle sets the path length available for shortwave absorption
+# [cronin2014](@cite). Like [kluft2019](@citet), we take a zenith angle of
+# 47.9° (``\cos θ \approx 0.67``); an incident flux of 509 W/m² then delivers
+# ``509 \times \cos(47.9^\circ) \approx 341`` W/m² at the top of the
+# atmosphere. The surface albedo of 0.3 stands in for the shortwave reflection
+# of the clouds, which this clear-sky column omits:
 
 insolation = (; cos_zenith = cosd(47.9), toa_flux = 509.0, surface_albedo = 0.3);
 
@@ -81,7 +82,7 @@ g = RRTMGP.Parameters.grav(params)   # gravitational acceleration [m/s²]
 # parameters, and the insolation into one configuration shared by every column
 # in this tutorial. One call then builds the clear-sky solver (downloading the
 # RRTMGP lookup tables on first use) and solves the initial state; its state is
-# exposed as writable views that the iteration overwrites in place:
+# exposed as writable views, which the iteration overwrites in place:
 
 setup = (; params, insolation..., interpolation = RRTMGP.ArithmeticMean())
 out = RRTMGP.solve(profile; setup...)
@@ -94,9 +95,9 @@ solver = out.solver;
 # and falls with the temperature (the water-vapor feedback in its simplest
 # form). The saturation vapor pressure ``e^*(T)`` comes from [Thermodynamics.jl](https://github.com/CliMA/Thermodynamics.jl),
 # which integrates the Clausius-Clapeyron relation under the Rankine-Kirchhoff
-# (constant-heat-capacity) approximation [romps2021](@cite), the same
-# formulation the CliMA model uses. From the vapor partial pressure
-# ``e = h\,e^*`` the water-vapor volume mixing ratio (moles of vapor per mole
+# (constant heat capacity) approximation [romps2021](@cite) used throughout the
+# CliMA model stack. From the vapor partial pressure
+# ``e = h\,e^*``, the water-vapor volume mixing ratio (moles of vapor per mole
 # of dry air, RRTMGP's convention) is ``e/(p - e)``. We floor it at the
 # stratospheric minimum Manabe used (a vmr of ≈ 4.8 × 10⁻⁶).
 
@@ -123,14 +124,16 @@ end;
 # ``Γ_d = g/c_p``, calculated from the Thermodynamics.jl constants:
 
 Γ_dry = g / cp_d
-println("dry adiabatic lapse rate g/cₚ = $(round(1000 * Γ_dry; digits = 1)) K/km")
+println("Dry adiabatic lapse rate g/cₚ = $(round(1000 * Γ_dry; digits = 1)) K/km")
 
-# Moist convection and large-scale eddies hold the observed troposphere to a
-# gentler value, so we impose a critical lapse rate of 6.5 K/km. Wherever
-# radiative cooling pulls the lapse rate above it, convection is assumed to
-# instantaneously restore the critical profile ``T(z) = T_s - Γ z``, anchored
-# at a trial surface temperature ``T_s`` (hard adjustment). The lapse rate is
-# defined per unit height, yet no altitudes are needed to apply it:
+# Moist convection and large-scale eddies hold the observed tropospheric lapse
+# rate to a smaller value. Like Manabe and collaborators, we impose a critical
+# lapse rate of 6.5 K/km, which is close to the observed tropospheric mean.
+# Wherever radiative cooling pulls the lapse rate above this value, convection
+# is assumed to instantaneously restore the critical profile
+# ``T(z) = T_s - Γ z``, anchored at a trial surface temperature ``T_s``. The
+# lapse rate is defined as a derivative with respect to height, yet no altitudes
+# are needed to apply it:
 # combining ``dT/dz = -Γ`` with hydrostatic balance and the ideal-gas law gives
 # ``dT/T = (Γ R_d / g)\, dp/p``, so in the solver's native pressure coordinate,
 # the critical profile is the power law
@@ -138,17 +141,16 @@ println("dry adiabatic lapse rate g/cₚ = $(round(1000 * Γ_dry; digits = 1)) K
 # T_c(p) = T_s \left(\frac{p}{p_s}\right)^{Γ R_d / g},
 # ```
 # which reduces to the dry adiabat ``T \propto p^{R_d/c_p}`` for ``Γ = g/c_p``.
-# Layers whose radiative-equilibrium temperature is warmer than ``T_c`` (the
-# stratosphere) are left untouched, allowing the tropopause to emerge from the
-# calculation.
+# Layers warmer than ``T_c`` (the stratosphere) are left untouched, so the
+# tropopause emerges from the calculation.
 #
-# Although convection should only redistribute energy, not create or destroy
-# it, convective adjustment by itself does not conserve column energy. We
-# enforce energy conservation in equilibrium by adjusting the surface
-# temperature (an unknown of the problem): each equilibration below holds a
-# trial ``T_s`` fixed, and the trial value is then adjusted until the net
-# radiative flux at the top of the atmosphere vanishes, so the energy balance
-# determines ``T_s``.
+# The convective adjustment warms the layers colder than ``T_c`` and leaves the surface
+# at the trial ``T_s``, so it adds energy to the column. To reach equilibrium, the
+# surface temperature is iteratively adjusted until the net radiative flux at
+# the top of the atmosphere vanishes. Each equilibration below computes the
+# radiative-convective state of a column at a **trial** ``T_s``, and the next
+# section varies that trial value until the budget closes and equilibrium is
+# reached.
 
 const Γ_crit = 6.5e-3 # critical lapse rate [K/m]
 
@@ -160,53 +162,28 @@ function convective_adjustment!(solver, T_sfc; Γ = Γ_crit)
     return nothing
 end;
 
-# ## The RCE iteration
+# ## Compute radiative-convective state at a trial surface temperature
 #
 # Each step applies the convective adjustment, updates the water vapor to the
 # fixed relative humidity, solves the radiative transfer, and marches the
-# temperature with the radiative heating rate. Level (cell-face) temperatures
-# are rebuilt from the layer (cell-center) temperatures inside
-# `update_fluxes!`, by the `ArithmeticMean` interpolation requested at
-# construction. The ground temperature enters separately, through the
-# surface-emission boundary condition (`surface_temperature`); keeping the two
-# distinct lets the air at the bottom face be colder than the ground, which
-# pure radiative equilibrium demands (the `UseSurfaceTempAtBottom`
-# extrapolation option would pin the bottom face to the ground temperature and
-# spuriously chill the lowest layer in the radiative-equilibrium experiment).
-# The column is equilibrated when the largest temperature change per step is
-# negligible.
-
-# Marching the layer temperatures independently excites a grid-scale
-# (two-layer) oscillation in the stratosphere: a sawtooth in the layer
-# temperatures maps to nearly unchanged level temperatures, so it barely
-# perturbs the level fluxes that would otherwise damp it, and it survives no
-# matter how small the time step. We remove it with a light three-point
-# (`1-2-1`) filter applied to the interior layers each step — a weak numerical
-# diffusion. Its damping is scale-selective: each step multiplies a mode of
-# wavelength ``L`` by ``1 - 4ν\sin^2(πΔz/L)``, so the two-layer mode shrinks by
-# ``1 - 4ν`` per step while smooth structure, which the filter perturbs only in
-# proportion to its curvature, is nearly untouched. The main visible cost is a
-# slight rounding of the tropopause kink; the balanced surface temperature
-# shifts by less than 0.1 K.
-
-function smooth!(T, ν)
-    nlay = size(T, 1)
-    prev = T[1, 1]
-    for k in 2:(nlay - 1)
-        cur = T[k, 1]
-        T[k, 1] = cur + ν * (prev - 2cur + T[k + 1, 1])
-        prev = cur
-    end
-    return nothing
-end
-
+# temperature with the radiative heating rate. The ground temperature enters
+# separately, through the surface-emission boundary condition
+# (`surface_temperature`); keeping the two distinct lets the air at the bottom
+# face be colder than the ground, as radiative equilibrium requires. The
+# `UseSurfaceTempAtBottom` extrapolation option ties the bottom face to the
+# ground temperature instead, which removes that difference (corresponding to
+# the limit of strong turbulent heat exchange at the surface).
+#
+# The column has settled when successive adjusted profiles stop changing. That
+# is the equilibrium state, in which radiative cooling in the convecting
+# troposphere balances convective heating.
+#
 # One iteration serves every experiment: `convection = false` gives pure
 # radiative equilibrium, `humidity = false` holds the water vapor constant
-# (used below to remove water vapor entirely and to freeze it for the
-# fixed-absolute-humidity experiments), and the `Γ` keyword changes the
-# critical lapse rate. The adjustment and humidity are synced before each
-# solve, including on the final (converged) step, so the reported fluxes are
-# consistent with the temperatures.
+# (used below to remove water vapor, and to prescribe an absolute humidity
+# distribution), and the `Γ` keyword changes the critical lapse rate. The
+# adjustment and humidity are synced before each solve, including on the final
+# step, so the reported fluxes match the temperatures.
 
 function equilibrate!(
     solver,
@@ -215,85 +192,42 @@ function equilibrate!(
     humidity = true,
     Γ = Γ_crit,
     dt = 8 * 3600.0,
-    maxsteps = 5000,
+    maxsteps = 20000,
     tol = 1e-4,
-    ν = 0.1,
 )
     RRTMGP.surface_temperature(solver) .= T_sfc
     T = RRTMGP.layer_temperature(solver)
+    T_prev = fill!(similar(T), 0)
     for _ in 1:maxsteps
         convection && convective_adjustment!(solver, T_sfc; Γ)
         humidity && set_humidity!(solver)
         RRTMGP.update_fluxes!(solver)
-        dT = clamp.(dt .* Array(RRTMGP.heating_rate(solver)), -2, 2)
-        maximum(abs, dT) < tol && break
-        T .+= dT
-        smooth!(T, ν)
+        maximum(abs, T .- T_prev) < tol && break
+        T_prev .= T
+        T .+= clamp.(dt .* Array(RRTMGP.heating_rate(solver)), -2, 2)
     end
     return nothing
 end;
 
-# Run it. The net flux at the top of the atmosphere (`net = up - down`)
-# measures the column's energy imbalance; at the true equilibrium surface
-# temperature it vanishes.
+# ## Closing the energy balance
+#
+# The net flux at the top of the atmosphere (`net = up - down`) measures the
+# column's energy imbalance, and it vanishes at the equilibrium surface
+# temperature. A secant iteration on that imbalance finds it in a handful of
+# steps, each restarting from the previous state:
 
 toa_imbalance(solver) = RRTMGP.net_flux(solver)[end, 1]
 
-T_sfc = FT(288)
-equilibrate!(solver, T_sfc)
-N = toa_imbalance(solver)
-println("TOA imbalance at Tₛ = $(T_sfc) K: $(round(N; digits = 2)) W/m²")
-
-# ## Radiative equilibrium versus radiative-convective equilibrium
-#
-# Repeating the iteration without the convective adjustment reproduces
-# Manabe and Strickler's famous comparison: pure radiative equilibrium produces
-# high surface temperatures and low upper-troposphere temperatures, while the
-# convective adjustment brings the profile into agreement with observations
-# (here, the midlatitude-summer standard atmosphere we started from). Near the
-# surface, the radiative-equilibrium temperature falls steeply — far more
-# steeply than any adiabat — and the air at the bottom face remains several
-# kelvin colder than the 288 K ground: the classic surface discontinuity of
-# radiative equilibrium. Both features are convectively unstable; the
-# turbulent heat fluxes that the convective adjustment stands in for would
-# erase them, which is what the RCE profile shows.
-
-T_rce = copy(Array(RRTMGP.layer_temperature(solver)))
-p_lay = copy(Array(RRTMGP.layer_pressure(solver)))
-
-solver_re = RRTMGP.solve(profile; lookups = solver.lookups, setup...).solver
-equilibrate!(solver_re, T_sfc; convection = false)
-T_re = copy(Array(RRTMGP.layer_temperature(solver_re)));
-
-fig = Figure(size = (500, 500))
-ax = Axis(
-    fig[1, 1];
-    xlabel = "temperature [K]",
-    ylabel = "pressure [hPa]",
-    yscale = log10,
-    yreversed = true,
-    limits = (nothing, nothing, nothing, 1000),
-    title = "Radiative vs. radiative-convective equilibrium",
+function balanced_surface_temperature!(
+    solver,
+    T1,
+    T2;
+    convection = true,
+    humidity = true,
+    Γ = Γ_crit,
+    tol = 5e-3,
 )
-lines!(ax, T_obs, p_lay[:, 1] ./ 100; color = :gray, linestyle = :dot, label = "standard atmosphere")
-lines!(ax, T_re[:, 1], p_lay[:, 1] ./ 100; label = "radiative equilibrium")
-lines!(ax, T_rce[:, 1], p_lay[:, 1] ./ 100; label = "RCE (Γ = 6.5 K/km)")
-axislegend(ax; position = :rt, framevisible = false, backgroundcolor = :white)
-fig
-
-# ## Climate sensitivity at fixed relative humidity
-#
-# Manabe and Wetherald's headline experiment: find the surface temperature
-# that balances the column (zero net flux at the top of the atmosphere) for
-# the present CO₂ concentration and for increased CO₂, keeping the relative
-# humidity fixed. The difference is the equilibrium climate sensitivity of
-# the radiative-convective column.
-#
-# A secant iteration on the TOA imbalance converges in a few equilibrations
-# (each restarted from the previous equilibrium, so they are fast):
-
-function balanced_surface_temperature!(solver, T1, T2; humidity = true, Γ = Γ_crit, tol = 5e-3)
-    eq(T) = (equilibrate!(solver, T; humidity, Γ); toa_imbalance(solver))
+    eq(T) = (equilibrate!(solver, T; convection, humidity, Γ); toa_imbalance(solver))
     N1 = eq(T1)
     N2 = eq(T2)
     while abs(N2) > tol && abs(T2 - T1) > 1e-3
@@ -305,15 +239,102 @@ function balanced_surface_temperature!(solver, T1, T2; humidity = true, Γ = Γ_
     return T2
 end
 
+# We start from two guesses for the surface temperature to obtain
+# the radiative-convective equilibrium at present-day CO₂:
+
 Ts_1x = balanced_surface_temperature!(solver, FT(285), FT(290))
 T_1x = copy(Array(RRTMGP.layer_temperature(solver)))
-vmr_1x = copy(Array(RRTMGP.volume_mixing_ratio(solver, "h2o"))) # reference vapor, for fixed AH
-println("equilibrium Tₛ (1 × CO₂): $(round(Ts_1x; digits = 2)) K")
+p_lay = copy(Array(RRTMGP.layer_pressure(solver)))
+vmr_1x = copy(Array(RRTMGP.volume_mixing_ratio(solver, "h2o"))) # reference vapor
+println("Equilibrium Tₛ (1 × CO₂): $(round(Ts_1x; digits = 2)) K")
 
-# The reference tropopause — the highest layer still on the critical profile —
-# sits near 10 km. On that profile, height and temperature are interchangeable,
-# ``z = (T_s - T)/Γ``, so the height follows from the temperature of the
-# highest adjusted layer, again with no altitude reconstruction:
+# Closing the budget at the top of the atmosphere leaves a residual radiative
+# flux into the ground. That residual is the sensible and latent heat flux
+# that is implicit in the RCE calculation.
+
+sfc_convective_flux(solver) = -RRTMGP.net_flux(solver)[1, 1]
+println("Implied surface convective flux: $(round(sfc_convective_flux(solver); digits = 1)) W/m²")
+
+# The figures below mark a column's ground temperature with a dot at the
+# surface pressure, in the color of that column's curve. The center of the
+# lowest layer lies above the surface, so the horizontal offset between a dot
+# and the bottom of its curve is the temperature difference between the ground
+# and the air above it.
+
+p_sfc_hPa = Array(RRTMGP.level_pressure(solver))[1, 1] / 100
+mark_ground!(ax, curve, T_sfc) = scatter!(ax, [T_sfc], [p_sfc_hPa]; color = curve.color, markersize = 9)
+
+# ## Radiative equilibrium versus radiative-convective equilibrium
+#
+# Dropping the convective adjustment and re-balancing the column reproduces
+# Manabe and Strickler's pure radiative equilibrium baseline. That calculation
+# predates the fixed-relative-humidity assumption and prescribed a distribution
+# of *absolute* humidity instead. We do the same, leaving the standard
+# atmosphere's water vapor untouched (`humidity = false`) in both columns, so
+# that they differ only in whether convection acts.
+
+function balanced_prescribed_humidity(; convection)
+    slv = RRTMGP.solve(profile; lookups = solver.lookups, setup...).solver
+    Ts = balanced_surface_temperature!(slv, FT(285), FT(300); convection, humidity = false)
+    return Ts, copy(Array(RRTMGP.layer_temperature(slv))), slv
+end
+
+Ts_rc, T_rc, _ = balanced_prescribed_humidity(; convection = true)
+Ts_re, T_re, solver_re = balanced_prescribed_humidity(; convection = false)
+println("Equilibrium Tₛ (radiative-convective): $(round(Ts_rc; digits = 1)) K")
+println("Equilibrium Tₛ (radiative):            $(round(Ts_re; digits = 1)) K")
+T_bot_re = Array(RRTMGP.level_temperature(solver_re))[1, 1]
+println("Bottom-face air temperature (radiative): $(round(T_bot_re; digits = 1)) K")
+println("Implied surface convective flux (radiative): $(round(sfc_convective_flux(solver_re); digits = 2)) W/m²")
+
+# Radiative equilibrium *without* convection leads to a surface 26 K warmer,
+# with a profile that departs from the observed atmosphere (here, the idealized
+# midlatitude-summer standard atmosphere we started from) at every height: the
+# temperature decreases from the surface upward at two to three times the dry
+# adiabatic lapse rate, runs 45 K below the standard atmosphere through the
+# middle and upper troposphere, and forms no tropopause. The air at the bottom
+# face is several kelvin colder than the ground beneath it — the surface
+# discontinuity of radiative equilibrium. This radiative equilibrium state is
+# unstable to convection, and the turbulent heat fluxes that the convective
+# adjustment stands in for erase it.
+#
+# The implied surface convective flux of the radiative column checks the
+# bookkeeping: without convection, the net radiative flux is the same at every
+# level, so closing the budget at the top of the atmosphere closes it at the
+# surface too, leaving no energy flux for convection to carry.
+
+fig = Figure(size = (500, 500))
+ax = Axis(
+    fig[1, 1];
+    xlabel = "temperature [K]",
+    ylabel = "pressure [hPa]",
+    yscale = log10,
+    yreversed = true,
+    limits = (nothing, nothing, nothing, 1050),
+    title = "Radiative vs. radiative-convective equilibrium",
+)
+obs = lines!(ax, T_obs, p_lay[:, 1] ./ 100; color = :gray, linestyle = :dot, label = "standard atmosphere")
+re = lines!(ax, T_re[:, 1], p_lay[:, 1] ./ 100; label = "radiative equilibrium")
+rc = lines!(ax, T_rc[:, 1], p_lay[:, 1] ./ 100; label = "RCE (Γ = 6.5 K/km)")
+mark_ground!(ax, obs, profile.t_sfc[1])
+mark_ground!(ax, re, Ts_re)
+mark_ground!(ax, rc, Ts_rc)
+axislegend(ax; position = :rt, framevisible = false, backgroundcolor = :white)
+fig
+
+# ## Climate sensitivity at fixed relative humidity
+#
+# Manabe and Wetherald's central experiment was to re-balance the column for
+# increased CO₂, keeping the relative humidity fixed, and compare the balanced
+# surface temperature against the reference state above. The difference for
+# doubled CO₂ is the equilibrium climate sensitivity of the radiative-convective
+# column.
+
+# The reference tropopause, the highest layer on the convective profile,
+# lies just above 11 km. On that profile, height and temperature are
+# interchangeable, ``z = (T_s - T)/Γ``, so the height follows from the
+# temperature of the highest adjusted layer, again with no altitude
+# reconstruction:
 
 function tropopause_height(solver, T_sfc; Γ = Γ_crit)
     T = Array(RRTMGP.layer_temperature(solver))[:, 1]
@@ -322,10 +343,10 @@ function tropopause_height(solver, T_sfc; Γ = Γ_crit)
     k = findlast(abs.(T .- T_sfc .* (p ./ p_sfc) .^ (Γ * R_d / g)) .< 0.5)
     return (T_sfc - T[k]) / Γ
 end
-println("tropopause height ≈ $(round(tropopause_height(solver, Ts_1x) / 1000; digits = 1)) km")
+println("Tropopause height ≈ $(round(tropopause_height(solver, Ts_1x) / 1000; digits = 1)) km")
 
 # Now scale the CO₂ and re-balance. `balanced_co2` builds a fresh column with a
-# scaled CO₂ concentration, warm-starts it from the 1 × CO₂ equilibrium, and
+# scaled CO₂ concentration, starts it from the 1 × CO₂ equilibrium, and
 # finds its balanced surface temperature. With `fixed_rh = false`, the water
 # vapor is frozen at its reference (1 × CO₂) values (**fixed absolute
 # humidity**) which removes the water-vapor feedback and isolates the direct
@@ -358,28 +379,28 @@ rows = (
     ("2×CO₂, fixed AH", Ts_2x_ah, Ts_2x_ah - Ts_1x),
     ("4×CO₂, fixed AH", Ts_4x_ah, Ts_4x_ah - Ts_1x),
 )
-println(rpad("experiment", 24), lpad("Tₛ [K]", 9), lpad("ΔTₛ [K]", 10))
+println(rpad("Experiment", 24), lpad("Tₛ [K]", 9), lpad("ΔTₛ [K]", 10))
 for (name, Ts, dT) in rows
     dstr = dT === nothing ? "—" : string(round(dT; digits = 1))
     println(rpad(name, 24), lpad(round(Ts; digits = 1), 9), lpad(dstr, 10))
 end
 
-# With fixed relative humidity and hard adjustment to 6.5 K/km, the equilibrium
-# climate sensitivity (the warming per CO₂ doubling) comes out near 2.9 K —
-# in the range of the classic calculations: Manabe and Wetherald obtained 2.36 K 
-# with their radiation scheme, and konrad's re-examination with RRTMG yields 
-# ≈ 2.1 K ([kluft2019](@citet)). The warming is roughly logarithmic in CO₂, 
-# growing slightly with each doubling as the warmer column holds more water vapor. 
-# Freezing the water vapor (fixed AH) roughly halves the warming, so the water-vapor 
-# feedback about doubles the response. The residual spread among the published 
-# sensitivities traces to the humidity profile, the adjustment scheme, and the ozone 
-# treatment; [kluft2021](@citet) dissects these dependencies, which you can reproduce 
-# by editing a few lines above.
+# For comparison, for the same configuration with clear skies, fixed relative
+# humidity, and a hard adjustment to a constant 6.5 K/km lapse rate,
+# [kluft2019](@citet) found an equilibrium climate sensitivity of 2.65 K for
+# konrad and [manabe1967](@citet) found 2.92 K. The 2.9 K here is close to the
+# Manabe and Wetherald result. Holding the water vapor fixed halves the warming,
+# so the water-vapor feedback doubles the response; the same two studies give
+# 1.34 K and 1.36 K for the fixed-absolute-humidity case, below the 1.5 K here.
+# The warming is close to logarithmic in CO₂; each doubling warms slightly more
+# than the last, as the forcing per doubling grows [kluft2019](@cite) and the
+# warmer column holds more water vapor. The spread among published values traces
+# to the humidity profile, the adjustment scheme, and the ozone treatment, each
+# of which you can vary by editing a few lines above.
 #
-# The warmed column shows the classic fingerprint of CO₂-driven change:
-# tropospheric warming with stratospheric cooling. This pattern was 
-# predicted decades before it was observed. Fixed absolute humidity gives
-# the same qualitative pattern but a weaker surface warming.
+# The warmed column carries the fingerprint of CO₂-driven change: tropospheric
+# warming with stratospheric cooling, predicted decades before it was observed.
+# Fixed absolute humidity gives the same pattern with a weaker surface warming.
 
 fig2 = Figure(size = (500, 500))
 ax2 = Axis(
@@ -388,25 +409,32 @@ ax2 = Axis(
     ylabel = "pressure [hPa]",
     yscale = log10,
     yreversed = true,
-    limits = (nothing, nothing, nothing, 1000),
+    limits = (nothing, nothing, nothing, 1050),
     title = "RCE response to CO₂",
 )
-lines!(ax2, T_1x[:, 1], p_lay[:, 1] ./ 100; label = "1×CO₂ (RH)")
-lines!(ax2, T_2x_rh[:, 1], p_lay[:, 1] ./ 100; linestyle = :dash, label = "2×CO₂ (RH)")
-lines!(ax2, T_4x_rh[:, 1], p_lay[:, 1] ./ 100; linestyle = :dot, label = "4×CO₂ (RH)")
-lines!(ax2, T_4x_ah[:, 1], p_lay[:, 1] ./ 100; linestyle = :dashdot, label = "4×CO₂ (AH)")
+for (T, Ts, style, label) in (
+    (T_1x, Ts_1x, nothing, "1×CO₂ (RH)"),
+    (T_2x_rh, Ts_2x_rh, :dash, "2×CO₂ (RH)"),
+    (T_4x_rh, Ts_4x_rh, :dot, "4×CO₂ (RH)"),
+    (T_4x_ah, Ts_4x_ah, :dashdot, "4×CO₂ (AH)"),
+)
+    curve = lines!(ax2, T[:, 1], p_lay[:, 1] ./ 100; linestyle = style, label)
+    mark_ground!(ax2, curve, Ts)
+end
 axislegend(ax2; position = :rt, framevisible = false, backgroundcolor = :white)
 fig2
 
 # ## Sensitivity to the critical lapse rate
 #
 # The assumed critical lapse rate ``Γ_c`` shapes the equilibrium. Re-balancing
-# the reference column for lapse rates from a stable moist adiabat (3.0 K/km) to
-# the dry adiabat (9.8 K/km) shows that a shallower lapse rate cools the surface
-# but lifts the tropopause: the troposphere "stretches" vertically because the
-# gentler gradient needs more depth to bridge the surface and stratospheric
-# temperatures. All the profiles balance the same absorbed sunlight, so they
-# emit the same outgoing longwave radiation to space.
+# the reference column for lapse rates between 3.0 K/km and the dry adiabat
+# (9.8 K/km) shows that a shallower lapse rate cools the surface but lifts the
+# tropopause: the troposphere stretches vertically, because the gentler
+# gradient needs more depth to bridge the surface and stratospheric
+# temperatures. Each column is balanced, so each emits to space the sunlight it
+# absorbs; the three absorb within about 1 W/m² of each other, so they settle
+# on nearly the same outgoing longwave flux from temperature profiles whose
+# surface temperatures span 9 K.
 
 fig3 = Figure(size = (500, 500))
 ax3 = Axis(
@@ -415,7 +443,7 @@ ax3 = Axis(
     ylabel = "pressure [hPa]",
     yscale = log10,
     yreversed = true,
-    limits = (nothing, nothing, nothing, 1000),
+    limits = (nothing, nothing, nothing, 1050),
     title = "Sensitivity to the critical lapse rate",
 )
 for Γ_km in (9.8, 6.5, 3.0)
@@ -423,17 +451,22 @@ for Γ_km in (9.8, 6.5, 3.0)
     slv = RRTMGP.solve(prof; lookups = solver.lookups, setup...).solver
     Ts = balanced_surface_temperature!(slv, FT(270), FT(292); Γ = Γ_km * 1e-3)
     z_top = tropopause_height(slv, Ts; Γ = Γ_km * 1e-3) / 1000
-    println("Γ = $(Γ_km) K/km: Tₛ = $(round(Ts; digits = 1)) K, tropopause ≈ $(round(z_top; digits = 1)) km")
+    olr = Array(RRTMGP.lw_flux_up(slv))[end, 1]
+    println(
+        "Γ = $(Γ_km) K/km: Tₛ = $(round(Ts; digits = 1)) K, ",
+        "tropopause ≈ $(round(z_top; digits = 1)) km, OLR = $(round(olr; digits = 1)) W/m²",
+    )
     T = Array(RRTMGP.layer_temperature(slv))
-    lines!(ax3, T[:, 1], p_lay[:, 1] ./ 100; label = "Γ = $(Γ_km) K/km")
+    curve = lines!(ax3, T[:, 1], p_lay[:, 1] ./ 100; label = "Γ = $(Γ_km) K/km")
+    mark_ground!(ax3, curve, Ts)
 end
 axislegend(ax3; position = :rt, framevisible = false, backgroundcolor = :white)
 fig3
 
 # ## Contributions of the individual absorbers
 #
-# Manabe and Wetherald's other classic diagnostic isolates each greenhouse gas.
-# We remove water vapor, carbon dioxide, or ozone one at a time, find the
+# The absorber decomposition of [manabe1964](@citet) isolates each greenhouse
+# gas. We remove water vapor, carbon dioxide, or ozone one at a time, find the
 # column's balanced surface temperature, and compare against the reference
 # (all-absorbers) profile computed above. Water vapor is removed by zeroing it
 # and holding it there (`humidity = false`); ozone by zeroing its layer profile;
@@ -449,8 +482,8 @@ function rce_without(absorber, T1, T2)
     return Ts, copy(Array(RRTMGP.layer_temperature(slv)))
 end
 
-## brackets straddle each case's expected surface temperature; the secant
-## converges from either side
+## Brackets straddle each case's expected surface temperature; the secant
+## method converges from either side
 Ts_no_h2o, T_no_h2o = rce_without(:h2o, FT(255), FT(272))
 Ts_no_co2, T_no_co2 = rce_without(:co2, FT(264), FT(278))
 Ts_no_o3, T_no_o3 = rce_without(:o3, FT(278), FT(288))
@@ -461,15 +494,19 @@ for (name, Ts) in (
     ("no CO₂", Ts_no_co2),
     ("no O₃", Ts_no_o3),
 )
-    println("equilibrium Tₛ ($name): $(round(Ts; digits = 1)) K")
+    println("Equilibrium Tₛ ($name): $(round(Ts; digits = 1)) K")
 end
 
-# The decomposition reproduces the textbook ordering. Water vapor is the
-# largest contributor: removing it drops the surface more than 20 K, below the
-# freezing point. Carbon dioxide is the next largest. Ozone affects the surface
-# less, but strongly cools the stratosphere it otherwise heats by absorbing
-# solar ultraviolet; the mid-atmosphere temperature inversion disappears
-# without it.
+# The decomposition reproduces the textbook ordering. Water vapor contributes
+# the most: removing it reduces the surface temperature by 24 K, below the
+# freezing point. Carbon dioxide comes next, at a 17 K reduction. Ozone
+# contributes 4 K at the surface, but by absorbing solar ultraviolet radiation
+# it creates the stratospheric inversion. Without ozone, the inversion is
+# gone: the temperature decreases with height toward a nearly isothermal
+# ≈ 160 K at the top of the column. Without CO₂, the stratosphere runs
+# *warmer* than the reference: ozone still absorbs sunlight up there, but the
+# main emitter of thermal infrared is gone, so the stratosphere must warm
+# until the remaining gases radiate the heating away.
 
 fig4 = Figure(size = (500, 500))
 ax4 = Axis(
@@ -478,13 +515,18 @@ ax4 = Axis(
     ylabel = "pressure [hPa]",
     yscale = log10,
     yreversed = true,
-    limits = (nothing, nothing, nothing, 1000),
+    limits = (nothing, nothing, nothing, 1050),
     title = "Contribution of individual absorbers",
 )
-lines!(ax4, T_1x[:, 1], p_lay[:, 1] ./ 100; label = "all absorbers")
-lines!(ax4, T_no_h2o[:, 1], p_lay[:, 1] ./ 100; label = "no H₂O")
-lines!(ax4, T_no_co2[:, 1], p_lay[:, 1] ./ 100; label = "no CO₂")
-lines!(ax4, T_no_o3[:, 1], p_lay[:, 1] ./ 100; label = "no O₃")
+for (T, Ts, label) in (
+    (T_1x, Ts_1x, "all absorbers"),
+    (T_no_h2o, Ts_no_h2o, "no H₂O"),
+    (T_no_co2, Ts_no_co2, "no CO₂"),
+    (T_no_o3, Ts_no_o3, "no O₃"),
+)
+    curve = lines!(ax4, T[:, 1], p_lay[:, 1] ./ 100; label)
+    mark_ground!(ax4, curve, Ts)
+end
 axislegend(ax4; position = :lt, framevisible = false, backgroundcolor = :white)
 fig4
 

--- a/src/ArtifactPaths.jl
+++ b/src/ArtifactPaths.jl
@@ -11,21 +11,24 @@ export get_lookup_filename, get_input_filename
 Generate the file names for lookup table files, for a given optics type, for the
 shortwave and longwave solvers.
 
-- `:gas`, `:cloud` and `:aerosol` optics types are supported for the longwave and shortwave solvers. 
-  - The `:gas` option provides the file that is used to load either the `LookUpLW` or `LookUpSW` struct in `LookUpTables.jl`.
-  - The `:cloud` option provides the file that is used to load the `LookUpCld` struct in `LookUpTables.jl`.
-  - The `:aerosol` option provides the file that is used to load the `LookUpAerosolMerra` struct in `LookUpTables.jl`.
+- `:gas`, `:cloud` and `:aerosol` optics types are supported for the longwave and
+  shortwave solvers.
+  - The `:gas` option provides the file that is used to load either the `LookUpLW` or
+    `LookUpSW` struct in `LookUpTables.jl`.
+  - The `:cloud` option provides the file that is used to load the `LookUpCld` struct
+    in `LookUpTables.jl`.
+  - The `:aerosol` option provides the file that is used to load the
+    `LookUpAerosolMerra` struct in `LookUpTables.jl`.
 - `:lw` (longwave) and `:sw` (shortwave) wavelength types are supported.
 
-These artifacts are obtained from "Pincus, R., Mlawer, E. J., Delamere, J., Iacono, M. J., & Pernak, R. (2023). RRTMGP data (Version 1.7) [Data set]. https://github.com/earth-system-radiation/rrtmgp-data" 
-
-The file "rrtmgp-sw-inputs-aerosol-optics.nc" overrides the lookup table available from the artifacts. This table corrects an error in the array ordering for the aerosol optics lookup table for the shortwave sea-salt data (‘aero_salt_tbl’). This file is provided by Michael Iacono at Atmospheric and Environmental Research, via personal communication. This file is expected to replace the currently existing lookup table in the `rrtmgp-data` repository in their next public release.
+These artifacts are obtained from "Pincus, R., Mlawer, E. J., Delamere, J., Iacono,
+M. J., & Pernak, R. (2023). RRTMGP data (Version 1.9) [Data set].
+https://github.com/earth-system-radiation/rrtmgp-data"
 """
 function get_lookup_filename(optics_type::Symbol, λ::Symbol)
     @assert optics_type ∈ (:gas, :cloud, :aerosol)
     @assert λ ∈ (:lw, :sw)
     basedir = get_artifact_path()
-    currdir = @__DIR__
     config = (optics_type, λ)
 
     config == (:gas, :lw) && return joinpath(basedir, "rrtmgp-gas-lw-g256.nc")
@@ -45,19 +48,24 @@ end
 """
     get_input_filename(problemtype::Symbol, λ::Symbol)
 
-Generate the file names for input files for tests, for a given problem type and wavelength type.
+Generate the file names for input files for tests, for a given problem type and
+wavelength type.
 `:gas`, and `:gas_clouds` and `:gas_clouds_aerosols` problem types are supported.
 `:lw` (longwave) and `:sw` (shortwave) wavelength types are supported.
 
-This file provides data for loading the `AtmosphericState` struct, the provides the atmospheric conditions for computing optical properties.
+This file provides data for loading the `AtmosphericState` struct, which provides the
+atmospheric conditions for computing optical properties.
 
 - The `:gas` option is used for the `clear sky` test.
 - The `:gas_clouds` option is used for the `all sky` test.
 - The `:gas_clouds_aerosols` option is used for the `all sky with aerosols` test.
 
-While these are primarily intended for the tests, some of this input data is also used in `ClimaAtmos.jl` and is therefore provided here for users' convenience.
+While these are primarily intended for the tests, some of this input data is also used
+in `ClimaAtmos.jl` and is therefore provided here for users' convenience.
 
-These artifacts are obtained from "Pincus, R., Mlawer, E. J., Delamere, J., Iacono, M. J., & Pernak, R. (2023). RRTMGP data (Version 1.7) [Data set]. https://github.com/earth-system-radiation/rrtmgp-data" 
+These artifacts are obtained from "Pincus, R., Mlawer, E. J., Delamere, J., Iacono,
+M. J., & Pernak, R. (2023). RRTMGP data (Version 1.9) [Data set].
+https://github.com/earth-system-radiation/rrtmgp-data"
 """
 function get_input_filename(problemtype::Symbol, λ::Symbol)
     @assert problemtype ∈ (:gas, :gas_clouds, :gas_clouds_aerosols)

--- a/src/api/aerosols.jl
+++ b/src/api/aerosols.jl
@@ -57,9 +57,9 @@ const _AEROSOL_NAMES = [
     aerosol_index_map()
 
 Return the canonical mapping from aerosol species name to its index in the
-`AerosolState` arrays (`aero_mass`, `aero_size`). This ordering is the single
-source of truth shared by the optics kernel, the lookup-table loader, and the
-state accessors. Returns a fresh copy — mutating it does not affect RRTMGP.
+`AerosolState` arrays (`aero_mass`, `aero_size`). This ordering is shared by
+the optics kernel, the lookup-table loader, and the state accessors. Returns
+a fresh copy; mutating it does not affect RRTMGP.
 """
 aerosol_index_map() = copy(AEROSOL_IDX)
 

--- a/src/api/getters.jl
+++ b/src/api/getters.jl
@@ -54,48 +54,311 @@ _require_clear_sky(::Nothing) = error(
 )
 _require_clear_sky(x) = x
 
-# Potentially views
+# Potentially views. Each getter carries a one-line docstring for REPL help; the shared
+# layout/masking/writability rules live in the getter contract (docs/src/getters.md).
+
+"""
+    top_of_atmosphere_lw_flux_dn(s::RRTMGPSolver)
+
+Return the prescribed incident longwave flux [W/m²], `(ngpt, ncol)`, or `nothing`.
+"""
 top_of_atmosphere_lw_flux_dn(s::RRTMGPSolver)         = _maybe_transpose(s.lws.bcs.inc_flux)
+
+"""
+    top_of_atmosphere_diffuse_sw_flux_dn(s::RRTMGPSolver)
+
+Return the prescribed incident diffuse shortwave flux [W/m²], `(ngpt, ncol)`, or `nothing`.
+"""
 top_of_atmosphere_diffuse_sw_flux_dn(s::RRTMGPSolver) = _maybe_transpose(s.sws.bcs.inc_flux_diffuse)
+
+"""
+    lw_flux_up(s::RRTMGPSolver)
+
+Return the upward longwave flux [W/m²]: a domain-masked `(nlev, ncol)` view.
+"""
 lw_flux_up(s::RRTMGPSolver)                           = _domain_view(s, s.presented_flux_lw.flux_up)
+
+"""
+    lw_flux_dn(s::RRTMGPSolver)
+
+Return the downward longwave flux [W/m²]: a domain-masked `(nlev, ncol)` view.
+"""
 lw_flux_dn(s::RRTMGPSolver)                           = _domain_view(s, s.presented_flux_lw.flux_dn)
+
+"""
+    lw_flux_net(s::RRTMGPSolver)
+
+Return the net (up - down) longwave flux [W/m²]: a domain-masked `(nlev, ncol)` view.
+"""
 lw_flux_net(s::RRTMGPSolver)                          = _domain_view(s, s.presented_flux_lw.flux_net)
+
+"""
+    clear_lw_flux_up(s::RRTMGPSolver)
+
+Return the clear-sky upward longwave flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_lw_flux_up(s::RRTMGPSolver)                     = _domain_view(s, _require_clear_sky(s.clear_flux_lw).flux_up)
+
+"""
+    clear_lw_flux_dn(s::RRTMGPSolver)
+
+Return the clear-sky downward longwave flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_lw_flux_dn(s::RRTMGPSolver)                     = _domain_view(s, _require_clear_sky(s.clear_flux_lw).flux_dn)
+
+"""
+    clear_lw_flux(s::RRTMGPSolver)
+
+Return the clear-sky net longwave flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_lw_flux(s::RRTMGPSolver)                        = _domain_view(s, _require_clear_sky(s.clear_flux_lw).flux_net)
+
+"""
+    surface_emissivity(s::RRTMGPSolver)
+
+Return the longwave surface emissivity [-]: a writable `(nbnd, ncol)` device array.
+"""
 surface_emissivity(s::RRTMGPSolver)                   = s.lws.bcs.sfc_emis
+
+"""
+    sw_flux_up(s::RRTMGPSolver)
+
+Return the upward shortwave flux [W/m²]: a domain-masked `(nlev, ncol)` view.
+"""
 sw_flux_up(s::RRTMGPSolver)                           = _domain_view(s, s.presented_flux_sw.flux_up)
+
+"""
+    sw_flux_dn(s::RRTMGPSolver)
+
+Return the downward shortwave flux [W/m²]: a domain-masked `(nlev, ncol)` view.
+"""
 sw_flux_dn(s::RRTMGPSolver)                           = _domain_view(s, s.presented_flux_sw.flux_dn)
+
+"""
+    sw_flux_net(s::RRTMGPSolver)
+
+Return the net (up - down) shortwave flux [W/m²]: a domain-masked `(nlev, ncol)` view.
+"""
 sw_flux_net(s::RRTMGPSolver)                          = _domain_view(s, s.presented_flux_sw.flux_net)
+
+"""
+    sw_direct_flux_dn(s::RRTMGPSolver)
+
+Return the direct-beam downward shortwave flux [W/m²]: a domain-masked `(nlev, ncol)` view.
+"""
 sw_direct_flux_dn(s::RRTMGPSolver)                    = _domain_view(s, s.presented_flux_sw.flux_dn_dir)
+
+"""
+    clear_sw_flux_up(s::RRTMGPSolver)
+
+Return the clear-sky upward shortwave flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_sw_flux_up(s::RRTMGPSolver)                     = _domain_view(s, _require_clear_sky(s.clear_flux_sw).flux_up)
+
+"""
+    clear_sw_flux_dn(s::RRTMGPSolver)
+
+Return the clear-sky downward shortwave flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_sw_flux_dn(s::RRTMGPSolver)                     = _domain_view(s, _require_clear_sky(s.clear_flux_sw).flux_dn)
+
+"""
+    clear_sw_direct_flux_dn(s::RRTMGPSolver)
+
+Return the clear-sky direct-beam downward shortwave flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_sw_direct_flux_dn(s::RRTMGPSolver)              = _domain_view(s, _require_clear_sky(s.clear_flux_sw).flux_dn_dir)
+
+"""
+    clear_sw_flux(s::RRTMGPSolver)
+
+Return the clear-sky net shortwave flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_sw_flux(s::RRTMGPSolver)                        = _domain_view(s, _require_clear_sky(s.clear_flux_sw).flux_net)
+"""
+    cloud_liquid_effective_radius(s::RRTMGPSolver)
+
+Return the cloud liquid effective radius [µm]: a writable, domain-masked `(nlay, ncol)` view.
+"""
 cloud_liquid_effective_radius(s::RRTMGPSolver)        = _domain_view(s, s.as.cloud_state.cld_r_eff_liq)
+
+"""
+    cloud_ice_effective_radius(s::RRTMGPSolver)
+
+Return the cloud ice effective radius [µm]: a writable, domain-masked `(nlay, ncol)` view.
+"""
 cloud_ice_effective_radius(s::RRTMGPSolver)           = _domain_view(s, s.as.cloud_state.cld_r_eff_ice)
+
+"""
+    cloud_liquid_water_path(s::RRTMGPSolver)
+
+Return the cloud liquid water path [g/m²]: a writable, domain-masked `(nlay, ncol)` view.
+"""
 cloud_liquid_water_path(s::RRTMGPSolver)              = _domain_view(s, s.as.cloud_state.cld_path_liq)
+
+"""
+    cloud_ice_water_path(s::RRTMGPSolver)
+
+Return the cloud ice water path [g/m²]: a writable, domain-masked `(nlay, ncol)` view.
+"""
 cloud_ice_water_path(s::RRTMGPSolver)                 = _domain_view(s, s.as.cloud_state.cld_path_ice)
+
+"""
+    cloud_fraction(s::RRTMGPSolver)
+
+Return the cloud fraction [-]: a writable, domain-masked `(nlay, ncol)` view.
+"""
 cloud_fraction(s::RRTMGPSolver)                       = _domain_view(s, s.as.cloud_state.cld_frac)
+
+"""
+    sw_cloud_cover(s::RRTMGPSolver)
+
+Return the column cloud cover [-] diagnosed from the shortwave McICA sampling, `(ncol,)`.
+"""
 sw_cloud_cover(s::RRTMGPSolver)                       = s.as.cloud_state.cld_cover_sw
+
+"""
+    lw_cloud_cover(s::RRTMGPSolver)
+
+Return the column cloud cover [-] diagnosed from the longwave McICA sampling, `(ncol,)`.
+"""
 lw_cloud_cover(s::RRTMGPSolver)                       = s.as.cloud_state.cld_cover_lw
+
+"""
+    aod_sw_extinction(s::RRTMGPSolver)
+
+Return the aerosol extinction optical depth [-] in the shortwave band containing 550 nm,
+`(ncol,)`.
+"""
 aod_sw_extinction(s::RRTMGPSolver)                    = s.as.aerosol_state.aod_sw_ext
+
+"""
+    aod_sw_scattering(s::RRTMGPSolver)
+
+Return the aerosol scattering optical depth [-] in the shortwave band containing 550 nm,
+`(ncol,)`.
+"""
 aod_sw_scattering(s::RRTMGPSolver)                    = s.as.aerosol_state.aod_sw_sca
+
+"""
+    center_z(s::RRTMGPSolver)
+
+Return the layer-center altitudes [m], `(nlay, ncol)`, or `nothing` if not provided.
+"""
 center_z(s::RRTMGPSolver)                             = _domain_view(s, s.center_z)
+
+"""
+    face_z(s::RRTMGPSolver)
+
+Return the level (face) altitudes [m], `(nlev, ncol)`, or `nothing` if not provided.
+"""
 face_z(s::RRTMGPSolver)                               = _domain_view(s, s.face_z)
+"""
+    cos_zenith(s::RRTMGPSolver)
+
+Return the cosine of the solar zenith angle [-]: a writable `(ncol,)` device array.
+"""
 cos_zenith(s::RRTMGPSolver)                           = s.sws.bcs.cos_zenith
+
+"""
+    toa_flux(s::RRTMGPSolver)
+
+Return the incident top-of-atmosphere solar flux [W/m²]: a writable `(ncol,)` device array.
+"""
 toa_flux(s::RRTMGPSolver)                             = s.sws.bcs.toa_flux
+
+"""
+    direct_sw_surface_albedo(s::RRTMGPSolver)
+
+Return the direct-beam shortwave surface albedo [-]: a writable `(nbnd, ncol)` device array.
+"""
 direct_sw_surface_albedo(s::RRTMGPSolver)             = s.sws.bcs.sfc_alb_direct
+
+"""
+    diffuse_sw_surface_albedo(s::RRTMGPSolver)
+
+Return the diffuse shortwave surface albedo [-]: a writable `(nbnd, ncol)` device array.
+"""
 diffuse_sw_surface_albedo(s::RRTMGPSolver)            = s.sws.bcs.sfc_alb_diffuse
+
+"""
+    latitude(s::RRTMGPSolver)
+
+Return the column latitudes [degrees], `(ncol,)`, or `nothing` if not provided.
+"""
 latitude(s::RRTMGPSolver)                             = s.as.lat
+
+"""
+    surface_temperature(s::RRTMGPSolver)
+
+Return the surface temperature [K]: a writable `(ncol,)` device array.
+"""
 surface_temperature(s::RRTMGPSolver)                  = s.as.t_sfc
+
+"""
+    layer_pressure(s::RRTMGPSolver)
+
+Return the layer-center pressure [Pa]: a writable, domain-masked `(nlay, ncol)` view.
+"""
 layer_pressure(s::RRTMGPSolver)                       = _domain_view(s, getview_p_lay(s.as))
+
+"""
+    layer_temperature(s::RRTMGPSolver)
+
+Return the layer-center temperature [K]: a writable, domain-masked `(nlay, ncol)` view.
+"""
 layer_temperature(s::RRTMGPSolver)                    = _domain_view(s, getview_t_lay(s.as))
+
+"""
+    layer_relative_humidity(s::RRTMGPSolver)
+
+Return the layer-center relative humidity [-]: a writable, domain-masked `(nlay, ncol)`
+view. Feeds the humidity-dependent aerosol optics; keeping it current is the host's job.
+"""
 layer_relative_humidity(s::RRTMGPSolver)              = _domain_view(s, getview_rel_hum(s.as))
+
+"""
+    level_pressure(s::RRTMGPSolver)
+
+Return the level (face) pressure [Pa]: a writable, domain-masked `(nlev, ncol)` view.
+"""
 level_pressure(s::RRTMGPSolver)                       = _domain_view(s, s.as.p_lev)
+
+"""
+    level_temperature(s::RRTMGPSolver)
+
+Return the level (face) temperature [K]: a writable, domain-masked `(nlev, ncol)` view.
+"""
 level_temperature(s::RRTMGPSolver)                    = _domain_view(s, s.as.t_lev)
+
+"""
+    net_flux(s::RRTMGPSolver)
+
+Return the combined longwave + shortwave net flux [W/m²]: a domain-masked `(nlev, ncol)`
+view.
+"""
 net_flux(s::RRTMGPSolver)                             = _domain_view(s, s.net_flux_buffer)
+
+"""
+    clear_net_flux(s::RRTMGPSolver)
+
+Return the clear-sky combined net flux [W/m²], `(nlev, ncol)`
+(`AllSkyRadiationWithClearSkyDiagnostics` only).
+"""
 clear_net_flux(s::RRTMGPSolver)                       = _domain_view(s, _require_clear_sky(s.clear_net_flux_buffer))
+
+"""
+    deep_atmosphere_inverse_scaling(s::RRTMGPSolver)
+
+Return the deep-atmosphere flux scaling [-], `(nlev, ncol)`, or `nothing` if not provided.
+"""
 deep_atmosphere_inverse_scaling(s::RRTMGPSolver)      = _domain_view(s, s.deep_atmosphere_inverse_scaling)
 #! format: on
 
@@ -199,6 +462,12 @@ parameter.
 optical_thickness_parameter(s::RRTMGPSolver) =
     hasproperty(_atmospheric_state(s), :otp) ? _atmospheric_state(s).otp : nothing
 
+"""
+    isothermal_boundary_layer(s::RRTMGPSolver)
+
+Return whether the solver carries an internal isothermal boundary layer above the
+physical domain (which every getter masks off).
+"""
 isothermal_boundary_layer(s::RRTMGPSolver) = s.grid_params.isothermal_boundary_layer
 
 """

--- a/src/api/getters.jl
+++ b/src/api/getters.jl
@@ -400,33 +400,69 @@ _solver_band_flux(ws) =
     hasproperty(ws, :band_flux) ? _require_band_flux(ws.band_flux) :
     error("spectral fluxes require a two-stream, non-gray solver.")
 
+# The six per-band getters share one contract: a domain-masked
+# `(nlev, ncol, n_bnd)` view of a retained band buffer, available only when the
+# solver was built with `spectral_fluxes = true`. Each carries its own
+# docstring so REPL help works for all of them; the shared detail is on the
+# "Get per-band (spectral) fluxes" how-to page.
+
 """
     spectral_lw_flux_up(s::RRTMGPSolver)
-    spectral_lw_flux_dn(s::RRTMGPSolver)
-    spectral_lw_flux_net(s::RRTMGPSolver)
-    spectral_sw_flux_up(s::RRTMGPSolver)
-    spectral_sw_flux_dn(s::RRTMGPSolver)
-    spectral_sw_flux_net(s::RRTMGPSolver)
 
-Return the spectrally-resolved (per-band) up/down/net longwave or shortwave flux [W/m²] as
-a domain-masked `(nlev, ncol, n_bnd)` array. The solver must have been constructed with
-`spectral_fluxes = true` (supported for two-stream, non-gray radiation). Band `b`'s slice
-`[:, :, b]` has the same layout as the broadband fluxes, and summing over the band dimension
-recovers them. Use [`lw_band_bounds`](@ref) / [`sw_band_bounds`](@ref) to identify each band's
-wavenumber range.
-
-The `up`/`dn`/`net` getters are views into the retained per-band buffers.
+Return the per-band upward longwave flux [W/m²]: a domain-masked
+`(nlev, ncol, n_bnd)` view. Requires `spectral_fluxes = true`; see
+[`lw_band_bounds`](@ref) for each band's wavenumber range.
 """
 spectral_lw_flux_up(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.lws).flux_up)
+
+"""
+    spectral_lw_flux_dn(s::RRTMGPSolver)
+
+Return the per-band downward longwave flux [W/m²]: a domain-masked
+`(nlev, ncol, n_bnd)` view. Requires `spectral_fluxes = true`; see
+[`lw_band_bounds`](@ref) for each band's wavenumber range.
+"""
 spectral_lw_flux_dn(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.lws).flux_dn)
+
+"""
+    spectral_lw_flux_net(s::RRTMGPSolver)
+
+Return the per-band net (up - down) longwave flux [W/m²]: a domain-masked
+`(nlev, ncol, n_bnd)` view. Requires `spectral_fluxes = true`; see
+[`lw_band_bounds`](@ref) for each band's wavenumber range.
+"""
 spectral_lw_flux_net(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.lws).flux_net)
+
+"""
+    spectral_sw_flux_up(s::RRTMGPSolver)
+
+Return the per-band upward shortwave flux [W/m²]: a domain-masked
+`(nlev, ncol, n_bnd)` view. Requires `spectral_fluxes = true`; see
+[`sw_band_bounds`](@ref) for each band's wavenumber range.
+"""
 spectral_sw_flux_up(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.sws).flux_up)
+
+"""
+    spectral_sw_flux_dn(s::RRTMGPSolver)
+
+Return the per-band downward shortwave flux [W/m²]: a domain-masked
+`(nlev, ncol, n_bnd)` view. Requires `spectral_fluxes = true`; see
+[`sw_band_bounds`](@ref) for each band's wavenumber range.
+"""
 spectral_sw_flux_dn(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.sws).flux_dn)
+
+"""
+    spectral_sw_flux_net(s::RRTMGPSolver)
+
+Return the per-band net (up - down) shortwave flux [W/m²]: a domain-masked
+`(nlev, ncol, n_bnd)` view. Requires `spectral_fluxes = true`; see
+[`sw_band_bounds`](@ref) for each band's wavenumber range.
+"""
 spectral_sw_flux_net(s::RRTMGPSolver) =
     _domain_view(s, _solver_band_flux(s.sws).flux_net)
 

--- a/src/api/interpolation.jl
+++ b/src/api/interpolation.jl
@@ -7,15 +7,15 @@
 
 # Each scheme assumes a constant lapse rate ∂T/∂z = L between the two known points
 # (z₁, p₁, T₁) and (z₂, p₂, T₂), giving T(z) = T₁ + (T₂ - T₁) / (z₂ - z₁) * (z - z₁).
-# Pressure follows hydrostatic balance when T₁ == T₂ and an isentropic p ∝ T^B law
-# otherwise:
+# Pressure follows hydrostatic balance when T₁ == T₂ and the constant-lapse-rate
+# hydrostatic power law p ∝ T^B otherwise:
 #   p(z) = T₁ == T₂ ? p₁ * (p₂ / p₁)^((z - z₁) / (z₂ - z₁))
 #                   : p₁ * (p₂ / p₁)^(log(T(z) / T₁) / log(T₂ / T₁)).
 # UniformZ, UniformP, and GeometricMean are the midpoint-in-height,
 # midpoint-in-pressure, and z = z₁ + (z₂ - z₁) / (√(T₂/T₁) + 1) special cases that
 # avoid needing altitudes; ArithmeticMean takes the plain average of p and T. The
-# full derivation is a candidate for a docs Explanation page alongside the
-# "Functional core" page.
+# full derivation is on the "Level interpolation" docs page
+# (docs/src/interpolation.md).
 
 """
     AbstractInterpolation
@@ -33,7 +33,8 @@ Subtypes:
 - `UniformP`: assume the face lies midway in pressure between the layers.
 - `BestFit`: constant-lapse-rate fit using layer altitudes; requires `center_z` and `face_z`.
 
-The derivations are summarized in the comment block above.
+The derivations, and guidance on choosing a scheme, are on the
+"Level interpolation" docs page.
 """
 abstract type AbstractInterpolation end
 struct NoInterpolation <: AbstractInterpolation end
@@ -47,8 +48,8 @@ struct BestFit <: AbstractInterpolation end
 # isentropic process, p(z) = p⁺ * (T(z) / T⁺)^(cₚ / R), where (p⁺, T⁺) is the first
 # layer above the bottom face. UseSurfaceTempAtBottom sets T(z) = Tₛ (the surface
 # temperature); HydrostaticBottom uses the dry-adiabatic lapse rate, giving
-# T(z) = T⁺ + (g / cₚ) * (z⁺ - z). The full derivation is a candidate for a docs
-# Explanation page alongside the "Functional core" page.
+# T(z) = T⁺ + (g / cₚ) * (z⁺ - z). The full derivation is on the
+# "Level interpolation" docs page (docs/src/interpolation.md).
 
 """
     AbstractBottomExtrapolation

--- a/src/api/lookup_bundle.jl
+++ b/src/api/lookup_bundle.jl
@@ -92,7 +92,7 @@ later session can [`load_lookup_tables`](@ref) without NCDatasets (e.g., for
 standalone/classroom use of the spectral methods, or to skip the NetCDF read).
 Uses Julia's `Serialization` stdlib: the file is tied to the Julia version and
 package layout that wrote it and serves as a cache; the NetCDF artifacts remain
-the source of truth. Returns `path`.
+the authoritative data. Returns `path`.
 """
 function save_lookup_tables(path::AbstractString, lookups::LookupBundle)
     Serialization.serialize(path, Adapt.adapt(Array, lookups))

--- a/src/api/standalone.jl
+++ b/src/api/standalone.jl
@@ -42,6 +42,26 @@ struct RadiationOutput{A, H, S}
     solver::S
 end
 
+# Copy a `(m, ncol)` profile array into a host array with `n ≥ m` rows, so it
+# fits RRTMGP's boundary-extended internal arrays. The added rows repeat the top
+# domain row, or continue its spacing when `extrapolate` (altitudes, which
+# nothing else fills in). The row-by-row fill runs on the host (`Array(x)`
+# brings a device-resident profile over first), so no device array is indexed
+# here; the caller moves the result to the device once. This runs at
+# construction.
+function _pad_top(x, n, ncol; extrapolate::Bool)
+    y_domain = Array(x) # host copy: profiles are reused, so never alias
+    m = size(y_domain, 1)
+    m == n && return y_domain
+    y = Array{eltype(y_domain)}(undef, n, ncol)
+    @views y[1:m, :] .= y_domain
+    for k in (m + 1):n
+        @views y[k, :] .=
+            extrapolate ? (2 .* y[k - 1, :] .- y[k - 2, :]) : y[m, :]
+    end
+    return y
+end
+
 _radiation_output(solver::RRTMGPSolver) = RadiationOutput(
     lw_flux_up(solver),
     lw_flux_dn(solver),
@@ -226,6 +246,11 @@ tables, so load NCDatasets first or pass cached `lookups`) or `GrayRadiation()` 
   temperatures and wants the faces kept consistent automatically.
 - `bottom_extrapolation = SameAsInterpolation()`: scheme for the bottom face
   (see [`AbstractBottomExtrapolation`](@ref)).
+- `isothermal_boundary_layer = false`: extend the column above the profile with
+  one isothermal layer reaching the lookup tables' minimum pressure (zero
+  pressure for `GrayRadiation`), so the radiation sees the mass above the
+  profile's top instead of truncating there (see [`RRTMGPGridParams`](@ref)).
+  The returned fluxes and heating rates stay on the profile's own grid.
 """
 function solve(
     profile::AtmosphereProfile;
@@ -242,14 +267,22 @@ function solve(
     ),
     interpolation::AbstractInterpolation = NoInterpolation(),
     bottom_extrapolation::AbstractBottomExtrapolation = SameAsInterpolation(),
+    isothermal_boundary_layer::Bool = false,
 )
     FT = eltype(profile.p_lay)
-    (nlay, ncol) = size(profile.p_lay)
+    (domain_nlay, ncol) = size(profile.p_lay)
     device = ClimaComms.device(context)
     DA = ClimaComms.array_type(device)
     # Copy (never alias) the profile's host arrays: the solve mutates its state
     # in place (clipping, column amounts), and the profile should stay reusable.
     dev(x) = DA{FT}(copy(x))
+    # With an isothermal boundary layer, RRTMGP's internal arrays carry one extra
+    # layer and level above the domain. `add_isothermal_boundary_layer!` refills
+    # them from the top of the domain on every solve, so the padding below only
+    # has to leave the arrays defined; `z_lev` is the exception, since nothing
+    # refills it, and it keeps the spacing of the topmost domain level.
+    pad(x, n) = DA{FT}(_pad_top(x, n, ncol; extrapolate = false))
+    pad_z(x, n) = DA{FT}(_pad_top(x, n, ncol; extrapolate = true))
 
     method isa Union{GrayRadiation, ClearSkyRadiation} || error(
         "`solve(profile)` supports `GrayRadiation` and `ClearSkyRadiation`; \
@@ -261,7 +294,15 @@ function solve(
          `ClearSkyRadiation(false)` or construct an `RRTMGPSolver` directly.",
     )
 
-    grid_params = RRTMGPGridParams(FT; context, domain_nlay = nlay, ncol)
+    grid_params = RRTMGPGridParams(
+        FT;
+        context,
+        domain_nlay,
+        ncol,
+        isothermal_boundary_layer,
+    )
+    nlay = grid_params.nlay # total layer count, boundary layer included
+    nlev = nlay + 1
     if isnothing(lookups)
         _check_lookup_support(method)
         lookups = lookup_tables(grid_params, method)
@@ -270,11 +311,11 @@ function solve(
     as = if method isa GrayRadiation
         AtmosphericStates.GrayAtmosphericState(
             dev(profile.lat),
-            dev(profile.p_lay),
-            dev(profile.p_lev),
-            dev(profile.t_lay),
-            dev(profile.t_lev),
-            dev(profile.z_lev),
+            pad(profile.p_lay, nlay),
+            pad(profile.p_lev, nlev),
+            pad(profile.t_lay, nlay),
+            pad(profile.t_lev, nlev),
+            pad_z(profile.z_lev, nlev),
             dev(profile.t_sfc),
             optical_thickness,
         )
@@ -293,24 +334,24 @@ function solve(
             vmr_wm[idx_gases[gas]] = FT(val)
         end
         vmr = VolumeMixingRatios.VmrGM(
-            dev(profile.vmr_h2o),
-            dev(profile.vmr_o3),
+            pad(profile.vmr_h2o, nlay),
+            pad(profile.vmr_o3, nlay),
             DA{FT}(vmr_wm),
         )
         # Row 1 (col_dry) is computed by `prepare_atmosphere!` inside
         # `update_fluxes!`; row 4 (rel_hum) feeds only aerosol optics, which
         # this path rejects above.
         layerdata = zeros(FT, 4, nlay, ncol)
-        layerdata[2, :, :] .= profile.p_lay
-        layerdata[3, :, :] .= profile.t_lay
+        layerdata[2, 1:domain_nlay, :] .= profile.p_lay
+        layerdata[3, 1:domain_nlay, :] .= profile.t_lay
         # `lon` is unused by RRTMGP but must match `lat`'s type; `lat` enables
         # latitude-dependent gravity in the column-amount computation.
         AtmosphericStates.AtmosphericState(
             dev(zeros(FT, ncol)),
             dev(profile.lat),
             DA{FT}(layerdata),
-            dev(profile.p_lev),
-            dev(profile.t_lev),
+            pad(profile.p_lev, nlev),
+            pad(profile.t_lev, nlev),
             dev(profile.t_sfc),
             vmr,
             nothing,

--- a/test/standalone.jl
+++ b/test/standalone.jl
@@ -133,6 +133,39 @@ end
     )
 end
 
+# `solve` pads the profile onto RRTMGP's boundary-extended arrays when an
+# isothermal boundary layer is requested. The outputs must stay on the
+# profile's own grid, and the extra layer must actually radiate: without it the
+# top face receives no downward longwave at all.
+@testset "solve(profile) with isothermal boundary layer" begin
+    for FT in (Float32, Float64)
+        nlay, ncol = 30, 2
+        prof = RRTMGP.standard_atmosphere(FT; nlay, ncol)
+        p_lay_before = copy(prof.p_lay)
+        solve_ibl(ibl) = RRTMGP.solve(
+            prof;
+            method = RRTMGP.GrayRadiation(),
+            isothermal_boundary_layer = ibl,
+        )
+        out, out_ibl = solve_ibl(false), solve_ibl(true)
+        for o in (out, out_ibl)
+            @test size(Array(o.net)) == (nlay + 1, ncol)
+            @test size(Array(o.heating_rate)) == (nlay, ncol)
+            @test all(isfinite, Array(o.net))
+        end
+        @test all(iszero, Array(out.lw_dn)[end, :])
+        @test all(>(0), Array(out_ibl.lw_dn)[end, :])
+        # the top layer no longer radiates to space on both sides
+        @test all(
+            abs.(Array(out_ibl.heating_rate)[end, :]) .<
+            abs.(Array(out.heating_rate)[end, :]),
+        )
+        @test prof.p_lay isa Array # the profile is padded, never mutated
+        @test size(prof.p_lay, 1) == nlay
+        @test prof.p_lay == p_lay_before # values untouched by both solves
+    end
+end
+
 # Passing `op_sw = OneScalar` must route the constructor to a non-scattering
 # `NoScatSWRTE` solver (rather than the default `TwoStreamSWRTE`), and the solve
 # must run end to end. Uses gray radiation so no lookup tables are needed.


### PR DESCRIPTION
- corrects several problems on RCE page (temperature iteration, use of fixed humidity in RE, noise)
- cleans up language/redundancy throughout docs
- add how-to page for aerosols (focus review on this)
- add explanation page for interpolation choices
- add option for isothermal_boundary_layer in standalone config (needed for clean RCE)
- bumps patch release